### PR TITLE
security: signed media URLs, CSRF, stricter secrets and throttles

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,6 +19,10 @@ UPLOAD_DIR="./uploads"
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"
 JWT_EXPIRES_IN="15m"
 COOKIE_SECRET="your-cookie-secret-change-this"
+# Optional: HMAC cho URL media (>=32 ký tự). Nếu bỏ trống sẽ dùng JWT_SECRET — nên tách để xoay JWT không làm hỏng link ảnh cũ.
+# MEDIA_SIGNING_SECRET="your-media-signing-secret-at-least-32-chars"
+# TTL URL media ký (ms), mặc định 7 ngày
+# MEDIA_URL_TTL_MS=604800000
 
 # AI Settings (OpenAI)
 OPENAI_API_KEY="sk-..."

--- a/backend/scripts/create-admin-quick.ts
+++ b/backend/scripts/create-admin-quick.ts
@@ -11,12 +11,21 @@ async function createAdminQuick() {
   try {
     // pnpm/npm pass `--` before extra args; strip it so `pnpm run create:admin:quick -- user@x pass` works
     const args = process.argv.slice(2).filter((a) => a !== '--');
-    const email = args[0] || 'nguyenhoangtin1404@gmail.com';
-    const password = args[1] || '123456';
+    const email = args[0];
+    const password = args[1];
+
+    if (!email || !password) {
+      console.error('Usage: pnpm run create:admin:quick -- <email> <password>');
+      process.exit(1);
+    }
+    if (password.length < 8) {
+      console.error('Password must be at least 8 characters');
+      process.exit(1);
+    }
 
     console.log('=== Tạo / cập nhật tài khoản Admin ===\n');
     console.log(`Email: ${email}`);
-    console.log(`Password: ${password}\n`);
+    console.log('Password: [HIDDEN]\n');
 
     const existingUser = await prisma.user.findUnique({
       where: { email },

--- a/backend/scripts/reset-admin-password.ts
+++ b/backend/scripts/reset-admin-password.ts
@@ -10,12 +10,21 @@ const prisma = new PrismaClient();
 async function resetAdminPassword() {
   try {
     const args = process.argv.slice(2).filter((a) => a !== '--');
-    const email = args[0] || 'admin@diecast360.com';
-    const password = args[1] || 'admin';
+    const email = args[0];
+    const password = args[1];
+
+    if (!email || !password) {
+      console.error('Usage: pnpm run reset:admin -- <email> <new-password>');
+      process.exit(1);
+    }
+    if (password.length < 8) {
+      console.error('Password must be at least 8 characters');
+      process.exit(1);
+    }
 
     console.log('=== Reset mật khẩu Admin ===\n');
     console.log(`Email: ${email}`);
-    console.log(`Password mới: ${password}\n`);
+    console.log('Password mới: [HIDDEN]\n');
 
     // Tìm user
     const user = await prisma.user.findUnique({
@@ -46,7 +55,7 @@ async function resetAdminPassword() {
     console.log(`Role: ${user.role}`);
     console.log(`\n💡 Bạn có thể đăng nhập tại: http://localhost:5173/admin/login`);
     console.log(`   Email: ${email}`);
-    console.log(`   Password: ${password}`);
+    console.log('   Password: [HIDDEN]');
   } catch (error) {
     console.error('❌ Lỗi khi reset mật khẩu:', error);
     process.exit(1);

--- a/backend/src/ai/ai.controller.spec.ts
+++ b/backend/src/ai/ai.controller.spec.ts
@@ -1,0 +1,47 @@
+import { AiController } from './ai.controller';
+import { AiService } from './ai.service';
+
+describe('AiController', () => {
+  let controller: AiController;
+  const aiService = {
+    generateItemDescription: jest.fn(),
+    generateFacebookPost: jest.fn(),
+  };
+
+  beforeEach(() => {
+    controller = new AiController(aiService as unknown as AiService);
+    jest.clearAllMocks();
+  });
+
+  it('passes tenantId to generateItemDescription', async () => {
+    aiService.generateItemDescription.mockResolvedValueOnce({ short_description: 'ok' });
+
+    await controller.generateDescription(
+      'item-1',
+      { custom_instructions: 'focus rarity' },
+      'shop-1',
+    );
+
+    expect(aiService.generateItemDescription).toHaveBeenCalledWith(
+      'item-1',
+      'shop-1',
+      'focus rarity',
+    );
+  });
+
+  it('passes tenantId to generateFacebookPost', async () => {
+    aiService.generateFacebookPost.mockResolvedValueOnce({ content: 'post' });
+
+    await controller.generateFbPost(
+      'item-2',
+      { custom_instructions: 'short' },
+      'shop-2',
+    );
+
+    expect(aiService.generateFacebookPost).toHaveBeenCalledWith(
+      'item-2',
+      'shop-2',
+      'short',
+    );
+  });
+});

--- a/backend/src/ai/ai.controller.ts
+++ b/backend/src/ai/ai.controller.ts
@@ -1,26 +1,33 @@
 import { Controller, Post, Param, Body, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { AiService } from './ai.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { GenerateAiDescriptionDto, GenerateFbPostDto } from './dto/ai-description.dto';
+import { TenantGuard } from '../common/guards/tenant.guard';
+import { CurrentTenantId } from '../common/decorators/tenant.decorator';
 
 @Controller('items')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, TenantGuard)
 export class AiController {
   constructor(private readonly aiService: AiService) {}
 
   @Post(':id/ai-description')
+  @Throttle({ default: { ttl: 60000, limit: 25 } })
   async generateDescription(
     @Param('id') id: string,
     @Body() dto: GenerateAiDescriptionDto,
+    @CurrentTenantId() tenantId: string,
   ) {
-    return this.aiService.generateItemDescription(id, dto.custom_instructions);
+    return this.aiService.generateItemDescription(id, tenantId, dto.custom_instructions);
   }
 
   @Post(':id/fb-post')
+  @Throttle({ default: { ttl: 60000, limit: 25 } })
   async generateFbPost(
     @Param('id') id: string,
     @Body() dto: GenerateFbPostDto,
+    @CurrentTenantId() tenantId: string,
   ) {
-    return this.aiService.generateFacebookPost(id, dto.custom_instructions);
+    return this.aiService.generateFacebookPost(id, tenantId, dto.custom_instructions);
   }
 }

--- a/backend/src/ai/ai.service.spec.ts
+++ b/backend/src/ai/ai.service.spec.ts
@@ -46,6 +46,7 @@ describe('AiService', () => {
     deleted_at: null,
     fb_post_content: null,
   };
+  const TEST_SHOP_ID = 'shop-1';
 
   const descriptionResponse = {
     short_description: 'Mô tả ngắn cho sản phẩm',
@@ -109,7 +110,7 @@ describe('AiService', () => {
     it('should generate description and return full DTO', async () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
 
-      const result = await service.generateItemDescription('item-1');
+      const result = await service.generateItemDescription('item-1', TEST_SHOP_ID);
 
       expect(result.short_description).toBe('Mô tả ngắn cho sản phẩm');
       expect(result.long_description).toBe('Mô tả chi tiết cho sản phẩm diecast');
@@ -117,7 +118,7 @@ describe('AiService', () => {
       expect(result.meta_title).toBe('SEO Title');
       expect(result.meta_description).toBe('SEO meta description');
       expect(prisma.item.findFirst).toHaveBeenCalledWith({
-        where: { id: 'item-1', deleted_at: null },
+        where: { id: 'item-1', deleted_at: null, shop_id: TEST_SHOP_ID },
       });
     });
 
@@ -125,7 +126,7 @@ describe('AiService', () => {
       prisma.item.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.generateItemDescription('nonexistent'),
+        service.generateItemDescription('nonexistent', TEST_SHOP_ID),
       ).rejects.toThrow(AppException);
     });
 
@@ -144,7 +145,7 @@ describe('AiService', () => {
 
       prisma.item.findFirst.mockResolvedValue(mockItem);
 
-      await expect(svcNoKey.generateItemDescription('item-1')).rejects.toThrow(AppException);
+      await expect(svcNoKey.generateItemDescription('item-1', TEST_SHOP_ID)).rejects.toThrow(AppException);
     });
 
     it('should throw when AI returns incomplete content', async () => {
@@ -153,7 +154,7 @@ describe('AiService', () => {
         choices: [{ message: { content: JSON.stringify({ short_description: 'only partial' }) } }],
       });
 
-      await expect(service.generateItemDescription('item-1')).rejects.toThrow(AppException);
+      await expect(service.generateItemDescription('item-1', TEST_SHOP_ID)).rejects.toThrow(AppException);
     });
 
     it('should throw when bullet_specs only contain empty entries', async () => {
@@ -169,7 +170,7 @@ describe('AiService', () => {
         }],
       });
 
-      await expect(service.generateItemDescription('item-1')).rejects.toMatchObject({
+      await expect(service.generateItemDescription('item-1', TEST_SHOP_ID)).rejects.toMatchObject({
         errorCode: ErrorCode.INTERNAL_SERVER_ERROR,
       });
     });
@@ -180,7 +181,7 @@ describe('AiService', () => {
         choices: [{ message: { content: null } }],
       });
 
-      await expect(service.generateItemDescription('item-1')).rejects.toThrow(AppException);
+      await expect(service.generateItemDescription('item-1', TEST_SHOP_ID)).rejects.toThrow(AppException);
     });
 
     it('should throw when AI returns malformed JSON', async () => {
@@ -189,7 +190,7 @@ describe('AiService', () => {
         choices: [{ message: { content: '{not-json}' } }],
       });
 
-      await expect(service.generateItemDescription('item-1')).rejects.toMatchObject({
+      await expect(service.generateItemDescription('item-1', TEST_SHOP_ID)).rejects.toMatchObject({
         errorCode: ErrorCode.INTERNAL_SERVER_ERROR,
       });
     });
@@ -198,14 +199,14 @@ describe('AiService', () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       mockCreate.mockRejectedValueOnce(new Error('API rate limit'));
 
-      await expect(service.generateItemDescription('item-1')).rejects.toThrow(AppException);
+      await expect(service.generateItemDescription('item-1', TEST_SHOP_ID)).rejects.toThrow(AppException);
     });
 
     it('should map OpenAI 429 errors to RATE_LIMIT_EXCEEDED', async () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       mockCreate.mockRejectedValueOnce({ status: 429, message: 'Too many requests' });
 
-      await expect(service.generateItemDescription('item-1')).rejects.toMatchObject({
+      await expect(service.generateItemDescription('item-1', TEST_SHOP_ID)).rejects.toMatchObject({
         errorCode: ErrorCode.RATE_LIMIT_EXCEEDED,
       });
     });
@@ -214,7 +215,7 @@ describe('AiService', () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       mockCreate.mockRejectedValueOnce(null);
 
-      await expect(service.generateItemDescription('item-1')).rejects.toMatchObject({
+      await expect(service.generateItemDescription('item-1', TEST_SHOP_ID)).rejects.toMatchObject({
         errorCode: ErrorCode.INTERNAL_SERVER_ERROR,
         message: 'Failed to generate AI description',
       });
@@ -235,7 +236,7 @@ describe('AiService', () => {
     it('should generate Facebook post and return content string', async () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
 
-      const result = await service.generateFacebookPost('item-1');
+      const result = await service.generateFacebookPost('item-1', TEST_SHOP_ID);
 
       expect(result).toHaveProperty('content');
       expect(result.content).toBe('🔥 Hot Wheels Civic tuyệt đẹp! #diecast');
@@ -245,7 +246,7 @@ describe('AiService', () => {
       prisma.item.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.generateFacebookPost('nonexistent'),
+        service.generateFacebookPost('nonexistent', TEST_SHOP_ID),
       ).rejects.toThrow(AppException);
     });
 
@@ -255,14 +256,14 @@ describe('AiService', () => {
         choices: [{ message: { content: null } }],
       });
 
-      await expect(service.generateFacebookPost('item-1')).rejects.toThrow(AppException);
+      await expect(service.generateFacebookPost('item-1', TEST_SHOP_ID)).rejects.toThrow(AppException);
     });
 
     it('should wrap OpenAI API errors as AppException', async () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       mockCreate.mockRejectedValueOnce(new Error('Timeout'));
 
-      await expect(service.generateFacebookPost('item-1')).rejects.toThrow(AppException);
+      await expect(service.generateFacebookPost('item-1', TEST_SHOP_ID)).rejects.toThrow(AppException);
     });
 
     it('should trim whitespace from generated Facebook post content', async () => {
@@ -271,7 +272,7 @@ describe('AiService', () => {
         choices: [{ message: { content: '  caption with spaces  ' } }],
       });
 
-      await expect(service.generateFacebookPost('item-1')).resolves.toEqual({
+      await expect(service.generateFacebookPost('item-1', TEST_SHOP_ID)).resolves.toEqual({
         content: 'caption with spaces',
       });
     });
@@ -280,7 +281,7 @@ describe('AiService', () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       mockCreate.mockRejectedValueOnce('Timeout from upstream');
 
-      await expect(service.generateFacebookPost('item-1')).rejects.toMatchObject({
+      await expect(service.generateFacebookPost('item-1', TEST_SHOP_ID)).rejects.toMatchObject({
         errorCode: ErrorCode.INTERNAL_SERVER_ERROR,
         message: 'Failed to generate Facebook post',
       });

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -25,7 +25,11 @@ export class AiService {
     });
   }
 
-  async generateItemDescription(itemId: string, customInstructions?: string): Promise<AiDescriptionResponseDto> {
+  async generateItemDescription(
+    itemId: string,
+    tenantId: string,
+    customInstructions?: string,
+  ): Promise<AiDescriptionResponseDto> {
     this.ensureApiKeyConfigured();
 
     // Fetch item data
@@ -33,6 +37,7 @@ export class AiService {
       where: {
         id: itemId,
         deleted_at: null,
+        shop_id: tenantId,
       },
     });
 
@@ -87,7 +92,11 @@ Trả về JSON với format sau (KHÔNG có markdown code block):
     }
   }
 
-  async generateFacebookPost(itemId: string, customInstructions?: string): Promise<{ content: string }> {
+  async generateFacebookPost(
+    itemId: string,
+    tenantId: string,
+    customInstructions?: string,
+  ): Promise<{ content: string }> {
     this.ensureApiKeyConfigured();
 
     // Fetch item data
@@ -95,6 +104,7 @@ Trả về JSON với format sau (KHÔNG có markdown code block):
       where: {
         id: itemId,
         deleted_at: null,
+        shop_id: tenantId,
       },
     });
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -17,6 +17,7 @@ import { CategoriesModule } from './categories/categories.module';
 import { ShopsModule } from './shops/shops.module';
 import { PreordersModule } from './preorders/preorders.module';
 import { ThrottlerExceptionFilter } from './common/filters/throttler-exception.filter';
+import { MediaModule } from './common/media/media.module';
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { ThrottlerExceptionFilter } from './common/filters/throttler-exception.f
     CategoriesModule,
     ShopsModule,
     PreordersModule,
+    MediaModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,7 @@
 import { Controller, Post, Get, Body, UseGuards, Request, Res, HttpCode, HttpStatus } from '@nestjs/common';
 import { Response } from 'express';
+import * as crypto from 'crypto';
+import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { SwitchShopDto } from './dto/switch-shop.dto';
@@ -40,11 +42,50 @@ export class AuthController {
     };
   }
 
+  /** Readable CSRF cookie for double-submit pattern (paired with X-CSRF-Token header). */
+  private getCsrfCookieOptions(maxAgeMs = 7 * 24 * 60 * 60 * 1000): CookieOptions {
+    const isSecure = this.configService.get('COOKIE_SECURE') === 'true';
+    const sameSite = (this.configService.get('COOKIE_SAME_SITE') || 'lax') as 'lax' | 'strict' | 'none';
+    return {
+      httpOnly: false,
+      secure: isSecure,
+      sameSite,
+      path: '/',
+      maxAge: maxAgeMs,
+    };
+  }
+
+  private issueCsrfCookie(res: Response): string {
+    const token = crypto.randomBytes(32).toString('hex');
+    res.cookie('csrf_token', token, this.getCsrfCookieOptions());
+    return token;
+  }
+
+  private clearCsrfCookie(res: Response): void {
+    res.clearCookie('csrf_token', {
+      path: '/',
+      httpOnly: false,
+      secure: this.configService.get('COOKIE_SECURE') === 'true',
+      sameSite: (this.configService.get('COOKIE_SAME_SITE') || 'lax') as 'lax' | 'strict' | 'none',
+    });
+  }
+
+  /**
+   * Issue or rotate CSRF token (GET — safe method, not blocked by CSRF middleware).
+   */
+  @Get('csrf')
+  @HttpCode(HttpStatus.OK)
+  getCsrf(@Res({ passthrough: true }) res: Response) {
+    const csrf_token = this.issueCsrfCookie(res);
+    return { csrf_token };
+  }
+
   /**
    * Login endpoint - Sets access_token and refresh_token as HttpOnly cookies
    */
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { ttl: 60000, limit: 8 } })
   async login(
     @Body() loginDto: LoginDto,
     @Res({ passthrough: true }) res: Response,
@@ -61,7 +102,9 @@ export class AuthController {
       ...this.getCookieOptions(refreshTokenMaxAge),
       path: '/api/v1/auth', // Restrict refresh token to auth endpoints only
     });
-    
+
+    this.issueCsrfCookie(res);
+
     // Return user info (tokens are in cookies, not in response body for security)
     return {
       user: result.user,
@@ -74,6 +117,7 @@ export class AuthController {
    */
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { ttl: 60000, limit: 25 } })
   async refresh(
     @Request() req,
     @Res({ passthrough: true }) res: Response,
@@ -84,6 +128,7 @@ export class AuthController {
       // Clear any stale cookies - user needs to login again
       res.clearCookie('access_token', { path: '/' });
       res.clearCookie('refresh_token', { path: '/api/v1/auth' });
+      this.clearCsrfCookie(res);
       // Return 401 to trigger login redirect
       return res.status(401).json({
         ok: false,
@@ -105,7 +150,9 @@ export class AuthController {
       ...this.getCookieOptions(refreshTokenMaxAge),
       path: '/api/v1/auth',
     });
-    
+
+    this.issueCsrfCookie(res);
+
     return { message: 'Token refreshed successfully' };
   }
 
@@ -114,6 +161,7 @@ export class AuthController {
    */
   @Post('logout')
   @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { ttl: 60000, limit: 40 } })
   async logout(
     @Request() req,
     @Res({ passthrough: true }) res: Response,
@@ -127,7 +175,8 @@ export class AuthController {
     // Clear cookies
     res.clearCookie('access_token', { path: '/' });
     res.clearCookie('refresh_token', { path: '/api/v1/auth' });
-    
+    this.clearCsrfCookie(res);
+
     return { message: 'Logout successful' };
   }
 
@@ -139,6 +188,7 @@ export class AuthController {
   @Post('switch-shop')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { ttl: 60000, limit: 30 } })
   async switchShop(
     @Body() dto: SwitchShopDto,
     @Request() req,
@@ -149,6 +199,8 @@ export class AuthController {
     // Issue new access_token with active_shop_id
     const accessTokenMaxAge = 15 * 60 * 1000; // 15 minutes
     res.cookie('access_token', result.access_token, this.getCookieOptions(accessTokenMaxAge));
+
+    this.issueCsrfCookie(res);
 
     return {
       active_shop: result.active_shop,

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -16,7 +16,10 @@ import { PrismaModule } from '../common/prisma/prisma.module';
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => {
-        const secret = configService.get<string>('JWT_SECRET') || 'super-secret';
+        const secret = configService.get<string>('JWT_SECRET');
+        if (!secret || secret.trim().length < 32) {
+          throw new Error('JWT_SECRET must be set and at least 32 characters long');
+        }
         const expiresIn = (configService.get<string>('JWT_EXPIRES_IN') || '15m') as StringValue;
         return {
           secret,

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -30,7 +30,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     private authService: AuthService,
     private configService: ConfigService,
   ) {
-    const secret = configService.get<string>('JWT_SECRET') || 'super-secret';
+    const secret = configService.get<string>('JWT_SECRET');
+    if (!secret || secret.trim().length < 32) {
+      throw new Error('JWT_SECRET must be set and at least 32 characters long');
+    }
     super({
       jwtFromRequest: cookieExtractor,
       ignoreExpiration: false,

--- a/backend/src/common/media/media-signing-secret.spec.ts
+++ b/backend/src/common/media/media-signing-secret.spec.ts
@@ -1,0 +1,50 @@
+import { ConfigService } from '@nestjs/config';
+import { resolveMediaSigningSecret } from './media-signing-secret';
+
+function mockConfig(values: Record<string, string | undefined>): ConfigService {
+  return {
+    get: (key: string) => values[key],
+  } as ConfigService;
+}
+
+describe('resolveMediaSigningSecret', () => {
+  it('prefers MEDIA_SIGNING_SECRET when long enough', () => {
+    const s = resolveMediaSigningSecret(
+      mockConfig({
+        MEDIA_SIGNING_SECRET: 'a'.repeat(32),
+        JWT_SECRET: 'b'.repeat(32),
+      }),
+    );
+    expect(s).toBe('a'.repeat(32));
+  });
+
+  it('falls back to JWT_SECRET when MEDIA unset or short', () => {
+    const jwt = 'j'.repeat(32);
+    expect(
+      resolveMediaSigningSecret(
+        mockConfig({
+          MEDIA_SIGNING_SECRET: 'short',
+          JWT_SECRET: jwt,
+        }),
+      ),
+    ).toBe(jwt);
+    expect(
+      resolveMediaSigningSecret(
+        mockConfig({
+          JWT_SECRET: jwt,
+        }),
+      ),
+    ).toBe(jwt);
+  });
+
+  it('throws when neither secret is sufficient', () => {
+    expect(() =>
+      resolveMediaSigningSecret(
+        mockConfig({
+          MEDIA_SIGNING_SECRET: 'x',
+          JWT_SECRET: 'y',
+        }),
+      ),
+    ).toThrow(/MEDIA_SIGNING_SECRET|JWT_SECRET/);
+  });
+});

--- a/backend/src/common/media/media-signing-secret.ts
+++ b/backend/src/common/media/media-signing-secret.ts
@@ -1,0 +1,21 @@
+import { ConfigService } from '@nestjs/config';
+
+const MIN_SECRET_LEN = 32;
+
+/**
+ * Secret for HMAC signed media URLs. Prefer {@code MEDIA_SIGNING_SECRET} so JWT rotation
+ * does not invalidate all media links; falls back to {@code JWT_SECRET} if unset.
+ */
+export function resolveMediaSigningSecret(config: ConfigService): string {
+  const media = (config.get<string>('MEDIA_SIGNING_SECRET') || '').trim();
+  if (media.length >= MIN_SECRET_LEN) {
+    return media;
+  }
+  const jwt = (config.get<string>('JWT_SECRET') || '').trim();
+  if (jwt.length >= MIN_SECRET_LEN) {
+    return jwt;
+  }
+  throw new Error(
+    'Set MEDIA_SIGNING_SECRET (>=32 chars) or JWT_SECRET (>=32 chars) for signed media URLs',
+  );
+}

--- a/backend/src/common/media/media.controller.spec.ts
+++ b/backend/src/common/media/media.controller.spec.ts
@@ -1,0 +1,107 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { finished } from 'node:stream/promises';
+import { Writable } from 'stream';
+import { MediaController } from './media.controller';
+import { signMediaPayload } from './signed-media.util';
+
+class CollectingResponse extends Writable {
+  chunks: Buffer[] = [];
+  headersSent = false;
+  setHeader = jest.fn();
+  status = jest.fn().mockReturnThis();
+
+  override _write(
+    chunk: unknown,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string, encoding);
+    this.chunks.push(buf);
+    callback();
+  }
+}
+
+describe('MediaController', () => {
+  const secret = 's'.repeat(32);
+  let tmpRoot: string;
+  let uploadsRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'dc360-media-'));
+    uploadsRoot = path.join(tmpRoot, 'uploads');
+    await fs.mkdir(path.join(uploadsRoot, 'images'), { recursive: true });
+    await fs.writeFile(path.join(uploadsRoot, 'images', 'pic.png'), 'png-bytes');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  function controllerFromConfig(get: (key: string) => string | undefined): MediaController {
+    return new MediaController({ get } as ConfigService);
+  }
+
+  it('streams file when signature is valid', async () => {
+    const controller = controllerFromConfig((key) => {
+      if (key === 'JWT_SECRET') return secret;
+      if (key === 'UPLOAD_DIR') return uploadsRoot;
+      return undefined;
+    });
+    const rel = 'images/pic.png';
+    const { d, s } = signMediaPayload({ p: rel, exp: Date.now() + 60_000 }, secret);
+
+    const res = new CollectingResponse();
+    await controller.serveSigned(d, s, res as never);
+    await finished(res);
+    expect(Buffer.concat(res.chunks).toString()).toBe('png-bytes');
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/png');
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Disposition', 'inline');
+  });
+
+  it('returns 404 when file is missing', async () => {
+    const controller = controllerFromConfig((key) => {
+      if (key === 'JWT_SECRET') return secret;
+      if (key === 'UPLOAD_DIR') return uploadsRoot;
+      return undefined;
+    });
+    const { d, s } = signMediaPayload(
+      { p: 'images/missing.png', exp: Date.now() + 60_000 },
+      secret,
+    );
+    const end = jest.fn();
+    const status = jest.fn().mockReturnValue({ end });
+    const res = {
+      headersSent: false,
+      status,
+      setHeader: jest.fn(),
+      pipe: jest.fn(),
+    };
+    await controller.serveSigned(d, s, res as never);
+    expect(status).toHaveBeenCalledWith(404);
+    expect(end).toHaveBeenCalled();
+  });
+
+  it('rejects invalid signature', async () => {
+    const controller = controllerFromConfig((key) => {
+      if (key === 'JWT_SECRET') return secret;
+      if (key === 'UPLOAD_DIR') return uploadsRoot;
+      return undefined;
+    });
+    const res = new CollectingResponse();
+    await expect(controller.serveSigned('bad', 'sig', res as never)).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('throws Forbidden when signing not configured', async () => {
+    const controller = controllerFromConfig(() => undefined);
+    const res = new CollectingResponse();
+    await expect(controller.serveSigned('x', 'y', res as never)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+});

--- a/backend/src/common/media/media.controller.ts
+++ b/backend/src/common/media/media.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Res,
+  BadRequestException,
+  ForbiddenException,
+  Logger,
+} from '@nestjs/common';
+import { Response } from 'express';
+import * as fs from 'fs/promises';
+import { createReadStream } from 'fs';
+import * as path from 'path';
+import { ConfigService } from '@nestjs/config';
+import { verifySignedMediaParams } from './signed-media.util';
+import { resolveMediaSigningSecret } from './media-signing-secret';
+
+/**
+ * Endpoint binary thô: không bọc {@link ResponseInterceptor} ({ ok, data }).
+ * Dùng cho &lt;img src&gt; / tải file; không gọi như JSON API envelope.
+ */
+@Controller('media')
+export class MediaController {
+  private readonly logger = new Logger(MediaController.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  @Get()
+  async serveSigned(
+    @Query('d') d: string | undefined,
+    @Query('s') s: string | undefined,
+    @Res() res: Response,
+  ): Promise<void> {
+    let secret: string;
+    try {
+      secret = resolveMediaSigningSecret(this.config);
+    } catch {
+      throw new ForbiddenException('Media signing is not configured');
+    }
+
+    const payload = verifySignedMediaParams(d, s, secret);
+    if (!payload) {
+      throw new BadRequestException('Invalid or expired media link');
+    }
+
+    const uploadDir = this.config.get<string>('UPLOAD_DIR') || './uploads';
+    const root = path.resolve(process.cwd(), uploadDir);
+    const absolute = path.resolve(root, payload.p);
+    const rel = path.relative(root, absolute);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new ForbiddenException('Invalid media path');
+    }
+
+    try {
+      await fs.access(absolute);
+    } catch {
+      res.status(404).end();
+      return;
+    }
+
+    const ext = payload.p.toLowerCase().split('.').pop() || '';
+    const mime =
+      ext === 'jpg' || ext === 'jpeg'
+        ? 'image/jpeg'
+        : ext === 'png'
+          ? 'image/png'
+          : ext === 'webp'
+            ? 'image/webp'
+            : ext === 'gif'
+              ? 'image/gif'
+              : 'application/octet-stream';
+
+    res.setHeader('Content-Type', mime);
+    res.setHeader('Cache-Control', 'private, max-age=3600');
+    if (['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(ext)) {
+      res.setHeader('Content-Disposition', 'inline');
+    }
+
+    const stream = createReadStream(absolute);
+    stream.on('error', (err) => {
+      this.logger.warn(
+        `Media stream failed: ${err instanceof Error ? err.name : 'Error'}`,
+      );
+      if (!res.headersSent) {
+        res.status(500).end();
+      }
+    });
+    stream.pipe(res);
+  }
+}

--- a/backend/src/common/media/media.module.ts
+++ b/backend/src/common/media/media.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { MediaController } from './media.controller';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [MediaController],
+})
+export class MediaModule {}

--- a/backend/src/common/media/signed-media.util.ts
+++ b/backend/src/common/media/signed-media.util.ts
@@ -1,0 +1,53 @@
+import * as crypto from 'crypto';
+
+export interface SignedMediaPayload {
+  /** Relative path under upload root, e.g. images/foo.jpg */
+  p: string;
+  /** Expiry epoch ms */
+  exp: number;
+}
+
+export function signMediaPayload(payload: SignedMediaPayload, secret: string): { d: string; s: string } {
+  const d = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  const s = crypto.createHmac('sha256', secret).update(d).digest('hex');
+  return { d, s };
+}
+
+export function verifySignedMediaParams(
+  d: string | undefined,
+  s: string | undefined,
+  secret: string,
+): SignedMediaPayload | null {
+  if (!d || !s || typeof d !== 'string' || typeof s !== 'string') return null;
+  const expected = crypto.createHmac('sha256', secret).update(d).digest('hex');
+  const a = Buffer.from(expected, 'utf8');
+  const b = Buffer.from(s, 'utf8');
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(d, 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const { p, exp } = parsed as Partial<SignedMediaPayload>;
+  if (typeof p !== 'string' || typeof exp !== 'number' || !Number.isFinite(exp)) return null;
+  if (exp <= Date.now()) return null;
+  const clean = p.replace(/^\.\//, '').replace(/^\//, '');
+  if (clean.includes('..') || clean.startsWith('/')) return null;
+  return { p: clean, exp };
+}
+
+/** Build GET URL for {@link MediaController} (global prefix /api/v1 already applied by Nest). */
+export function buildSignedMediaFileUrl(
+  apiBaseUrl: string,
+  relativeFilePath: string,
+  secret: string,
+  ttlMs: number,
+): string {
+  const clean = relativeFilePath.replace(/^\.\//, '').replace(/^\//, '');
+  const exp = Date.now() + ttlMs;
+  const { d, s } = signMediaPayload({ p: clean, exp }, secret);
+  const base = apiBaseUrl.replace(/\/$/, '');
+  return `${base}/media?d=${encodeURIComponent(d)}&s=${encodeURIComponent(s)}`;
+}

--- a/backend/src/common/middleware/csrf.middleware.spec.ts
+++ b/backend/src/common/middleware/csrf.middleware.spec.ts
@@ -1,0 +1,94 @@
+import { createCsrfMiddleware, isCsrfExemptRoute, normalizeApiV1RoutePath } from './csrf.middleware';
+
+describe('normalizeApiV1RoutePath', () => {
+  it('extracts route after /api/v1', () => {
+    expect(normalizeApiV1RoutePath('/api/v1/auth/me')).toBe('/auth/me');
+    expect(normalizeApiV1RoutePath('/api/v1/auth/login')).toBe('/auth/login');
+  });
+
+  it('strips trailing slashes', () => {
+    expect(normalizeApiV1RoutePath('/api/v1/items/')).toBe('/items');
+  });
+
+  it('returns full path when marker missing', () => {
+    expect(normalizeApiV1RoutePath('/health')).toBe('/health');
+  });
+});
+
+describe('isCsrfExemptRoute', () => {
+  it('exempts login with standard prefix', () => {
+    expect(isCsrfExemptRoute('/api/v1/auth/login')).toBe(true);
+  });
+
+  it('does not exempt other auth routes', () => {
+    expect(isCsrfExemptRoute('/api/v1/auth/refresh')).toBe(false);
+    expect(isCsrfExemptRoute('/api/v1/auth/csrf')).toBe(false);
+  });
+});
+
+describe('createCsrfMiddleware', () => {
+  const mw = createCsrfMiddleware();
+
+  it('allows GET without CSRF header', (done) => {
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/v1/items',
+      cookies: {},
+      headers: {},
+    };
+    const res = { status: jest.fn(), json: jest.fn() };
+    mw(req as never, res as never, (err?: unknown) => {
+      expect(err).toBeUndefined();
+      done();
+    });
+  });
+
+  it('allows POST /api/v1/auth/login without CSRF', (done) => {
+    const req = {
+      method: 'POST',
+      originalUrl: '/api/v1/auth/login',
+      cookies: {},
+      headers: {},
+    };
+    const res = { status: jest.fn(), json: jest.fn() };
+    mw(req as never, res as never, (err?: unknown) => {
+      expect(err).toBeUndefined();
+      done();
+    });
+  });
+
+  it('blocks POST without matching CSRF', (done) => {
+    const req = {
+      method: 'POST',
+      originalUrl: '/api/v1/items',
+      cookies: {},
+      headers: {},
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn((body: { error: { code: string } }) => {
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(body.error.code).toBe('CSRF_INVALID');
+        done();
+      }),
+    };
+    mw(req as never, res as never, () => {
+      done(new Error('expected block'));
+    });
+  });
+
+  it('allows POST when header matches cookie', (done) => {
+    const token = 'abc123';
+    const req = {
+      method: 'POST',
+      originalUrl: '/api/v1/items',
+      cookies: { csrf_token: token },
+      headers: { 'x-csrf-token': token },
+    };
+    const res = { status: jest.fn(), json: jest.fn() };
+    mw(req as never, res as never, (err?: unknown) => {
+      expect(err).toBeUndefined();
+      done();
+    });
+  });
+});

--- a/backend/src/common/middleware/csrf.middleware.ts
+++ b/backend/src/common/middleware/csrf.middleware.ts
@@ -1,0 +1,83 @@
+import type { NextFunction, Request, Response } from 'express';
+
+const CSRF_COOKIE = 'csrf_token';
+const CSRF_HEADER = 'x-csrf-token';
+
+const API_V1_MARKER = '/api/v1';
+
+function isSafeMethod(method: string): boolean {
+  return method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
+}
+
+/** Strip query string for path-only checks. */
+export function pathWithoutQuery(url: string): string {
+  const q = url.indexOf('?');
+  return q === -1 ? url : url.slice(0, q);
+}
+
+/**
+ * Route path relative to global prefix {@code /api/v1}, e.g. {@code /auth/login}.
+ * If the marker is missing (some proxies), returns the full path without query.
+ */
+export function normalizeApiV1RoutePath(fullUrl: string): string {
+  const p = pathWithoutQuery(fullUrl);
+  const idx = p.indexOf(API_V1_MARKER);
+  if (idx === -1) {
+    return p;
+  }
+  let rest = p.slice(idx + API_V1_MARKER.length);
+  if (!rest || rest === '/') {
+    return '/';
+  }
+  if (!rest.startsWith('/')) {
+    rest = `/${rest}`;
+  }
+  return rest.replace(/\/+$/, '') || '/';
+}
+
+/** Mutating requests exempt from CSRF (login chưa có cookie csrf_token). */
+export function isCsrfExemptRoute(fullUrl: string): boolean {
+  const route = normalizeApiV1RoutePath(fullUrl);
+  if (route === '/auth/login') {
+    return true;
+  }
+  const p = pathWithoutQuery(fullUrl);
+  return p.endsWith('/auth/login');
+}
+
+/**
+ * Double-submit CSRF for cookie-authenticated mutating requests.
+ * GET/HEAD/OPTIONS always pass. Bootstrap CSRF uses GET /auth/csrf (safe method).
+ * Raw binary endpoint GET /api/v1/media is also safe method — not listed here intentionally.
+ */
+export function createCsrfMiddleware(): (req: Request, res: Response, next: NextFunction) => void {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const method = (req.method || 'GET').toUpperCase();
+    if (isSafeMethod(method)) {
+      next();
+      return;
+    }
+
+    const fullPath = req.originalUrl || req.url || '';
+
+    if (isCsrfExemptRoute(fullPath)) {
+      next();
+      return;
+    }
+
+    const headerVal = req.headers[CSRF_HEADER];
+    const header = Array.isArray(headerVal) ? headerVal[0] : headerVal;
+    const cookie = req.cookies?.[CSRF_COOKIE] as string | undefined;
+
+    if (!header || !cookie || header !== cookie) {
+      res.status(403).json({
+        ok: false,
+        error: { code: 'CSRF_INVALID', details: [] },
+        message: 'CSRF token missing or invalid',
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/backend/src/common/security/runtime-security.ts
+++ b/backend/src/common/security/runtime-security.ts
@@ -1,0 +1,24 @@
+export function normalizeEnvBoolean(value: string | undefined): boolean {
+  return (value || '').trim().toLowerCase() === 'true';
+}
+
+/** Production boot checks (cookie/CORS hardening). */
+export function validateRuntimeSecurityConfig(env: NodeJS.ProcessEnv = process.env): void {
+  const isProduction = (env.NODE_ENV || '').trim().toLowerCase() === 'production';
+  if (!isProduction) return;
+
+  const cookieSecure = normalizeEnvBoolean(env.COOKIE_SECURE);
+  if (!cookieSecure) {
+    throw new Error('COOKIE_SECURE must be true in production');
+  }
+
+  const sameSite = (env.COOKIE_SAME_SITE || 'lax').trim().toLowerCase();
+  if (!['lax', 'strict'].includes(sameSite)) {
+    throw new Error('COOKIE_SAME_SITE must be "lax" or "strict" in production');
+  }
+
+  const allowLanCors = normalizeEnvBoolean(env.CORS_ALLOW_LAN);
+  if (allowLanCors) {
+    throw new Error('CORS_ALLOW_LAN must be false in production');
+  }
+}

--- a/backend/src/images/images.controller.ts
+++ b/backend/src/images/images.controller.ts
@@ -11,6 +11,7 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ImagesService } from './images.service';
 import { UpdateImageDto } from './dto/update-image.dto';
@@ -25,6 +26,7 @@ export class ImagesController {
   constructor(private readonly imagesService: ImagesService) {}
 
   @Post()
+  @Throttle({ default: { ttl: 60000, limit: 40 } })
   @UseInterceptors(FileInterceptor('file'))
   async uploadImage(
     @Param('itemId') itemId: string,

--- a/backend/src/items/ai-draft.controller.spec.ts
+++ b/backend/src/items/ai-draft.controller.spec.ts
@@ -63,7 +63,7 @@ describe('AiDraftController', () => {
   });
 
   it('should create a draft after analyzing and saving images', async () => {
-    const result = await controller.createDraft([buildFile('box.jpg'), buildFile('bottom.jpg')]);
+    const result = await controller.createDraft([buildFile('box.jpg'), buildFile('bottom.jpg')], 'shop-1');
 
     expect(aiService.analyzeImages).toHaveBeenCalledWith([Buffer.from('box.jpg'), Buffer.from('bottom.jpg')]);
     expect(prisma.aiItemDraft.create).toHaveBeenCalledWith({
@@ -86,21 +86,22 @@ describe('AiDraftController', () => {
       .mockResolvedValueOnce('drafts/first.jpg')
       .mockResolvedValueOnce('drafts/second.jpg');
 
-    await controller.createDraft([buildFile('same.jpg'), buildFile('same.jpg')]);
+    await controller.createDraft([buildFile('same.jpg'), buildFile('same.jpg')], 'shop-1');
 
     const firstFilename = storage.saveFile.mock.calls[0][1] as string;
     const secondFilename = storage.saveFile.mock.calls[1][1] as string;
     expect(firstFilename).not.toBe(secondFilename);
+    expect(firstFilename).toContain('shop1');
   });
 
   it('should reject empty uploads', async () => {
-    await expect(controller.createDraft([])).rejects.toBeInstanceOf(BadRequestException);
+    await expect(controller.createDraft([], 'shop-1')).rejects.toBeInstanceOf(BadRequestException);
   });
 
   it('should propagate analysis errors without saving or cleaning up files', async () => {
     aiService.analyzeImages.mockRejectedValueOnce(new Error('analysis failed'));
 
-    await expect(controller.createDraft([buildFile('box.jpg')])).rejects.toThrow('analysis failed');
+    await expect(controller.createDraft([buildFile('box.jpg')], 'shop-1')).rejects.toThrow('analysis failed');
 
     expect(storage.saveFile).not.toHaveBeenCalled();
     expect(storage.deleteFile).not.toHaveBeenCalled();
@@ -114,7 +115,7 @@ describe('AiDraftController', () => {
     prisma.aiItemDraft.create.mockRejectedValueOnce(new Error('db write failed'));
 
     await expect(
-      controller.createDraft([buildFile('box.jpg'), buildFile('bottom.jpg')]),
+      controller.createDraft([buildFile('box.jpg'), buildFile('bottom.jpg')], 'shop-1'),
     ).rejects.toThrow('db write failed');
 
     expect(storage.deleteFile).toHaveBeenCalledTimes(2);
@@ -128,7 +129,7 @@ describe('AiDraftController', () => {
       .mockRejectedValueOnce(new Error('disk full'));
 
     await expect(
-      controller.createDraft([buildFile('box.jpg'), buildFile('bottom.jpg')]),
+      controller.createDraft([buildFile('box.jpg'), buildFile('bottom.jpg')], 'shop-1'),
     ).rejects.toThrow('disk full');
 
     expect(storage.deleteFile).toHaveBeenCalledTimes(1);
@@ -142,7 +143,7 @@ describe('AiDraftController', () => {
     prisma.aiItemDraft.create.mockRejectedValueOnce(new Error('db write failed'));
     storage.deleteFile.mockRejectedValueOnce(new Error('cleanup failed'));
 
-    await expect(controller.createDraft([buildFile('box.jpg')])).rejects.toThrow('db write failed');
+    await expect(controller.createDraft([buildFile('box.jpg')], 'shop-1')).rejects.toThrow('db write failed');
 
     expect(loggerErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Failed to cleanup draft file "drafts/box.jpg"'),

--- a/backend/src/items/ai-draft.controller.ts
+++ b/backend/src/items/ai-draft.controller.ts
@@ -5,9 +5,11 @@ import { AiService } from '../ai/ai.service';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { IStorageService } from '../storage/storage.interface';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TenantGuard } from '../common/guards/tenant.guard';
+import { CurrentTenantId } from '../common/decorators/tenant.decorator';
 
 @Controller('items/ai-draft')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, TenantGuard)
 export class AiDraftController {
   private readonly logger = new Logger(AiDraftController.name);
 
@@ -22,6 +24,7 @@ export class AiDraftController {
   @UseInterceptors(FilesInterceptor('images', 10)) // max 10 files
   async createDraft(
     @UploadedFiles() files: Array<Express.Multer.File>,
+    @CurrentTenantId() tenantId: string,
   ) {
     if (!files || files.length === 0) {
       throw new BadRequestException('At least one image is required');
@@ -49,7 +52,7 @@ export class AiDraftController {
       // 2. Save images to storage
       const imageUrls: string[] = [];
       for (const [index, file] of files.entries()) {
-        const filename = this.buildDraftFilename(file.originalname, index);
+        const filename = this.buildDraftFilename(file.originalname, index, tenantId);
         const path = await this.storage.saveFile(file.buffer, filename, 'drafts');
         savedPaths.push(path);
         imageUrls.push(this.storage.getFileUrl(path));
@@ -87,8 +90,9 @@ export class AiDraftController {
     }
   }
 
-  private buildDraftFilename(originalName: string, index: number): string {
+  private buildDraftFilename(originalName: string, index: number, tenantId: string): string {
+    const tenantPrefix = tenantId.replace(/[^a-zA-Z0-9]/g, '').slice(0, 12) || 'tenant';
     const sanitized = originalName.replace(/[^a-zA-Z0-9.]/g, '_');
-    return `draft_${Date.now()}_${index}_${Math.random().toString(36).slice(2, 10)}_${sanitized}`;
+    return `draft_${tenantPrefix}_${Date.now()}_${index}_${Math.random().toString(36).slice(2, 10)}_${sanitized}`;
   }
 }

--- a/backend/src/main.security.spec.ts
+++ b/backend/src/main.security.spec.ts
@@ -1,0 +1,44 @@
+import { validateRuntimeSecurityConfig } from './common/security/runtime-security';
+
+describe('validateRuntimeSecurityConfig', () => {
+  it('allows non-production defaults', () => {
+    expect(() =>
+      validateRuntimeSecurityConfig({
+        NODE_ENV: 'development',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects production when COOKIE_SECURE is not true', () => {
+    expect(() =>
+      validateRuntimeSecurityConfig({
+        NODE_ENV: 'production',
+        COOKIE_SECURE: 'false',
+        COOKIE_SAME_SITE: 'strict',
+        CORS_ALLOW_LAN: 'false',
+      }),
+    ).toThrow('COOKIE_SECURE must be true in production');
+  });
+
+  it('rejects production when COOKIE_SAME_SITE is none', () => {
+    expect(() =>
+      validateRuntimeSecurityConfig({
+        NODE_ENV: 'production',
+        COOKIE_SECURE: 'true',
+        COOKIE_SAME_SITE: 'none',
+        CORS_ALLOW_LAN: 'false',
+      }),
+    ).toThrow('COOKIE_SAME_SITE must be "lax" or "strict" in production');
+  });
+
+  it('rejects production when LAN CORS is enabled', () => {
+    expect(() =>
+      validateRuntimeSecurityConfig({
+        NODE_ENV: 'production',
+        COOKIE_SECURE: 'true',
+        COOKIE_SAME_SITE: 'strict',
+        CORS_ALLOW_LAN: 'true',
+      }),
+    ).toThrow('CORS_ALLOW_LAN must be false in production');
+  });
+});

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,9 +4,10 @@ import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/exceptions/http-exception.filter';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
-import { join } from 'path';
 import * as sharp from 'sharp';
 import * as cookieParser from 'cookie-parser';
+import { createCsrfMiddleware } from './common/middleware/csrf.middleware';
+import { validateRuntimeSecurityConfig } from './common/security/runtime-security';
 
 /** Merge FRONTEND_URL + FRONTEND_URLS and add localhost ↔ 127.0.0.1 variants (same port). */
 function buildCorsAllowedOrigins(): string[] {
@@ -58,18 +59,17 @@ sharp.concurrency(1); // Process images sequentially to limit concurrent memory 
 sharp.simd(false); // Disable SIMD to reduce memory footprint (slight performance trade-off)
 
 async function bootstrap() {
+  validateRuntimeSecurityConfig();
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   
   // Cookie parser middleware - enables reading cookies from requests
-  const cookieSecret = process.env.COOKIE_SECRET || 'diecast360-cookie-secret';
+  const cookieSecret = process.env.COOKIE_SECRET;
+  if (!cookieSecret || cookieSecret.trim().length < 32) {
+    throw new Error('COOKIE_SECRET must be set and at least 32 characters long');
+  }
   app.use(cookieParser(cookieSecret));
-  
-  // Serve static files from uploads directory
-  const uploadDir = process.env.UPLOAD_DIR || './uploads';
-  app.useStaticAssets(join(process.cwd(), uploadDir), {
-    prefix: '/uploads',
-  });
-  
+  app.use(createCsrfMiddleware());
+
   app.setGlobalPrefix('api/v1');
   
   app.useGlobalPipes(
@@ -85,8 +85,8 @@ async function bootstrap() {
 
   const corsOrigins = buildCorsAllowedOrigins();
   const allowLanCors =
-    process.env.CORS_ALLOW_LAN === 'true' ||
-    (process.env.CORS_ALLOW_LAN !== 'false' && process.env.NODE_ENV !== 'production');
+    process.env.NODE_ENV !== 'production' &&
+    process.env.CORS_ALLOW_LAN === 'true';
 
   app.enableCors({
     origin: (origin, callback) => {
@@ -111,5 +111,9 @@ async function bootstrap() {
   await app.listen(port);
   console.log(`Application is running on: http://localhost:${port}`);
 }
-bootstrap();
+export { validateRuntimeSecurityConfig } from './common/security/runtime-security';
+
+if (require.main === module) {
+  bootstrap();
+}
 

--- a/backend/src/spinner/spinner.controller.ts
+++ b/backend/src/spinner/spinner.controller.ts
@@ -12,6 +12,7 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { SpinnerService } from './spinner.service';
 import { CreateSpinSetDto } from './dto/create-spin-set.dto';
@@ -60,6 +61,7 @@ export class SpinSetController {
   }
 
   @Post('frames')
+  @Throttle({ default: { ttl: 60000, limit: 35 } })
   @UseInterceptors(FileInterceptor('frame'))
   async uploadFrame(
     @Param('spinSetId') spinSetId: string,

--- a/backend/src/storage/local-storage.service.spec.ts
+++ b/backend/src/storage/local-storage.service.spec.ts
@@ -1,4 +1,6 @@
+import { ConfigService } from '@nestjs/config';
 import { LocalStorageService } from './local-storage.service';
+import { verifySignedMediaParams } from '../common/media/signed-media.util';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
@@ -10,6 +12,19 @@ const mockedFs = jest.mocked(fs);
 describe('LocalStorageService', () => {
   let service: LocalStorageService;
   const originalEnv = process.env;
+  const mediaSigningSecret = 'm'.repeat(32);
+
+  const mockConfig = (): ConfigService =>
+    ({
+      get: jest.fn((key: string) => {
+        if (key === 'UPLOAD_DIR') return '/test/uploads';
+        if (key === 'BACKEND_URL') return 'http://localhost:3000';
+        if (key === 'MEDIA_SIGNING_SECRET') return mediaSigningSecret;
+        if (key === 'JWT_SECRET') return 'short';
+        if (key === 'MEDIA_URL_TTL_MS') return 3600000;
+        return undefined;
+      }),
+    }) as unknown as ConfigService;
 
   beforeEach(() => {
     process.env = { ...originalEnv, UPLOAD_DIR: '/test/uploads' };
@@ -20,7 +35,7 @@ describe('LocalStorageService', () => {
     mockedFs.rename.mockResolvedValue(undefined);
     mockedFs.copyFile.mockResolvedValue(undefined);
 
-    service = new LocalStorageService();
+    service = new LocalStorageService(mockConfig());
   });
 
   afterEach(() => {
@@ -114,19 +129,30 @@ describe('LocalStorageService', () => {
   // getFileUrl
   // ============================================================
   describe('getFileUrl', () => {
-    it('should return correct URL', () => {
-      const url = service.getFileUrl('images/test.jpg');
-      expect(url).toBe('http://localhost:3000/uploads/images/test.jpg');
+    it('should return signed media URL', () => {
+      const href = service.getFileUrl('images/test.jpg');
+      const u = new URL(href);
+      expect(u.pathname).toBe('/api/v1/media');
+      const d = u.searchParams.get('d');
+      const s = u.searchParams.get('s');
+      expect(d).toBeTruthy();
+      expect(s).toBeTruthy();
+      const payload = verifySignedMediaParams(d!, s!, mediaSigningSecret);
+      expect(payload?.p).toBe('images/test.jpg');
     });
 
     it('should strip leading ./ from path', () => {
-      const url = service.getFileUrl('./images/test.jpg');
-      expect(url).toBe('http://localhost:3000/uploads/images/test.jpg');
+      const href = service.getFileUrl('./images/test.jpg');
+      const u = new URL(href);
+      const payload = verifySignedMediaParams(u.searchParams.get('d')!, u.searchParams.get('s')!, mediaSigningSecret);
+      expect(payload?.p).toBe('images/test.jpg');
     });
 
     it('should strip leading / from path', () => {
-      const url = service.getFileUrl('/images/test.jpg');
-      expect(url).toBe('http://localhost:3000/uploads/images/test.jpg');
+      const href = service.getFileUrl('/images/test.jpg');
+      const u = new URL(href);
+      const payload = verifySignedMediaParams(u.searchParams.get('d')!, u.searchParams.get('s')!, mediaSigningSecret);
+      expect(payload?.p).toBe('images/test.jpg');
     });
   });
 });

--- a/backend/src/storage/local-storage.service.ts
+++ b/backend/src/storage/local-storage.service.ts
@@ -1,14 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { buildSignedMediaFileUrl } from '../common/media/signed-media.util';
+import { resolveMediaSigningSecret } from '../common/media/media-signing-secret';
 import { IStorageService } from './storage.interface';
 
 @Injectable()
 export class LocalStorageService implements IStorageService {
   private readonly uploadDir: string;
 
-  constructor() {
-    this.uploadDir = process.env.UPLOAD_DIR || './uploads';
+  constructor(private readonly config: ConfigService) {
+    this.uploadDir = this.config.get<string>('UPLOAD_DIR') || './uploads';
     this.ensureUploadDir();
   }
 
@@ -64,10 +67,12 @@ export class LocalStorageService implements IStorageService {
   }
 
   getFileUrl(filePath: string): string {
-    const baseUrl = process.env.BACKEND_URL || 'http://localhost:3000';
-    // Remove leading ./ or / from filePath
+    const backend = (this.config.get<string>('BACKEND_URL') || 'http://localhost:3000').replace(/\/$/, '');
+    const apiBase = `${backend}/api/v1`;
+    const secret = resolveMediaSigningSecret(this.config);
+    const ttlMs = Number(this.config.get('MEDIA_URL_TTL_MS')) || 7 * 24 * 60 * 60 * 1000;
     const cleanPath = filePath.replace(/^\.\//, '').replace(/^\//, '');
-    return `${baseUrl}/uploads/${cleanPath}`;
+    return buildSignedMediaFileUrl(apiBase, cleanPath, secret, ttlMs);
   }
 }
 

--- a/backend/src/storage/storage.module.ts
+++ b/backend/src/storage/storage.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { LocalStorageService } from './local-storage.service';
 import { IStorageService } from './storage.interface';
 
@@ -8,6 +9,7 @@ const StorageServiceProvider = {
 };
 
 @Module({
+  imports: [ConfigModule],
   providers: [StorageServiceProvider, LocalStorageService],
   exports: ['IStorageService', LocalStorageService],
 })

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { API_CONFIG } from '../config/api';
+import { csrfHeaderPair, ensureCsrfBootstrap, fetchWithCsrfRetry } from './csrf';
 
 export const apiClient = axios.create({
   baseURL: API_CONFIG.BASE_URL,
@@ -12,6 +13,15 @@ export const apiClient = axios.create({
 // Request interceptor - Cookies are automatically sent with withCredentials: true
 apiClient.interceptors.request.use(
   (config) => {
+    const method = (config.method || 'get').toUpperCase();
+    if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+      const extra = csrfHeaderPair();
+      const h = config.headers ?? {};
+      for (const [k, v] of Object.entries(extra)) {
+        (h as Record<string, string>)[k] = v;
+      }
+      config.headers = h;
+    }
     return config;
   },
   (error) => {
@@ -28,6 +38,32 @@ apiClient.interceptors.response.use(
   },
   async (error) => {
     const originalRequest = error.config;
+    if (!originalRequest) {
+      return Promise.reject(error.response?.data || error);
+    }
+
+    const errData = error.response?.data as { error?: { code?: string } } | undefined;
+    const reqWithFlags = originalRequest as typeof originalRequest & { _csrfRetry?: boolean };
+    if (
+      error.response?.status === 403 &&
+      errData?.error?.code === 'CSRF_INVALID' &&
+      !reqWithFlags._csrfRetry
+    ) {
+      const method = (originalRequest.method || 'get').toUpperCase();
+      const url = String(originalRequest.url || '');
+      if (
+        ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method) &&
+        !url.includes('/auth/csrf')
+      ) {
+        reqWithFlags._csrfRetry = true;
+        try {
+          await ensureCsrfBootstrap();
+          return apiClient(originalRequest);
+        } catch {
+          return Promise.reject(error.response?.data || error);
+        }
+      }
+    }
 
     // Skip refresh attempt for auth endpoints to avoid loops
     const isAuthEndpoint = originalRequest.url?.includes('/auth/');
@@ -39,9 +75,30 @@ apiClient.interceptors.response.use(
       try {
         // Attempt to refresh the token using cookie-based refresh
         // The refresh_token cookie will be sent automatically
-        const refreshResponse = await axios.post(`${API_CONFIG.BASE_URL}/auth/refresh`, {}, {
-          withCredentials: true,
-        });
+        const refreshResponse = await (async () => {
+          const doRefresh = () =>
+            axios.post(
+              `${API_CONFIG.BASE_URL}/auth/refresh`,
+              {},
+              {
+                withCredentials: true,
+                headers: csrfHeaderPair(),
+              },
+            );
+          try {
+            return await doRefresh();
+          } catch (e) {
+            if (
+              axios.isAxiosError(e) &&
+              e.response?.status === 403 &&
+              (e.response?.data as { error?: { code?: string } })?.error?.code === 'CSRF_INVALID'
+            ) {
+              await ensureCsrfBootstrap();
+              return await doRefresh();
+            }
+            throw e;
+          }
+        })();
 
         // Check if refresh was successful
         if (refreshResponse.status === 200) {
@@ -87,10 +144,13 @@ export const uploadFile = async <T = unknown>(
   url: string, 
   formData: FormData
 ): Promise<T> => {
-  const response = await axios.post(`${API_CONFIG.BASE_URL}${url}`, formData, {
-    withCredentials: true,
-    // DO NOT set Content-Type manually — Axios auto-detects
-    // multipart/form-data with correct boundary from FormData
-  });
+  const response = await fetchWithCsrfRetry(() =>
+    axios.post(`${API_CONFIG.BASE_URL}${url}`, formData, {
+      withCredentials: true,
+      headers: csrfHeaderPair(),
+      // DO NOT set Content-Type manually — Axios auto-detects
+      // multipart/form-data with correct boundary from FormData
+    }),
+  );
   return response.data;
 };

--- a/frontend/src/api/csrf.ts
+++ b/frontend/src/api/csrf.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+import { API_CONFIG } from '../config/api';
+
+/**
+ * Double-submit CSRF: readable cookie + X-CSRF-Token header (must match).
+ */
+export function readCsrfTokenFromCookie(): string | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const parts = document.cookie.split(';');
+  for (const part of parts) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    const name = part.slice(0, idx).trim();
+    if (name !== 'csrf_token') continue;
+    const raw = part.slice(idx + 1).trim();
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  }
+  return undefined;
+}
+
+export function csrfHeaderPair(): Record<string, string> {
+  const token = readCsrfTokenFromCookie();
+  return token ? { 'X-CSRF-Token': token } : {};
+}
+
+/** Lấy cookie csrf_token từ backend (GET an toàn). */
+export async function ensureCsrfBootstrap(): Promise<void> {
+  await axios.get(`${API_CONFIG.BASE_URL}/auth/csrf`, { withCredentials: true });
+}
+
+function isCsrfInvalidAxiosError(err: unknown): boolean {
+  if (!axios.isAxiosError(err)) return false;
+  if (err.response?.status !== 403) return false;
+  const code = (err.response?.data as { error?: { code?: string } })?.error?.code;
+  return code === 'CSRF_INVALID';
+}
+
+/** Một lần bootstrap CSRF rồi gửi lại request (tránh vòng lặp vô hạn). */
+export async function fetchWithCsrfRetry<T>(send: () => Promise<T>): Promise<T> {
+  try {
+    return await send();
+  } catch (e) {
+    if (!isCsrfInvalidAxiosError(e)) throw e;
+    await ensureCsrfBootstrap();
+    return await send();
+  }
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -207,7 +207,7 @@ export const Layout = ({ children }: LayoutProps) => {
         <div>
           <p className="text-sm font-semibold tracking-wide text-white">Diecast360</p>
           <p className="mt-1 max-w-md text-sm leading-relaxed text-slate-400">
-            Catalog công khai, quản trị đa shop, media & viewer 360° — giao diện Corporate Trust.
+            Catalog công khai, quản trị đa shop, media & viewer 360°.
           </p>
         </div>
         <p className="text-xs font-medium text-slate-500">© {new Date().getFullYear()} Diecast360</p>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -21,6 +21,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     try {
       const response = await apiClient.get('/auth/me') as ApiResponse<{ user: User }>;
       setUser(response.data?.user);
+      if (response.data?.user) {
+        try {
+          await apiClient.get('/auth/csrf');
+        } catch {
+          /* cookie may still be set; ignore */
+        }
+      }
       return true;
     } catch {
       setUser(null);


### PR DESCRIPTION
- Remove public /uploads; serve files via HMAC GET /api/v1/media
- Optional MEDIA_SIGNING_SECRET; runtime-security validation extracted
- Double-submit CSRF middleware; auth csrf cookie + frontend retry/bootstrap
- Require JWT_SECRET/COOKIE_SECRET min length; tighten CORS LAN and prod checks
- Tenant isolation for AI routes; throttle auth/upload/AI endpoints
- Harden admin scripts (no default passwords); layout footer copy tweak

Made-with: Cursor