### PR TITLE
docs(planning): Phase 16 per-shop public homepage (GSD)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -24,6 +24,7 @@ A seller can create and publish a diecast listing with complete media and ready-
 - [ ] Pre-order lifecycle management (Issue #13, Phase 9)
 - [ ] Transaction-based inventory with audit trail (Issue #46, Phase 8)
 - [ ] Reporting and analytics dashboard (Issue #49, Phase 10)
+- [ ] Per-shop public homepage and catalog URLs (Phase 16 — PBLC-03)
 
 ### Out of Scope
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -20,6 +20,7 @@
 
 - [x] **PBLC-01**: Visitor can browse public items and open item detail pages.
 - [x] **PBLC-02**: Public item detail shows cover/status and spinner when available.
+- [ ] **PBLC-03**: Public catalog and item URLs resolve to a single shop tenant (slug or id); visitors cannot infer or list other shops' inventory from public endpoints when shop context is set.
 
 ### AI and Social
 
@@ -83,6 +84,7 @@
 | MEDI-03 | Phase 3 | Complete (2026-03-10) |
 | PBLC-01 | Phase 3 | Complete (2026-03-10) |
 | PBLC-02 | Phase 3 | Complete (2026-03-10) |
+| PBLC-03 | Phase 16 | Pending |
 | AISO-01 | Phase 4 | Complete (2026-03-13) |
 | AISO-02 | Phase 4 | Complete (2026-03-13) |
 | AISO-03 | Phase 4 | Complete (2026-03-13) |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -21,6 +21,7 @@ This roadmap organizes Diecast360 delivery from core product foundations to oper
 - [x] **Phase 13: Issue #33 - Playwright Phase 2** - Extended E2E coverage and quality-gate hardening. *(2026-04-29)*
 - [x] **Phase 14: Multi-Tenant Shop** - Support multiple isolated diecast shops on a single deployment with scoped access.
 - [ ] **Phase 15: Admin RBAC & Tenant Authorization** - Separate platform operator permissions from per-shop roles; extend shop roles (e.g. read-only staff) and align API + admin UI.
+- [ ] **Phase 16: Per-Shop Public Homepage** - Resolve public catalog and item detail to a single shop tenant via URL or explicit query param, aligned with existing multi-tenant isolation.
 
 ## Phase Details
 
@@ -176,6 +177,7 @@ Plans:
 | 13. Issue #33 - Playwright Phase 2 | 3/3 | Complete | 2026-04-29 |
 | 14. Multi-Tenant Shop | 3/3 | Complete | 2026-03-23 |
 | 15. Admin RBAC & Tenant Authorization | 0/3 | Planned | — |
+| 16. Per-Shop Public Homepage | 0/3 | Planned | — |
 
 ## Execution Update (2026-03-04)
 
@@ -304,6 +306,7 @@ Implemented in codebase for Phase 13:
 
 Phases not yet complete and pending tasks:
 - Phase 15: Admin RBAC & Tenant Authorization — plans authored; execution pending (`15-01` through `15-03`).
+- Phase 16: Per-Shop Public Homepage — plans authored; execution pending (`16-01` through `16-03`).
 
 Partially executed phases (still pending full completion):
 - None.
@@ -331,6 +334,18 @@ Plans:
 - [ ] 15-01: Schema — `PlatformRole`, `User.platform_role`, extend `ShopRole` / audit enums, backfill from legacy `super_admin` memberships
 - [ ] 15-02: Backend — `RolesGuard`, platform-only routes, `shop_staff` read/write matrix, shops member role DTOs, tests
 - [ ] 15-03: Frontend — capability-based admin UI, member role picker, automated regression tests
+
+### Phase 16: Per-Shop Public Homepage
+
+**Goal:** Public visitors always see catalog and item detail scoped to exactly one shop; shareable URLs identify the shop without relying on admin JWT `active_shop_id`.
+**Requirements:** PBLC-03, MULT-01, MULT-03
+**Depends on:** Phase 14 (multi-tenant foundation); coordinates with Phase 15 only if public resolution must respect new platform vs shop role semantics (prefer no hard dependency).
+**Plans:** 3 plans
+
+Plans:
+- [ ] 16-01: Backend — optional `shop_id` on public item list/detail; resolve by UUID or `Shop.slug`; 404 for unknown/inactive shop; tests + contract docs
+- [ ] 16-02: Frontend — route or query resolution for shop context; catalog + detail + deep links preserve `shop_id`; optional default shop env for single-tenant deploys
+- [ ] 16-03: E2E + regression — Playwright scenarios for two shops, cross-tenant negative case, link builder smoke for public nav
 
 ## Execution Update (2026-04-20) — Security / media follow-up (ngoài số phase)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,11 +5,11 @@
 See: .planning/PROJECT.md (updated 2026-03-04)
 
 **Core value:** A seller can publish a diecast listing with complete media and ready-to-post content in one flow.
-**Current focus:** Roadmap phases 1–14 complete in planning; Phase 13 (Playwright Phase 2) shipped 2026-04-29.
+**Current focus:** Phase 16 planning added (per-shop public catalog/homepage, PBLC-03); Phase 15 RBAC execution pending.
 
 ## Current Position
 
-Phase: **14 of 14** (roadmap complete)
+Phase: **16** planned (public shop-scoped homepage); **15** RBAC execution pending
 Plan: Phase 13 **đã hoàn thành** (13-01, 13-02, 13-03)
 Status: Phase 13 complete (2026-04-29). Advanced E2E, Playwright CI stability, documented E2E gate policy.
 Last activity: 2026-04-29 — spinner/social-selling/responsive E2E, `stubAuthCsrf`, CI retries/workers.

--- a/.planning/phases/16-per-shop-public-homepage/16-01-PLAN.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-01-PLAN.md
@@ -1,0 +1,117 @@
+---
+phase: 16-per-shop-public-homepage
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - backend/src/public/public.controller.ts
+  - backend/src/public/public.service.ts
+  - backend/src/public/dto/query-public-items.dto.ts
+  - backend/src/public/public.service.spec.ts
+  - docs/API_CONTRACT.md
+autonomous: true
+requirements:
+  - PBLC-03
+  - MULT-01
+  - MULT-03
+must_haves:
+  truths:
+    - "GET /public/items?shop_id=<uuid|slug> returns only items for that shop"
+    - "Unknown or inactive shop returns 404 (or documented consistent error) for list and detail"
+    - "When shop_id query is present, JWT active_shop_id does not change which shop's items are listed"
+  artifacts:
+    - path: backend/src/public/public.controller.ts
+      provides: Accepts optional shop_id and resolves tenant before service
+    - path: backend/src/public/public.service.ts
+      provides: findAll/findOne receive resolved shop id or null
+    - path: docs/API_CONTRACT.md
+      provides: Documents shop_id query for public item endpoints
+  key_links:
+    - from: public.controller.ts
+      to: public.service.ts
+    - from: query param shop_id
+      to: Prisma Item where shop_id
+---
+
+<objective>
+**What:** Cho phép khách (không JWT) và người có JWT chỉ định **một shop** qua query `shop_id` (UUID hoặc `Shop.slug`); resolve shop active rồi áp `shop_id` vào `PublicService` list/detail.
+
+**Why:** Hiện public catalog có thể trả aggregate mọi shop khi không có tenant — trái kỳ vọng multi-tenant storefront.
+
+**Output:** Controller + DTO + service behavior + unit tests + đoạn contract API cập nhật.
+</objective>
+
+<execution_context>
+@./.codex/get-shit-done/workflows/execute-plan.md
+@./.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/16-per-shop-public-homepage/16-CONTEXT.md
+@.planning/phases/16-per-shop-public-homepage/16-RESEARCH.md
+@backend/src/public/public.controller.ts
+@backend/src/public/public.service.ts
+@backend/prisma/schema.prisma
+
+<interfaces>
+From `public.controller.ts`: `findAll`, `findOne` use `OptionalJwtAuthGuard` and today set `tenantId` from `req.user?.active_shop_id` only.
+
+From `public.service.ts`: `findAll(queryDto, tenantId?)` and `findOne(id, tenantId?)` append `...(tenantId ? { shop_id: tenantId } : {})` to Prisma where.
+
+From `Shop` model: `id`, `slug`, `is_active` unique slug.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>DTO + resolve helper for public shop key</name>
+  <files>backend/src/public/dto/query-public-items.dto.ts, backend/src/public/public.controller.ts (or small new helper module colocated with public)</files>
+  <action>Add optional validated `shop_id` query string to list DTO (reuse same param name for detail handler via `@Query('shop_id')`). Implement `resolvePublicShopId(raw: string | undefined): Promise<string | null>` using Prisma: if absent return null; if present try UUID lookup on `Shop.id`, else lookup by exact `slug`; require `is_active === true`; on miss throw `AppException` NOT_FOUND with stable message (e.g. shop not found). Document precedence in code comment: explicit query overrides JWT tenant for public reads (per CONTEXT).</action>
+  <verify>
+    <automated>cd /workspace/backend && npx jest src/public/public.service.spec.ts -x</automated>
+  </verify>
+  <done>DTO accepts optional shop_id; resolver returns canonical shop UUID or throws NOT_FOUND for bad/inactive slug/id.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Wire controller + service + unit coverage</name>
+  <files>backend/src/public/public.controller.ts, backend/src/public/public.service.ts, backend/src/public/public.service.spec.ts</files>
+  <behavior>
+    - List with shop A id returns only items where shop_id = A (mock prisma or use existing test patterns in spec file).
+    - Detail with item in shop B but shop_id=A returns 404 / not found path.
+    - When query shop_id is set, service receives that id even if req.user would have different active_shop_id (mock user).
+  </behavior>
+  <action>In controller: compute `resolvedShopId` from query first; if resolved, pass to service; else fall back to JWT `active_shop_id` (preserve legacy). Optionally pass both only if needed — prefer single effective tenant id variable. Extend `public.service.spec.ts` accordingly; add tests for slug vs uuid if resolver is testable in isolation.</action>
+  <verify>
+    <automated>cd /workspace/backend && npx jest src/public/public.service.spec.ts -x</automated>
+  </verify>
+  <done>All public service/controller tests green; no cross-tenant leakage in where-clause for explicit shop_id.</done>
+</task>
+
+<task type="auto">
+  <name>Document public API contract</name>
+  <files>docs/API_CONTRACT.md</files>
+  <action>Document `shop_id` optional query for `GET /api/v1/public/items` and `GET /api/v1/public/items/:id`: accepted forms (uuid vs slug), 404 cases, precedence over JWT when present, behavior when omitted (reference deployment policy / default from frontend env in Phase 16-02).</action>
+  <verify>
+    <automated>grep -n "public/items" /workspace/docs/API_CONTRACT.md | head -20</automated>
+  </verify>
+  <done>Contract section exists and matches implementation.</done>
+</task>
+
+</tasks>
+
+<verification>
+Run full backend unit slice touching public module; confirm Prisma queries always include `shop_id` when resolved tenant present.
+</verification>
+
+<success_criteria>
+- Public list/detail honor `shop_id` query for anonymous users
+- Explicit shop context cannot be overridden by JWT to a different shop
+- REQUIREMENTS PBLC-03, MULT-01, MULT-03 satisfied at API layer
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/16-per-shop-public-homepage/16-01-SUMMARY.md`
+</output>

--- a/.planning/phases/16-per-shop-public-homepage/16-02-PLAN.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-02-PLAN.md
@@ -1,0 +1,103 @@
+---
+phase: 16-per-shop-public-homepage
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - 16-01
+files_modified:
+  - frontend/src/App.tsx
+  - frontend/src/config/routes.ts
+  - frontend/src/pages/PublicCatalogPage.tsx
+  - frontend/src/pages/PublicItemDetailPage.tsx
+  - frontend/src/pages/publicCatalogUrlState.ts
+  - frontend/src/components/Layout.tsx
+  - frontend/src/api/config.ts
+  - frontend/.env.example
+autonomous: true
+requirements:
+  - PBLC-03
+  - MULT-03
+must_haves:
+  truths:
+    - "Catalog React Query key includes effective shop id so switching shop refetches"
+    - "Item detail requests include same shop context param as catalog"
+    - "Internal links (item cards, back to catalog) preserve shop context"
+  artifacts:
+    - path: frontend/src/pages/PublicCatalogPage.tsx
+      provides: Passes shop_id to /public/items
+    - path: frontend/src/pages/PublicItemDetailPage.tsx
+      provides: Passes shop_id to /public/items/:id
+  key_links:
+    - from: URL searchParams shop_id
+      to: apiClient.get query string
+---
+
+<objective>
+**What:** Frontend xác định **effectiveShopId** (query → optional build env `VITE_PUBLIC_CATALOG_SHOP_ID` → tùy chọn JWT `active_shop_id` nếu product muốn dev convenience) và gắn vào mọi request public catalog/detail; đồng bộ URL state với pattern `sanitizeShopIdQueryParam`.
+
+**Why:** Backend 16-01 chỉ có tác dụng khi client gửi `shop_id`; UX phải giữ param qua navigation.
+
+**Output:** Catalog + detail wired; routes/constants cập nhật; env example ghi chú.
+</objective>
+
+<execution_context>
+@./.codex/get-shit-done/workflows/execute-plan.md
+@./.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/phases/16-per-shop-public-homepage/16-CONTEXT.md
+@frontend/src/utils/sanitizeShopId.ts
+@frontend/src/pages/public/PreOrdersPage.tsx
+@frontend/src/pages/PublicCatalogPage.tsx
+@frontend/src/pages/publicCatalogUrlState.ts
+@frontend/src/App.tsx
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Centralize effective public shop id hook or helper</name>
+  <files>frontend/src/hooks/usePublicShopContext.ts (new), frontend/src/api/config.ts</files>
+  <action>Create a small hook `usePublicShopContext()` reading `useSearchParams`, `import.meta.env.VITE_PUBLIC_CATALOG_SHOP_ID`, and `useAuth()` optional user — mirror precedence from CONTEXT (query overrides JWT). Export `effectiveShopId: string` empty string when none. Add `VITE_PUBLIC_CATALOG_SHOP_ID` to `frontend/.env.example` with comment. Reuse `sanitizeShopIdQueryParam` everywhere raw strings enter.</action>
+  <verify>
+    <automated>cd /workspace/frontend && pnpm exec tsc --noEmit 2>&1 | tail -30</automated>
+  </verify>
+  <done>Typecheck passes; hook returns stable memoized id string.</done>
+</task>
+
+<task type="auto">
+  <name>Wire PublicCatalogPage + URL state</name>
+  <files>frontend/src/pages/PublicCatalogPage.tsx, frontend/src/pages/publicCatalogUrlState.ts</files>
+  <action>Include `shop_id` in React Query key and append to `apiClient.get` when non-empty. When user lands without shop but env default exists, optionally `setSearchParams` once to canonicalize URL (follow preorder pattern only if it avoids hydration issues). Ensure `buildCatalogSearchParams` / `parseCatalogUrlState` preserve unknown keys or explicitly merge `shop_id` so filters do not strip it.</action>
+  <verify>
+    <automated>cd /workspace/frontend && pnpm exec vitest run --passWithNoTests 2>&1 | tail -25</automated>
+  </verify>
+  <done>Catalog fetches include shop_id when context exists; URL parser keeps shop_id across filter updates.</done>
+</task>
+
+<task type="auto">
+  <name>Wire PublicItemDetailPage + Layout links</name>
+  <files>frontend/src/pages/PublicItemDetailPage.tsx, frontend/src/components/Layout.tsx, frontend/src/App.tsx, frontend/src/config/routes.ts</files>
+  <action>Pass `shop_id` on all `/public/items` calls in detail page. ItemCard links to `/items/:id?shop_id=` when context present. Public nav (home, contact if applicable) preserves `shop_id` search param similar to `BottomNavigation` on preorders. If introducing path-based shop routes instead, update ROUTES and this plan's files_modified in SUMMARY — prefer consistency with 16-01 query contract unless team changes both.</action>
+  <verify>
+    <automated>cd /workspace/frontend && pnpm run build 2>&1 | tail -20</automated>
+  </verify>
+  <done>Production build succeeds; no orphan links dropping shop context on primary flows.</done>
+</task>
+
+</tasks>
+
+<verification>
+Manual smoke: open `/?shop_id=<slug>`, click item, refresh detail — still correct shop scope.
+</verification>
+
+<success_criteria>
+- Effective shop id flows catalog → detail → back
+- Env default documented for single-shop deployments
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/16-per-shop-public-homepage/16-02-SUMMARY.md`
+</output>

--- a/.planning/phases/16-per-shop-public-homepage/16-03-PLAN.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-03-PLAN.md
@@ -1,0 +1,84 @@
+---
+phase: 16-per-shop-public-homepage
+plan: 03
+type: execute
+wave: 3
+depends_on:
+  - 16-01
+  - 16-02
+files_modified:
+  - frontend/tests/e2e/public-catalog.spec.ts
+  - frontend/tests/e2e/fixtures/index.ts
+  - backend/src/public/public.service.spec.ts
+autonomous: true
+requirements:
+  - PBLC-03
+  - MULT-01
+  - QATE-02
+must_haves:
+  truths:
+    - "Playwright asserts catalog scoped to shop A does not render item title from shop B under mocked API"
+    - "Regression: existing public flows still pass with shop_id in URL"
+  artifacts:
+    - path: frontend/tests/e2e/public-catalog.spec.ts
+      provides: Multi-tenant public catalog coverage
+  key_links:
+    - from: e2e route.goto
+      to: mocked /public/items response keyed by shop_id query
+---
+
+<objective>
+**What:** Thêm E2E (hoặc mở rộng spec hiện có) xác minh **cô lập hiển thị** catalog public theo `shop_id`; bổ sung test backend nếu 16-01 thiếu edge case.
+
+**Why:** MULT/PBLC yêu cầu không lộ dữ liệu shop khác; automation tránh regress khi refactor URL.
+
+**Output:** Ít nhất một spec Playwright ổn định + mock API theo query.
+</objective>
+
+<execution_context>
+@./.codex/get-shit-done/workflows/execute-plan.md
+@./.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@frontend/tests/e2e/preorders.spec.ts
+@frontend/tests/e2e/fixtures/index.ts
+@.planning/phases/16-per-shop-public-homepage/16-RESEARCH.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Playwright — two-shop mock + negative assertion</name>
+  <files>frontend/tests/e2e/public-catalog.spec.ts, frontend/tests/e2e/fixtures/index.ts</files>
+  <action>Extend page.route for `/api/v1/public/items` (or path prefix used in app) to return different `items` arrays based on parsed `shop_id` query. Test A: goto `/?shop_id=shop-a`, expect visible text from shop A fixture. Test B: same URL must not show shop B exclusive title. Optional: request without shop_id documents current aggregate or empty-state per 16-02 — assert stable behavior chosen in CONTEXT.</action>
+  <verify>
+    <automated>cd /workspace/frontend && pnpm exec playwright test public-catalog.spec.ts --reporter=line 2>&1 | tail -40</automated>
+  </verify>
+  <done>Spec passes locally in CI-like mode; uses existing stub auth/csrf patterns if needed for layout.</done>
+</task>
+
+<task type="auto">
+  <name>Backend regression slice (if gaps)</name>
+  <files>backend/src/public/public.service.spec.ts</files>
+  <action>Add tests for inactive shop rejection and slug case-sensitivity per implementation — only if not already covered in 16-01.</action>
+  <verify>
+    <automated>cd /workspace/backend && npx jest src/public/public.service.spec.ts -x</automated>
+  </verify>
+  <done>Edge cases from RESEARCH covered or explicitly documented as out of scope in SUMMARY.</done>
+</task>
+
+</tasks>
+
+<verification>
+Full frontend E2E job or targeted `pnpm exec playwright test` subset documented in SUMMARY.
+</verification>
+
+<success_criteria>
+- Automated proof that public catalog respects shop_id for visitors
+- QATE-02 strengthened for this multi-tenant surface
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/16-per-shop-public-homepage/16-03-SUMMARY.md`
+</output>

--- a/.planning/phases/16-per-shop-public-homepage/16-CONTEXT.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-CONTEXT.md
@@ -1,0 +1,29 @@
+# Phase 16 Context: Trang chủ / catalog công khai theo từng shop (multi-tenant)
+
+**Gathered:** 2026-04-29  
+**Status:** Ready for execution (plans below)  
+**Source:** Gap giữa Phase 14 (cô lập tenant admin/API) và trải nghiệm public hiện tại
+
+## Vấn đề hiện trạng
+
+- `GET /public/items` và `GET /public/items/:id` dùng `OptionalJwtAuthGuard` và chỉ lọc theo `shop_id` khi JWT có `active_shop_id`; **khách không đăng nhập** không gửi tenant → `PublicService` trả về **tất cả** item public trên deployment (không cô lập theo shop).
+- Trang catalog (`PublicCatalogPage`) gọi API **không** truyền `shop_id` (khác với `PreOrdersPage` đã có `?shop_id=` + `sanitizeShopIdQueryParam`).
+- Model `Shop` đã có `slug` unique — phù hợp URL thân thiện và link chia sẻ.
+
+## Quyết định đã chốt (locked)
+
+1. **Ngữ cảnh shop trên public** phải xác định được **mà không cần** người xem đăng nhập; ưu tiên **URL có thể chia sẻ** (path hoặc query — executor chọn một convention và giữ nhất quán trong phase).
+2. **Định danh shop** chấp nhận **UUID** (`shop.id`) và/hoặc **`slug`** (`Shop.slug`); shop `is_active: false` → không phục vụ catalog public (404 hoặc 403 — chốt một mã và ghi contract).
+3. **Ưu tiên explicit context hơn JWT** cho public: nếu request có `shop_id` (hoặc path slug) hợp lệ thì **bỏ qua** `active_shop_id` từ JWT cho việc lọc catalog/detail (tránh admin đang switch shop làm lệch trang public mà họ mở trong cùng trình duyệt).
+4. **Backward compatibility:** build single-tenant hoặc link cũ không có shop — hỗ trợ **`VITE_PUBLIC_CATALOG_SHOP_ID`** (hoặc tên env đồng bộ với convention preorder) làm default; nếu multi-shop production và thiếu context → UX rõ ràng (hướng dẫn URL / chọn shop), không âm thầm gộp dữ liệu nhiều shop.
+
+## Claude's discretion
+
+- Chọn `/s/:slug` vs `/?shop_id=` vs `/shop/:slug` — cân nhắc SEO, độ dài URL, và sửa ít nhất `Layout`/nav links.
+- Có cần endpoint `GET /public/shops/:slug` chỉ trả `{ id, name, slug }` cho header trang hay dùng metadata từ list — tùy executor.
+- Cache HTTP/CDN cho response public có `shop_id` — optional trong phase này.
+
+## Deferred (không làm trong phase 16)
+
+- Trang landing liệt kê **tất cả** shop trên platform (marketplace directory).
+- Subdomain per tenant (`shop-a.example.com`) — chỉ ghi note trong RESEARCH nếu cần roadmap sau.

--- a/.planning/phases/16-per-shop-public-homepage/16-RESEARCH.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-RESEARCH.md
@@ -1,0 +1,90 @@
+# Phase 16 Research: Public catalog scoped per shop
+
+**Phase:** 16 — Per-Shop Public Homepage  
+**Date:** 2026-04-29
+
+## RESEARCH COMPLETE
+
+## 1. Code anchors (executor must re-read before coding)
+
+**Backend — tenant chỉ từ JWT khi có user:**
+
+```11:16:backend/src/public/public.controller.ts
+  @Get('items')
+  @UseGuards(OptionalJwtAuthGuard)
+  findAll(@Query() queryDto: QueryPublicItemsDto, @Req() req: Request) {
+    const user = req.user as { active_shop_id?: string | null } | undefined;
+    const tenantId = user?.active_shop_id ?? null;
+    return this.publicService.findAll(queryDto, tenantId);
+```
+
+**Backend — khi `tenantId` null, không thêm `shop_id` vào where:**
+
+```48:52:backend/src/public/public.service.ts
+    const where: Prisma.ItemWhereInput = {
+      deleted_at: null,
+      is_public: true,
+      ...(tenantId ? { shop_id: tenantId } : {}),
+    };
+```
+
+**Frontend — catalog không truyền shop:**
+
+```86:98:frontend/src/pages/PublicCatalogPage.tsx
+    queryFn: async ({ pageParam = 1 }) => {
+      const params = new URLSearchParams({
+        page: pageParam.toString(),
+        page_size: '20',
+      });
+      ...
+      const response = await apiClient.get(`/public/items?${params.toString()}`);
+```
+
+**Frontend — pattern sẵn có cho public + shop (reuse):**
+
+- `frontend/src/utils/sanitizeShopId.ts`
+- `frontend/src/pages/public/PreOrdersPage.tsx` (thứ tự query → env → JWT)
+
+**Schema — slug shop:**
+
+- `backend/prisma/schema.prisma` model `Shop`: `slug String @unique`
+
+## 2. Resolution algorithm (recommended)
+
+1. Parse optional public shop key from **query `shop_id`** and/or **path param** (if implemented).
+2. If value matches UUID format → `prisma.shop.findFirst({ where: { id } })`.
+3. Else → treat as **slug** → `findFirst({ where: { slug: normalized } })` (case policy: exact match DB slug).
+4. If not found or `is_active === false` → **404** on list/detail (consistent with "shop not available").
+5. Pass resolved `shop.id` as `tenantId` into `PublicService.findAll` / `findOne` **instead of** JWT `active_shop_id` when step 1 produced a tenant (per CONTEXT: explicit wins).
+
+## 3. API contract notes
+
+- Add optional query param `shop_id` to `GET /public/items` and `GET /public/items/:id` documented in `docs/API_CONTRACT.md`.
+- Semantics: "restrict to this shop"; invalid/inactive → 404; omit + no default env → document aggregate vs error (align with CONTEXT).
+
+## 4. Frontend routing (options)
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| `?shop_id=` only | Minimal router change | SEO weaker; easy to drop param on navigation |
+| `/s/:slug/*` nested routes | Shareable, readable | More `App.tsx` / `Layout` link updates |
+| `/shop/:slug` single segment prefix | Clear | Same as above |
+
+**Recommendation:** Implement **query param first** (fastest, matches preorder) **or** path prefix if product wants clean links — pick one in plan 16-02 and test deep links (`/items/:id`).
+
+## 5. Security / isolation
+
+- Public endpoints must **never** return items whose `shop_id` ≠ resolved tenant when shop context is present.
+- Slug is not secret; UUID in URL is guessable — rely on **public flag + shop scope**, not obscurity.
+- Rate-limiting: reuse existing public throttle if any; no new requirement unless gaps found.
+
+## 6. Testing strategy
+
+- Extend `public.service.spec.ts` (or integration tests) for: slug resolve, inactive shop, cross-tenant item id with wrong shop returns 404.
+- Playwright: two mocked shop IDs; assert list A does not show B's item title.
+
+## Validation Architecture
+
+- **Unit:** resolution helper + `PublicService` where-clause with `shop_id`.
+- **Integration:** supertest `GET /public/items?shop_id=` with seeded shops (if test DB pattern exists).
+- **E2E:** mocked API responses keyed by `shop_id` query (mirror preorder fixture style).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds **GSD Phase 16** planning so each shop can have a **scoped public storefront** (catalog + item detail) under multi-tenant isolation, instead of anonymous `/public/items` returning an aggregate across shops.

## What changed

- **Roadmap:** New Phase 16 with three planned waves (backend `shop_id` resolution, frontend wiring, Playwright coverage).
- **Requirements:** New **PBLC-03** (public URLs resolve to one shop; no cross-tenant leakage when shop context is set).
- **Phase artifacts:** `16-CONTEXT.md`, `16-RESEARCH.md`, and executable-style `16-01` through `16-03` PLAN files under `.planning/phases/16-per-shop-public-homepage/`.
- **PROJECT / STATE:** Note Phase 16 focus and pending execution.

## Notes

- Planning aligns with existing code: `PublicController` today only scopes by JWT `active_shop_id`; `PublicCatalogPage` does not pass `shop_id` (unlike public preorders).
- Execution is intentionally **not** included in this PR — run `$gsd-execute-phase 16` (or implement plans manually) after review.

## How to review

- Read `.planning/phases/16-per-shop-public-homepage/16-CONTEXT.md` for decisions and scope.
- Skim `16-01-PLAN.md` → `16-03-PLAN.md` for wave order and acceptance checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-870f67b6-2c3b-4f88-98d5-982d974c55ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-870f67b6-2c3b-4f88-98d5-982d974c55ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

