### PR TITLE
fix(pagination): minimum one total_pages for empty list APIs

### DIFF
--- a/backend/src/common/utils/pagination.utils.spec.ts
+++ b/backend/src/common/utils/pagination.utils.spec.ts
@@ -1,0 +1,22 @@
+import { totalPagesFromCount } from './pagination.utils';
+
+describe('totalPagesFromCount', () => {
+  it('returns 1 when total is 0', () => {
+    expect(totalPagesFromCount(0, 20)).toBe(1);
+  });
+
+  it('returns 1 for a single full page', () => {
+    expect(totalPagesFromCount(5, 20)).toBe(1);
+    expect(totalPagesFromCount(20, 20)).toBe(1);
+  });
+
+  it('rounds up for partial last pages', () => {
+    expect(totalPagesFromCount(21, 20)).toBe(2);
+    expect(totalPagesFromCount(50, 10)).toBe(5);
+  });
+
+  it('clamps invalid page size to 1', () => {
+    expect(totalPagesFromCount(0, 0)).toBe(1);
+    expect(totalPagesFromCount(5, -3)).toBe(5);
+  });
+});

--- a/backend/src/common/utils/pagination.utils.ts
+++ b/backend/src/common/utils/pagination.utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Page count for list APIs: empty results still expose one logical page so clients
+ * never show "page 1 of 0".
+ */
+export function totalPagesFromCount(total: number, pageSize: number): number {
+  const safeSize = Math.max(1, pageSize);
+  return Math.max(1, Math.ceil(total / safeSize));
+}

--- a/backend/src/inventory/inventory.service.ts
+++ b/backend/src/inventory/inventory.service.ts
@@ -7,6 +7,7 @@ import { PrismaService } from '../common/prisma/prisma.service';
 import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
 import { CreateInventoryTransactionDto } from './dto/create-inventory-transaction.dto';
 import { QueryInventoryTransactionsDto } from './dto/query-inventory-transactions.dto';
+import { totalPagesFromCount } from '../common/utils/pagination.utils';
 
 @Injectable()
 export class InventoryService {
@@ -167,7 +168,7 @@ export class InventoryService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
       current_quantity: item?.quantity ?? 0,
     };

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -510,6 +510,21 @@ describe('ItemsService', () => {
       expect(findManyCall.where.facebook_posts).toEqual({ none: {} });
     });
 
+    it('should report one total page when list is empty', async () => {
+      prisma.item.findMany.mockResolvedValue([]);
+      prisma.item.count.mockResolvedValue(0);
+
+      const result = await service.findAll({}, TEST_SHOP_ID);
+
+      expect(result.items).toHaveLength(0);
+      expect(result.pagination).toEqual({
+        page: 1,
+        page_size: 20,
+        total: 0,
+        total_pages: 1,
+      });
+    });
+
     it('should handle custom pagination', async () => {
       prisma.item.findMany.mockResolvedValue([]);
       prisma.item.count.mockResolvedValue(50);

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -10,6 +10,7 @@ import { EmbeddingService, EmbeddingUnavailableError } from '../ai/embedding.ser
 import { QueryItemsDto } from './dto/query-items.dto';
 import type { VectorSyncItem, ItemWithCoverImage, CsvFieldValue } from '../common/types/item.types';
 import { toNumber } from '../common/utils/decimal.utils';
+import { totalPagesFromCount } from '../common/utils/pagination.utils';
 import { FacebookGraphService } from '../integrations/facebook/facebook-graph.service';
 import { FacebookConfigService } from '../integrations/facebook/facebook-config.service';
 import { PublishFacebookPostDto } from './dto/publish-facebook-post.dto';
@@ -278,7 +279,7 @@ Condition: ${item.condition || ''}`;
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }

--- a/backend/src/members/members.service.ts
+++ b/backend/src/members/members.service.ts
@@ -10,6 +10,7 @@ import { AdjustMemberPointsDto } from './dto/adjust-member-points.dto';
 import { CreateMembershipTierDto } from './dto/create-membership-tier.dto';
 import { UpdateMembershipTierDto } from './dto/update-membership-tier.dto';
 import { resolvePointsAdjustment } from './rules/points-adjustment.resolver';
+import { totalPagesFromCount } from '../common/utils/pagination.utils';
 
 @Injectable()
 export class MembersService {
@@ -52,7 +53,7 @@ export class MembersService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }
@@ -225,7 +226,7 @@ export class MembersService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }

--- a/backend/src/preorders/preorders.service.ts
+++ b/backend/src/preorders/preorders.service.ts
@@ -9,6 +9,7 @@ import { PreOrderDomainException } from './domain/preorder-domain.exception';
 import { CreatePreorderDto } from './dto/create-preorder.dto';
 import { UpdatePreorderDto } from './dto/update-preorder.dto';
 import { QueryPreordersDto } from './dto/query-preorders.dto';
+import { totalPagesFromCount } from '../common/utils/pagination.utils';
 
 @Injectable()
 export class PreordersService {
@@ -310,7 +311,7 @@ export class PreordersService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }
@@ -400,7 +401,7 @@ export class PreordersService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }
@@ -457,7 +458,7 @@ export class PreordersService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }

--- a/backend/src/public/public.service.ts
+++ b/backend/src/public/public.service.ts
@@ -5,6 +5,7 @@ import { AppException, ErrorCode } from '../common/exceptions/http-exception.fil
 import { QueryPublicItemsDto } from './dto/query-public-items.dto';
 import { Prisma } from '../generated/prisma/client';
 import { toNumber } from '../common/utils/decimal.utils';
+import { totalPagesFromCount } from '../common/utils/pagination.utils';
 
 @Injectable()
 export class PublicService {
@@ -153,7 +154,7 @@ export class PublicService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -13,6 +13,7 @@ import * as bcrypt from 'bcrypt';
 import { isUUID } from 'class-validator';
 import { IStorageService } from '../storage/storage.interface';
 import { toNumber } from '../common/utils/decimal.utils';
+import { totalPagesFromCount } from '../common/utils/pagination.utils';
 
 const MAX_SLUG_ALLOCATION_ATTEMPTS = 32;
 
@@ -217,7 +218,7 @@ export class ShopsService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }
@@ -275,7 +276,7 @@ export class ShopsService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }
@@ -323,7 +324,7 @@ export class ShopsService {
         page,
         page_size: pageSize,
         total,
-        total_pages: Math.ceil(total / pageSize),
+        total_pages: totalPagesFromCount(total, pageSize),
       },
     };
   }

--- a/frontend/src/pages/admin/FacebookPostsPage.tsx
+++ b/frontend/src/pages/admin/FacebookPostsPage.tsx
@@ -32,7 +32,7 @@ export const FacebookPostsPage = () => {
   });
 
   const items: AdminItem[] = data?.items || [];
-  const pagination: Pagination = data?.pagination || { page: 1, page_size: 20, total: 0, total_pages: 0 };
+  const pagination: Pagination = data?.pagination || { page: 1, page_size: 20, total: 0, total_pages: 1 };
 
   return (
     <div className={styles.container}>

--- a/frontend/tests/unit/FacebookPostsPage.test.tsx
+++ b/frontend/tests/unit/FacebookPostsPage.test.tsx
@@ -16,13 +16,13 @@ const h = vi.hoisted(() => ({
     get: vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
       data: {
         items: [],
-        pagination: { page: 1, page_size: 20, total: 0, total_pages: 0 },
+        pagination: { page: 1, page_size: 20, total: 0, total_pages: 1 },
       },
     })),
   },
   queryData: {
     items: [],
-    pagination: { page: 1, page_size: 20, total: 0, total_pages: 0 },
+    pagination: { page: 1, page_size: 20, total: 0, total_pages: 1 },
   } as FacebookPostsQueryData,
 }));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

List endpoints used `Math.ceil(total / pageSize)`, which yields **0 pages when `total` is 0**. Clients then showed inconsistent UI (e.g. “page 1 of 0”).

## Changes

- Add `totalPagesFromCount()` in `backend/src/common/utils/pagination.utils.ts` (`Math.max(1, Math.ceil(total / max(1, pageSize)))`).
- Replace raw `Math.ceil` pagination math in **items**, **public catalog**, **members**, **inventory**, **shops**, and **preorders** services.
- Add `pagination.utils.spec.ts` and **empty `findAll`** coverage in `items.service.spec.ts`.
- Align **FacebookPostsPage** default pagination and unit test fixtures to `total_pages: 1` when data is empty.

## Verification

- `cd backend && npm ci && npx jest --testPathPatterns="pagination.utils|items.service.spec" --runInBand`
- `cd frontend && npm run test:unit -- --run FacebookPostsPage`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e9fb773-decd-401e-add8-9501cefcd6b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e9fb773-decd-401e-add8-9501cefcd6b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

