### PR TITLE
feat(phase-15): Admin RBAC & Tenant Authorization — PlatformRole, shop_staff, dual-layer guard

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -20,7 +20,7 @@ This roadmap organizes Diecast360 delivery from core product foundations to oper
 - [x] **Phase 12: Issue #44 - Playwright Phase 1** - E2E smoke automation setup and CI integration. *(2026-04-24)*
 - [x] **Phase 13: Issue #33 - Playwright Phase 2** - Extended E2E coverage and quality-gate hardening. *(2026-04-29)*
 - [x] **Phase 14: Multi-Tenant Shop** - Support multiple isolated diecast shops on a single deployment with scoped access.
-- [ ] **Phase 15: Admin RBAC & Tenant Authorization** - Separate platform operator permissions from per-shop roles; extend shop roles (e.g. read-only staff) and align API + admin UI.
+- [x] **Phase 15: Admin RBAC & Tenant Authorization** - Separate platform operator permissions from per-shop roles; extend shop roles (e.g. read-only staff) and align API + admin UI.
 
 ## Phase Details
 
@@ -175,7 +175,7 @@ Plans:
 | 12. Issue #44 - Playwright Phase 1 | 3/3 | Complete | 2026-04-24 |
 | 13. Issue #33 - Playwright Phase 2 | 3/3 | Complete | 2026-04-29 |
 | 14. Multi-Tenant Shop | 3/3 | Complete | 2026-03-23 |
-| 15. Admin RBAC & Tenant Authorization | 0/3 | Planned | — |
+| 15. Admin RBAC & Tenant Authorization | 3/3 | Complete | 2026-04-29 |
 
 ## Execution Update (2026-03-04)
 
@@ -303,7 +303,7 @@ Implemented in codebase for Phase 13:
 ## Remaining Work Snapshot (By Phase)
 
 Phases not yet complete and pending tasks:
-- Phase 15: Admin RBAC & Tenant Authorization — plans authored; execution pending (`15-01` through `15-03`).
+- Phase 15: Admin RBAC & Tenant Authorization — **complete** (2026-04-29). All 3 plans executed.
 
 Partially executed phases (still pending full completion):
 - None.
@@ -328,9 +328,9 @@ Plans:
 **Plans:** 3 plans
 
 Plans:
-- [ ] 15-01: Schema — `PlatformRole`, `User.platform_role`, extend `ShopRole` / audit enums, backfill from legacy `super_admin` memberships
-- [ ] 15-02: Backend — `RolesGuard`, platform-only routes, `shop_staff` read/write matrix, shops member role DTOs, tests
-- [ ] 15-03: Frontend — capability-based admin UI, member role picker, automated regression tests
+- [x] 15-01: Schema — `PlatformRole`, `User.platform_role`, extend `ShopRole` / audit enums, backfill from legacy `super_admin` memberships
+- [x] 15-02: Backend — `RolesGuard`, platform-only routes, `shop_staff` read/write matrix, shops member role DTOs, tests
+- [x] 15-03: Frontend — capability-based admin UI, member role picker, automated regression tests
 
 ## Execution Update (2026-04-20) — Security / media follow-up (ngoài số phase)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,14 +5,14 @@
 See: .planning/PROJECT.md (updated 2026-03-04)
 
 **Core value:** A seller can publish a diecast listing with complete media and ready-to-post content in one flow.
-**Current focus:** Roadmap phases 1–14 complete in planning; Phase 13 (Playwright Phase 2) shipped 2026-04-29.
+**Current focus:** Roadmap phases 1–15 complete; Phase 15 (Admin RBAC & Tenant Authorization) shipped 2026-04-29.
 
 ## Current Position
 
-Phase: **14 of 14** (roadmap complete)
-Plan: Phase 13 **đã hoàn thành** (13-01, 13-02, 13-03)
-Status: Phase 13 complete (2026-04-29). Advanced E2E, Playwright CI stability, documented E2E gate policy.
-Last activity: 2026-04-29 — spinner/social-selling/responsive E2E, `stubAuthCsrf`, CI retries/workers.
+Phase: **15 of 15** (roadmap complete)
+Plan: Phase 15 **đã hoàn thành** (15-01, 15-02, 15-03)
+Status: Phase 15 complete (2026-04-29). Platform RBAC, shop_staff role, dual-layer guard, modal role picker.
+Last activity: 2026-04-29 — PlatformRole schema+migration, RolesGuard Option C, @PlatformRoles decorator, frontend platform gates.
 
 Progress: [##########] 100% (roadmap)
 
@@ -52,6 +52,7 @@ Progress: [##########] 100% (roadmap)
 - (2026-04-23) Completed Phase 11 membership foundation: tier/member/ledger schema + constraints, deterministic points/tier rule engine, tenant-scoped members APIs, admin members dashboard, and members Playwright smoke scenario.
 - (2026-04-24) Completed Phase 12 Playwright baseline: shared fixture layer (`fixtures/index.ts`), auth/items/public-catalog smoke specs (10 passing E2E tests total with 32 across full suite), CI Playwright report artifact upload on failure, HTML reporter, QA workflow docs.
 - (2026-04-29) Completed Phase 13: advanced Playwright specs (`spinner`, `social-selling`, `responsive`), CI runner tuning (retries/workers), E2E triage notes in `docs/TODO.md`, `stubAuthCsrf` helper for admin mocks.
+- (2026-04-29) Completed Phase 15: PlatformRole enum + User.platform_role migration+backfill; dual-layer RolesGuard (platform_role check + shop_staff HTTP-method enforcement — Option C); @PlatformRoles decorator; AddShopAdminDto extended with role field; frontend isPlatformSuper + useIsSuperAdmin updated; AddMemberModal role picker (shop_admin/shop_staff); audit labels for new actions.
 
 ### Pending Todos
 
@@ -63,6 +64,6 @@ Progress: [##########] 100% (roadmap)
 
 ## Session Continuity
 
-Last session: 2026-04-29 (Phase 13 Playwright Phase 2)
-Stopped at: Phase 13 complete; all roadmap phases through 14 are done in repo planning
-Resume file: `.planning/phases/13-issue-33-playwright-automation-phase-2/13-03-PLAN.md`
+Last session: 2026-04-29 (Phase 15 Admin RBAC & Tenant Authorization)
+Stopped at: Phase 15 complete; all 15 roadmap phases done
+Resume file: `.planning/phases/15-admin-rbac-tenant-refinement/15-03-PLAN.md`

--- a/backend/prisma/migrations/20260429000000_rbac_platform_and_shop_roles/migration.sql
+++ b/backend/prisma/migrations/20260429000000_rbac_platform_and_shop_roles/migration.sql
@@ -9,6 +9,11 @@ CREATE TYPE "PlatformRole" AS ENUM ('platform_super');
 ALTER TABLE "users" ADD COLUMN "platform_role" "PlatformRole";
 
 -- 3. Backfill: any user with at least one super_admin shop row → platform_super
+--
+-- Safety note: user_shop_roles has NO soft-delete, NO deleted_at, NO is_active column.
+-- Rows only exist for active memberships — they are hard-deleted on CASCADE when a User
+-- or Shop is removed, and are never updated except via upsert (role change).
+-- Therefore this WHERE clause covers exactly the current active super_admin set.
 UPDATE "users"
 SET "platform_role" = 'platform_super'
 WHERE "id" IN (

--- a/backend/prisma/migrations/20260429000000_rbac_platform_and_shop_roles/migration.sql
+++ b/backend/prisma/migrations/20260429000000_rbac_platform_and_shop_roles/migration.sql
@@ -1,0 +1,25 @@
+-- Migration: rbac_platform_and_shop_roles
+-- Adds PlatformRole enum + User.platform_role, extends ShopRole with shop_staff,
+-- extends ShopAuditAction with role-change events, and backfills platform_role.
+
+-- 1. Create PlatformRole enum
+CREATE TYPE "PlatformRole" AS ENUM ('platform_super');
+
+-- 2. Add User.platform_role column (nullable, no default = NULL)
+ALTER TABLE "users" ADD COLUMN "platform_role" "PlatformRole";
+
+-- 3. Backfill: any user with at least one super_admin shop row → platform_super
+UPDATE "users"
+SET "platform_role" = 'platform_super'
+WHERE "id" IN (
+  SELECT DISTINCT "user_id"
+  FROM "user_shop_roles"
+  WHERE "role" = 'super_admin'
+);
+
+-- 4. Extend ShopRole enum with shop_staff (additive — existing rows unaffected)
+ALTER TYPE "ShopRole" ADD VALUE IF NOT EXISTS 'shop_staff';
+
+-- 5. Extend ShopAuditAction enum with role-change events
+ALTER TYPE "ShopAuditAction" ADD VALUE IF NOT EXISTS 'set_platform_role';
+ALTER TYPE "ShopAuditAction" ADD VALUE IF NOT EXISTS 'set_shop_member_role';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,9 +21,14 @@ enum ItemStatus {
   da_ban
 }
 
+enum PlatformRole {
+  platform_super
+}
+
 enum ShopRole {
   super_admin
   shop_admin
+  shop_staff
 }
 
 enum ShopAuditAction {
@@ -33,6 +38,8 @@ enum ShopAuditAction {
   update_shop
   deactivate_shop
   activate_shop
+  set_platform_role
+  set_shop_member_role
 }
 
 enum PreOrderStatus {
@@ -95,6 +102,7 @@ model User {
   password_hash String
   full_name     String?
   role          String         @default("admin")
+  platform_role PlatformRole?
   is_active     Boolean        @default(true)
   created_at    DateTime       @default(now())
   updated_at    DateTime       @updatedAt

--- a/backend/src/ai/ai.controller.ts
+++ b/backend/src/ai/ai.controller.ts
@@ -4,10 +4,14 @@ import { AiService } from './ai.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { GenerateAiDescriptionDto, GenerateFbPostDto } from './dto/ai-description.dto';
 import { TenantGuard } from '../common/guards/tenant.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { ShopRole } from '../generated/prisma/client';
 import { CurrentTenantId } from '../common/decorators/tenant.decorator';
 
 @Controller('items')
-@UseGuards(JwtAuthGuard, TenantGuard)
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class AiController {
   constructor(private readonly aiService: AiService) {}
 

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -237,7 +237,7 @@ describe('AuthService', () => {
   });
 
   describe('getUserTenantAccess', () => {
-    it('should map user_shop_roles to tenant access payload', async () => {
+    it('should map user_shop_roles to tenant access payload including platform_role', async () => {
       prisma.userShopRole.findMany.mockResolvedValue([
         {
           shop_id: 'shop-1',
@@ -250,10 +250,12 @@ describe('AuthService', () => {
           },
         },
       ]);
+      prisma.user.findUnique.mockResolvedValue({ platform_role: 'platform_super' });
 
       const result = await service.getUserTenantAccess('user-1');
 
       expect(result).toEqual({
+        platform_role: 'platform_super',
         allowed_shop_ids: ['shop-1'],
         shop_roles: [{ shop_id: 'shop-1', role: 'shop_admin' }],
         allowed_shops: [
@@ -272,6 +274,15 @@ describe('AuthService', () => {
           shop: { select: { id: true, name: true, slug: true, is_active: true } },
         },
       });
+    });
+
+    it('should return platform_role null when user has no platform role', async () => {
+      prisma.userShopRole.findMany.mockResolvedValue([]);
+      prisma.user.findUnique.mockResolvedValue({ platform_role: null });
+
+      const result = await service.getUserTenantAccess('user-1');
+
+      expect(result.platform_role).toBeNull();
     });
   });
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -43,6 +43,7 @@ export class AuthService {
         email: user.email,
         full_name: user.full_name,
         role: user.role,
+        platform_role: user.platform_role ?? null,
       },
     };
   }
@@ -127,11 +128,12 @@ export class AuthService {
   /**
    * JWT validation only — no `shop_roles` / `shops` join (avoids overhead on every authenticated request).
    * Full tenant payload: {@link getUserTenantAccess} (e.g. GET /auth/me). Per-shop: targeted query in {@link switchShop}.
+   * `platform_role` is included so RolesGuard can enforce platform-level access without an extra DB query.
    */
   async validateUser(userId: string) {
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { id: true, email: true, full_name: true, role: true, is_active: true },
+      select: { id: true, email: true, full_name: true, role: true, platform_role: true, is_active: true },
     });
 
     if (!user || !user.is_active) {
@@ -143,19 +145,27 @@ export class AuthService {
       email: user.email,
       full_name: user.full_name,
       role: user.role,
+      platform_role: user.platform_role,
     };
   }
 
   /**
    * Load shop memberships + shop summaries — use for GET /auth/me only, not for JwtStrategy.
+   * Also returns `platform_role` so frontend can gate platform-only UI.
    */
   async getUserTenantAccess(userId: string) {
-    const roles = await this.prisma.userShopRole.findMany({
-      where: { user_id: userId },
-      include: {
-        shop: { select: { id: true, name: true, slug: true, is_active: true } },
-      },
-    });
+    const [roles, user] = await Promise.all([
+      this.prisma.userShopRole.findMany({
+        where: { user_id: userId },
+        include: {
+          shop: { select: { id: true, name: true, slug: true, is_active: true } },
+        },
+      }),
+      this.prisma.user.findUnique({
+        where: { id: userId },
+        select: { platform_role: true },
+      }),
+    ]);
 
     const shop_roles = roles.map((r) => ({
       shop_id: r.shop_id,
@@ -171,6 +181,7 @@ export class AuthService {
     }));
 
     return {
+      platform_role: user?.platform_role ?? null,
       allowed_shop_ids: shop_roles.map((r) => r.shop_id),
       shop_roles,
       allowed_shops,

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -17,8 +17,8 @@ import { UpdateCategoryDto } from './dto/update-category.dto';
 import { QueryCategoriesDto } from './dto/query-categories.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
-import { Roles } from '../common/decorators/roles.decorator';
-import { ShopRole } from '../generated/prisma/client';
+import { PlatformRoles } from '../common/decorators/platform-roles.decorator';
+import { PlatformRole } from '../generated/prisma/client';
 
 @Controller('categories')
 export class CategoriesController {
@@ -38,28 +38,28 @@ export class CategoriesController {
 
   @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(ShopRole.super_admin)
+  @PlatformRoles(PlatformRole.platform_super)
   create(@Body() createDto: CreateCategoryDto) {
     return this.categoriesService.create(createDto);
   }
 
   @Patch(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(ShopRole.super_admin)
+  @PlatformRoles(PlatformRole.platform_super)
   update(@Param('id') id: string, @Body() updateDto: UpdateCategoryDto) {
     return this.categoriesService.update(id, updateDto);
   }
 
   @Patch(':id/toggle')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(ShopRole.super_admin)
+  @PlatformRoles(PlatformRole.platform_super)
   toggleActive(@Param('id') id: string) {
     return this.categoriesService.toggleActive(id);
   }
 
   @Delete(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(ShopRole.super_admin)
+  @PlatformRoles(PlatformRole.platform_super)
   @HttpCode(HttpStatus.OK)
   remove(@Param('id') id: string) {
     return this.categoriesService.remove(id);

--- a/backend/src/common/decorators/allow-staff-write.decorator.ts
+++ b/backend/src/common/decorators/allow-staff-write.decorator.ts
@@ -1,0 +1,16 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Escape-hatch decorator for shop_staff write access.
+ *
+ * By default, RolesGuard denies all mutating HTTP methods (POST/PATCH/DELETE/PUT)
+ * for shop_staff users (Option C enforcement). Apply @AllowStaffWrite() to a
+ * specific route handler to override this and grant staff full access to that route.
+ *
+ * Example:
+ *   @Patch('profile')
+ *   @AllowStaffWrite()
+ *   updateOwnProfile(...) { ... }
+ */
+export const ALLOW_STAFF_WRITE_KEY = 'allow_staff_write';
+export const AllowStaffWrite = () => SetMetadata(ALLOW_STAFF_WRITE_KEY, true);

--- a/backend/src/common/decorators/platform-roles.decorator.ts
+++ b/backend/src/common/decorators/platform-roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { PlatformRole } from '../../generated/prisma/client';
+
+export const PLATFORM_ROLES_KEY = 'platform_roles';
+export const PlatformRoles = (...roles: PlatformRole[]) => SetMetadata(PLATFORM_ROLES_KEY, roles);

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -1,8 +1,9 @@
 import { BadRequestException, ExecutionContext, ForbiddenException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ShopRole } from '../../generated/prisma/client';
+import { PlatformRole, ShopRole } from '../../generated/prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { ROLES_KEY } from '../decorators/roles.decorator';
+import { PLATFORM_ROLES_KEY } from '../decorators/platform-roles.decorator';
 import { RolesGuard } from './roles.guard';
 
 describe('RolesGuard', () => {
@@ -10,105 +11,183 @@ describe('RolesGuard', () => {
   let reflector: Reflector;
   let prisma: { userShopRole: { findMany: jest.Mock } };
 
-  const createContext = (requestUser: unknown): ExecutionContext =>
+  const createContext = (requestUser: unknown, method = 'GET'): ExecutionContext =>
     ({
       getHandler: () => jest.fn(),
       getClass: () => class TestController {},
       switchToHttp: () => ({
-        getRequest: () => ({ user: requestUser }),
+        getRequest: () => ({ user: requestUser, method }),
       }),
     }) as unknown as ExecutionContext;
 
+  const mockReflector = (platformRoles?: PlatformRole[], shopRoles?: ShopRole[]) => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation((key) => {
+      if (key === PLATFORM_ROLES_KEY) return platformRoles ?? null;
+      if (key === ROLES_KEY) return shopRoles ?? null;
+      return null;
+    });
+  };
+
   beforeEach(() => {
     reflector = new Reflector();
-    prisma = {
-      userShopRole: {
-        findMany: jest.fn(),
-      },
-    };
+    prisma = { userShopRole: { findMany: jest.fn() } };
     guard = new RolesGuard(reflector, prisma as unknown as PrismaService);
   });
 
+  // ── No metadata ─────────────────────────────────────────────────────────────
+
   it('allows access when no roles metadata', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+    mockReflector();
     await expect(guard.canActivate(createContext(null))).resolves.toBe(true);
   });
 
-  it('allows access when required roles array is empty', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([]);
+  it('allows access when both role arrays are empty', async () => {
+    mockReflector([], []);
     await expect(guard.canActivate(createContext(null))).resolves.toBe(true);
   });
 
-  it('throws when user is missing', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([ShopRole.super_admin]);
+  // ── Platform layer ───────────────────────────────────────────────────────────
+
+  it('allows platform_super user on @PlatformRoles route', async () => {
+    mockReflector([PlatformRole.platform_super]);
+    const ctx = createContext({ id: 'u1', platform_role: PlatformRole.platform_super });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('denies user without platform_role on @PlatformRoles route', async () => {
+    mockReflector([PlatformRole.platform_super]);
+    const ctx = createContext({ id: 'u1', platform_role: null });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('throws ForbiddenException when user is missing on platform route', async () => {
+    mockReflector([PlatformRole.platform_super]);
     await expect(guard.canActivate(createContext(undefined))).rejects.toThrow(ForbiddenException);
   });
 
-  it('allows super_admin when already present on request user', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([ShopRole.super_admin]);
-    const context = createContext({
-      id: 'u1',
-      shop_roles: [{ shop_id: 's1', role: ShopRole.super_admin }],
-    });
+  // ── Legacy @Roles(super_admin) mapped to platform_role ──────────────────────
 
-    await expect(guard.canActivate(context)).resolves.toBe(true);
-    expect(prisma.userShopRole.findMany).not.toHaveBeenCalled();
+  it('allows platform_super user on legacy @Roles(super_admin) route', async () => {
+    mockReflector(undefined, [ShopRole.super_admin]);
+    const ctx = createContext({
+      id: 'u1',
+      platform_role: PlatformRole.platform_super,
+      shop_roles: [],
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
-  it('loads roles from db when request user has no shop_roles', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([ShopRole.super_admin]);
-    prisma.userShopRole.findMany.mockResolvedValue([{ shop_id: 's1', role: ShopRole.super_admin }]);
+  it('denies user without platform_role on legacy @Roles(super_admin) route', async () => {
+    mockReflector(undefined, [ShopRole.super_admin]);
+    prisma.userShopRole.findMany.mockResolvedValue([]);
+    const ctx = createContext({ id: 'u1', platform_role: null });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
 
-    await expect(guard.canActivate(createContext({ id: 'u1' }))).resolves.toBe(true);
+  // ── Tenant layer ─────────────────────────────────────────────────────────────
+
+  it('allows shop_admin with matching active_shop_id', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin]);
+    const ctx = createContext({
+      id: 'u1',
+      active_shop_id: 'shop-a',
+      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('throws BadRequestException when active_shop_id is missing for tenant route', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin]);
+    const ctx = createContext({
+      id: 'u1',
+      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
+    });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws ForbiddenException when shop does not match active_shop_id', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin]);
+    const ctx = createContext({
+      id: 'u1',
+      active_shop_id: 'shop-b',
+      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
+    });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('loads roles from DB when shop_roles not on request', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin]);
+    prisma.userShopRole.findMany.mockResolvedValue([{ shop_id: 'shop-a', role: ShopRole.shop_admin }]);
+    const ctx = createContext({ id: 'u1', active_shop_id: 'shop-a' });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
     expect(prisma.userShopRole.findMany).toHaveBeenCalledWith({
       where: { user_id: 'u1' },
       select: { shop_id: true, role: true },
     });
   });
 
-  it('throws when required role is not present after db lookup', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([ShopRole.super_admin]);
-    prisma.userShopRole.findMany.mockResolvedValue([{ shop_id: 's1', role: ShopRole.shop_admin }]);
+  // ── Option C: shop_staff HTTP method enforcement ─────────────────────────────
 
-    await expect(guard.canActivate(createContext({ id: 'u1' }))).rejects.toThrow(ForbiddenException);
+  it('allows shop_staff on GET tenant route (safe method)', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext(
+      { id: 'u1', active_shop_id: 'shop-a', shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_staff }] },
+      'GET',
+    );
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
-  it('allows super_admin even when active_shop_id points to a different shop', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([ShopRole.super_admin]);
-    const context = createContext({
-      id: 'u1',
-      active_shop_id: 'shop-b',
-      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.super_admin }],
-    });
-
-    await expect(guard.canActivate(context)).resolves.toBe(true);
+  it('denies shop_staff on POST tenant route (mutating method)', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext(
+      { id: 'u1', active_shop_id: 'shop-a', shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_staff }] },
+      'POST',
+    );
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
   });
 
-  it('throws BadRequestException when tenant-scoped role is requested but active_shop_id is missing', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([ShopRole.shop_admin]);
-    const context = createContext({
-      id: 'u1',
-      // active_shop_id missing
-      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
-    });
-
-    await expect(guard.canActivate(context)).rejects.toThrow(BadRequestException);
+  it('denies shop_staff on PATCH tenant route', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext(
+      { id: 'u1', active_shop_id: 'shop-a', shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_staff }] },
+      'PATCH',
+    );
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
   });
 
-  it('allows tenant-scoped role when active_shop_id matches', async () => {
-    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([ShopRole.shop_admin]);
-    const context = createContext({
-      id: 'u1',
-      active_shop_id: 'shop-a',
-      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
-    });
-
-    await expect(guard.canActivate(context)).resolves.toBe(true);
+  it('denies shop_staff on DELETE tenant route', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext(
+      { id: 'u1', active_shop_id: 'shop-a', shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_staff }] },
+      'DELETE',
+    );
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
   });
 
-  it('uses ROLES_KEY when reading metadata', async () => {
+  it('allows shop_staff on HEAD tenant route (safe method)', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext(
+      { id: 'u1', active_shop_id: 'shop-a', shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_staff }] },
+      'HEAD',
+    );
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('allows shop_admin on POST tenant route (full write access)', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext(
+      { id: 'u1', active_shop_id: 'shop-a', shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }] },
+      'POST',
+    );
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  // ── Metadata key verification ────────────────────────────────────────────────
+
+  it('reads both PLATFORM_ROLES_KEY and ROLES_KEY from metadata', async () => {
     const spy = jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
     await guard.canActivate(createContext({}));
+    expect(spy).toHaveBeenCalledWith(PLATFORM_ROLES_KEY, expect.any(Array));
     expect(spy).toHaveBeenCalledWith(ROLES_KEY, expect.any(Array));
   });
 });

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -4,6 +4,7 @@ import { PlatformRole, ShopRole } from '../../generated/prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { ROLES_KEY } from '../decorators/roles.decorator';
 import { PLATFORM_ROLES_KEY } from '../decorators/platform-roles.decorator';
+import { ALLOW_STAFF_WRITE_KEY } from '../decorators/allow-staff-write.decorator';
 import { RolesGuard } from './roles.guard';
 
 describe('RolesGuard', () => {
@@ -20,10 +21,15 @@ describe('RolesGuard', () => {
       }),
     }) as unknown as ExecutionContext;
 
-  const mockReflector = (platformRoles?: PlatformRole[], shopRoles?: ShopRole[]) => {
+  const mockReflector = (
+    platformRoles?: PlatformRole[],
+    shopRoles?: ShopRole[],
+    allowStaffWrite?: boolean,
+  ) => {
     jest.spyOn(reflector, 'getAllAndOverride').mockImplementation((key) => {
       if (key === PLATFORM_ROLES_KEY) return platformRoles ?? null;
       if (key === ROLES_KEY) return shopRoles ?? null;
+      if (key === ALLOW_STAFF_WRITE_KEY) return allowStaffWrite ?? null;
       return null;
     });
   };
@@ -182,6 +188,24 @@ describe('RolesGuard', () => {
       'POST',
     );
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('allows shop_staff on POST when @AllowStaffWrite() is set', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff], true);
+    const ctx = createContext(
+      { id: 'u1', active_shop_id: 'shop-a', shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_staff }] },
+      'POST',
+    );
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('still denies shop_staff on PATCH when @AllowStaffWrite() is NOT set', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff], false);
+    const ctx = createContext(
+      { id: 'u1', active_shop_id: 'shop-a', shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_staff }] },
+      'PATCH',
+    );
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
   });
 
   // ── Metadata key verification ────────────────────────────────────────────────

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -32,6 +32,8 @@ describe('RolesGuard', () => {
     reflector = new Reflector();
     prisma = { userShopRole: { findMany: jest.fn() } };
     guard = new RolesGuard(reflector, prisma as unknown as PrismaService);
+    // Clear the static cache between tests to prevent cross-test contamination.
+    RolesGuard['shopRolesCache'].clear();
   });
 
   // ── No metadata ─────────────────────────────────────────────────────────────

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -9,6 +9,7 @@ import { Reflector } from '@nestjs/core';
 import { PlatformRole, ShopRole } from '../../generated/prisma/client';
 import { ROLES_KEY } from '../decorators/roles.decorator';
 import { PLATFORM_ROLES_KEY } from '../decorators/platform-roles.decorator';
+import { ALLOW_STAFF_WRITE_KEY } from '../decorators/allow-staff-write.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 
 export interface JwtUserShopRole {
@@ -24,6 +25,9 @@ export interface JwtUserShopRole {
  * this codebase — all routes use the standard NestJS method decorators
  * (@Get, @Post, @Patch, @Delete, @Put) which map 1:1 to HTTP methods.
  * WebSocket / SSE / RPC routes do not use RolesGuard.
+ *
+ * To exempt a specific route from this restriction, apply @AllowStaffWrite()
+ * on the route handler. The guard reads that metadata and skips the method check.
  *
  * Audit of @Roles(super_admin) usages NOT migrated to @PlatformRoles:
  * None remain. All former @Roles(super_admin) routes have been converted:
@@ -173,12 +177,18 @@ export class RolesGuard implements CanActivate {
 
     // ── Option C: shop_staff HTTP-method enforcement ─────────────────────────
     // shop_staff is read-only. Deny any mutating method globally without needing
-    // per-controller checks. To allow a specific write for staff in the future,
-    // add an @AllowStaffWrite() escape-hatch decorator.
+    // per-controller checks. Apply @AllowStaffWrite() to a specific route handler
+    // to grant staff write access to that route as an explicit exception.
     if (matchingRole.role === ShopRole.shop_staff) {
-      const method: string = request.method?.toUpperCase() ?? '';
-      if (!SAFE_METHODS.has(method)) {
-        throw new ForbiddenException('Shop staff accounts are read-only and cannot perform this action.');
+      const allowStaffWrite = this.reflector.getAllAndOverride<boolean>(ALLOW_STAFF_WRITE_KEY, [
+        context.getHandler(),
+        context.getClass(),
+      ]);
+      if (!allowStaffWrite) {
+        const method: string = request.method?.toUpperCase() ?? '';
+        if (!SAFE_METHODS.has(method)) {
+          throw new ForbiddenException('Shop staff accounts are read-only and cannot perform this action.');
+        }
       }
     }
 

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -83,8 +83,10 @@ export class RolesGuard implements CanActivate {
     }
 
     // ── Platform layer ───────────────────────────────────────────────────────
-    // Handle @PlatformRoles(...) explicitly, and handle legacy @Roles(super_admin)
-    // by mapping it to platform_role check (strict after migration backfill).
+    // `user.platform_role` is populated by AuthService.validateUser() which runs a
+    // fresh DB query on every authenticated request (JwtStrategy.validate → validateUser).
+    // It is NOT cached in the JWT token itself, so role changes take effect on the
+    // very next request without requiring a token refresh or re-login.
     const requiresPlatform =
       (platformRoles && platformRoles.length > 0) ||
       (requiredRoles && requiredRoles.includes(ShopRole.super_admin));

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -61,18 +61,20 @@ export class RolesGuard implements CanActivate {
     private prisma: PrismaService,
   ) {}
 
-  // In-process cache to avoid hitting DB on every request for @Roles(...) routes.
+  // Static (process-wide) cache shared across all RolesGuard instances.
+  // NestJS creates one guard instance per controller when @UseGuards(RolesGuard) is used
+  // directly on a controller class — a per-instance cache would not be invalidatable.
   // TTL is intentionally small because roles can change (e.g. user promoted/demoted).
-  private readonly shopRolesCache = new Map<
+  private static readonly shopRolesCache = new Map<
     string,
     { expiresAt: number; shopRoles: JwtUserShopRole[] }
   >();
 
-  private readonly shopRolesCacheTtlMs = 30_000;
+  private static readonly shopRolesCacheTtlMs = 30_000;
 
   /** Invalidate cached shop roles for a user after role mutations. */
-  invalidateShopRolesCache(userId: string): void {
-    this.shopRolesCache.delete(userId);
+  static invalidateShopRolesCache(userId: string): void {
+    RolesGuard.shopRolesCache.delete(userId);
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -132,7 +134,7 @@ export class RolesGuard implements CanActivate {
     // Load shop roles (from request or cache).
     let shopRoles = user?.shop_roles as JwtUserShopRole[] | undefined;
     if (!Array.isArray(shopRoles) || shopRoles.length === 0) {
-      const cached = this.shopRolesCache.get(user.id);
+      const cached = RolesGuard.shopRolesCache.get(user.id);
       if (cached && cached.expiresAt > Date.now()) {
         shopRoles = cached.shopRoles;
       } else {
@@ -141,8 +143,8 @@ export class RolesGuard implements CanActivate {
           select: { shop_id: true, role: true },
         });
         shopRoles = rows.map((r) => ({ shop_id: r.shop_id, role: r.role }));
-        this.shopRolesCache.set(user.id, {
-          expiresAt: Date.now() + this.shopRolesCacheTtlMs,
+        RolesGuard.shopRolesCache.set(user.id, {
+          expiresAt: Date.now() + RolesGuard.shopRolesCacheTtlMs,
           shopRoles,
         });
       }

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -6,8 +6,9 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ShopRole } from '../../generated/prisma/client';
+import { PlatformRole, ShopRole } from '../../generated/prisma/client';
 import { ROLES_KEY } from '../decorators/roles.decorator';
+import { PLATFORM_ROLES_KEY } from '../decorators/platform-roles.decorator';
 import { PrismaService } from '../prisma/prisma.service';
 
 export interface JwtUserShopRole {
@@ -15,12 +16,28 @@ export interface JwtUserShopRole {
   role: ShopRole;
 }
 
+/** HTTP methods that are considered safe/read-only for shop_staff enforcement. */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
 /**
- * RolesGuard — enforces that a request's user has at least one of the required roles.
+ * RolesGuard — dual-layer authorization guard.
  *
- * Usage: Apply after JwtAuthGuard.
- * `JwtStrategy` does not attach `shop_roles` (see AuthService.validateUser). If missing, this guard
- * loads only `{ shop_id, role }` rows — only on routes decorated with `@Roles(...)`, not on every API call.
+ * ## Platform layer (@PlatformRoles decorator)
+ * Routes decorated with `@PlatformRoles(PlatformRole.platform_super)` require the user
+ * to have `User.platform_role === platform_super`. No shop context is needed.
+ * This replaces the old `@Roles(ShopRole.super_admin)` global shortcut.
+ *
+ * ## Tenant layer (@Roles decorator)
+ * Routes decorated with `@Roles(ShopRole.shop_admin)` (or shop_staff) require:
+ *   1. A valid `active_shop_id` in the JWT.
+ *   2. A matching `UserShopRole` row for that shop.
+ *   3. Option C: `shop_staff` users are automatically restricted to safe HTTP methods
+ *      (GET/HEAD/OPTIONS) — no individual controller needs to check this.
+ *
+ * ## Legacy compatibility
+ * Routes still using `@Roles(ShopRole.super_admin)` without `@PlatformRoles` are
+ * handled by checking `platform_role` first (strict — backfill in migration 15-01
+ * already assigned platform_role to all former super_admin users).
  */
 @Injectable()
 export class RolesGuard implements CanActivate {
@@ -38,13 +55,24 @@ export class RolesGuard implements CanActivate {
 
   private readonly shopRolesCacheTtlMs = 30_000;
 
+  /** Invalidate cached shop roles for a user after role mutations. */
+  invalidateShopRolesCache(userId: string): void {
+    this.shopRolesCache.delete(userId);
+  }
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const platformRoles = this.reflector.getAllAndOverride<PlatformRole[]>(PLATFORM_ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
     const requiredRoles = this.reflector.getAllAndOverride<ShopRole[]>(ROLES_KEY, [
       context.getHandler(),
       context.getClass(),
     ]);
 
-    if (!requiredRoles || requiredRoles.length === 0) {
+    // No authorization metadata — open route.
+    if ((!platformRoles || platformRoles.length === 0) && (!requiredRoles || requiredRoles.length === 0)) {
       return true;
     }
 
@@ -54,6 +82,37 @@ export class RolesGuard implements CanActivate {
       throw new ForbiddenException('A role is required to access this resource.');
     }
 
+    // ── Platform layer ───────────────────────────────────────────────────────
+    // Handle @PlatformRoles(...) explicitly, and handle legacy @Roles(super_admin)
+    // by mapping it to platform_role check (strict after migration backfill).
+    const requiresPlatform =
+      (platformRoles && platformRoles.length > 0) ||
+      (requiredRoles && requiredRoles.includes(ShopRole.super_admin));
+
+    if (requiresPlatform) {
+      const userPlatformRole = user.platform_role as PlatformRole | null | undefined;
+      if (userPlatformRole === PlatformRole.platform_super) {
+        return true;
+      }
+      // If only platform was required, deny immediately.
+      const onlyPlatformRequired =
+        !requiredRoles ||
+        requiredRoles.length === 0 ||
+        requiredRoles.every((r) => r === ShopRole.super_admin);
+      if (onlyPlatformRequired) {
+        throw new ForbiddenException('Platform operator access required.');
+      }
+      // Fall through to tenant layer if route also accepts tenant roles.
+    }
+
+    // ── Tenant layer ─────────────────────────────────────────────────────────
+    const tenantRoles = (requiredRoles || []).filter((r) => r !== ShopRole.super_admin);
+    if (tenantRoles.length === 0) {
+      // Only platform roles were requested and user didn't pass the platform check above.
+      throw new ForbiddenException('Platform operator access required.');
+    }
+
+    // Load shop roles (from request or cache).
     let shopRoles = user?.shop_roles as JwtUserShopRole[] | undefined;
     if (!Array.isArray(shopRoles) || shopRoles.length === 0) {
       const cached = this.shopRolesCache.get(user.id);
@@ -71,52 +130,39 @@ export class RolesGuard implements CanActivate {
         });
       }
 
-      request.user = {
-        ...user,
-        shop_roles: shopRoles,
-      };
+      request.user = { ...user, shop_roles: shopRoles };
     }
 
-    if (shopRoles.length === 0) {
+    if (!shopRoles || shopRoles.length === 0) {
       throw new ForbiddenException('A role is required to access this resource.');
     }
 
     const activeShopId = typeof user.active_shop_id === 'string' ? user.active_shop_id : undefined;
-
-    // super_admin is treated as a global permission: it should not depend on `active_shop_id`.
-    const hasGlobalSuperAdmin = shopRoles.some(
-      (ur) => ur.role === ShopRole.super_admin && requiredRoles.includes(ShopRole.super_admin),
-    );
-    if (hasGlobalSuperAdmin) {
-      return true;
-    }
-
-    // If the endpoint requires any non-global role, we must have an active shop context.
-    const requiresTenantScopedRole = requiredRoles.some((r) => r !== ShopRole.super_admin);
-    if (requiresTenantScopedRole) {
-      if (!activeShopId) {
-        throw new BadRequestException(
-          'Active shop is not selected. Call POST /auth/switch-shop with a shop_id you have access to, then retry.',
-        );
-      }
-
-      const hasTenantRole = shopRoles.some(
-        (userRole) =>
-          userRole?.role != null &&
-          requiredRoles.includes(userRole.role) &&
-          userRole.shop_id === activeShopId,
+    if (!activeShopId) {
+      throw new BadRequestException(
+        'Active shop is not selected. Call POST /auth/switch-shop with a shop_id you have access to, then retry.',
       );
-
-      if (!hasTenantRole) {
-        throw new ForbiddenException(
-          `Access forbidden. Required roles: ${requiredRoles.join(', ')}`,
-        );
-      }
-
-      return true;
     }
 
-    // Only global role(s) were requested but the user doesn't have global super_admin.
-    throw new ForbiddenException(`Access forbidden. Required roles: ${requiredRoles.join(', ')}`);
+    const matchingRole = shopRoles.find(
+      (ur) => ur?.role != null && (tenantRoles as ShopRole[]).includes(ur.role) && ur.shop_id === activeShopId,
+    );
+
+    if (!matchingRole) {
+      throw new ForbiddenException(`Access forbidden. Required roles: ${tenantRoles.join(', ')}`);
+    }
+
+    // ── Option C: shop_staff HTTP-method enforcement ─────────────────────────
+    // shop_staff is read-only. Deny any mutating method globally without needing
+    // per-controller checks. To allow a specific write for staff in the future,
+    // add an @AllowStaffWrite() escape-hatch decorator.
+    if (matchingRole.role === ShopRole.shop_staff) {
+      const method: string = request.method?.toUpperCase() ?? '';
+      if (!SAFE_METHODS.has(method)) {
+        throw new ForbiddenException('Shop staff accounts are read-only and cannot perform this action.');
+      }
+    }
+
+    return true;
   }
 }

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -16,7 +16,22 @@ export interface JwtUserShopRole {
   role: ShopRole;
 }
 
-/** HTTP methods that are considered safe/read-only for shop_staff enforcement. */
+/**
+ * HTTP methods considered safe/read-only for shop_staff enforcement (Option C).
+ *
+ * All controllers that include shop_staff in @Roles(...) use this set for
+ * enforcement at the guard level. There are no non-standard HTTP verbs in
+ * this codebase — all routes use the standard NestJS method decorators
+ * (@Get, @Post, @Patch, @Delete, @Put) which map 1:1 to HTTP methods.
+ * WebSocket / SSE / RPC routes do not use RolesGuard.
+ *
+ * Audit of @Roles(super_admin) usages NOT migrated to @PlatformRoles:
+ * None remain. All former @Roles(super_admin) routes have been converted:
+ *   - ShopsController    → @PlatformRoles(platform_super)  (class-level)
+ *   - CategoriesController → @PlatformRoles(platform_super) (per-route)
+ * Any new route using @Roles(ShopRole.super_admin) will be handled by the
+ * platform-role branch of this guard (see "Legacy compatibility" below).
+ */
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
 /**

--- a/backend/src/images/images.controller.ts
+++ b/backend/src/images/images.controller.ts
@@ -18,10 +18,14 @@ import { UpdateImageDto } from './dto/update-image.dto';
 import { ReorderImagesDto } from './dto/reorder-images.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TenantGuard } from '../common/guards/tenant.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { ShopRole } from '../generated/prisma/client';
 import { CurrentTenantId } from '../common/decorators/tenant.decorator';
 
 @Controller('items/:itemId/images')
-@UseGuards(JwtAuthGuard, TenantGuard)
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class ImagesController {
   constructor(private readonly imagesService: ImagesService) {}
 

--- a/backend/src/inventory/inventory.controller.ts
+++ b/backend/src/inventory/inventory.controller.ts
@@ -13,7 +13,7 @@ import { ReverseInventoryTransactionDto } from './dto/reverse-inventory-transact
 
 @Controller('inventory/items/:itemId/transactions')
 @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
-@Roles(ShopRole.shop_admin, ShopRole.super_admin)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class InventoryController {
   constructor(private readonly inventoryService: InventoryService) {}
 

--- a/backend/src/items/ai-draft.controller.ts
+++ b/backend/src/items/ai-draft.controller.ts
@@ -6,10 +6,14 @@ import { PrismaService } from '../common/prisma/prisma.service';
 import { IStorageService } from '../storage/storage.interface';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TenantGuard } from '../common/guards/tenant.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { ShopRole } from '../generated/prisma/client';
 import { CurrentTenantId } from '../common/decorators/tenant.decorator';
 
 @Controller('items/ai-draft')
-@UseGuards(JwtAuthGuard, TenantGuard)
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class AiDraftController {
   private readonly logger = new Logger(AiDraftController.name);
 

--- a/backend/src/items/items.controller.ts
+++ b/backend/src/items/items.controller.ts
@@ -24,10 +24,14 @@ import { CreateFacebookPostDto } from './dto/create-facebook-post.dto';
 import { PublishFacebookPostDto } from './dto/publish-facebook-post.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TenantGuard } from '../common/guards/tenant.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { ShopRole } from '../generated/prisma/client';
 import { CurrentTenantId } from '../common/decorators/tenant.decorator';
 
 @Controller('items')
-@UseGuards(JwtAuthGuard, TenantGuard)
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class ItemsController {
   private readonly logger = new Logger(ItemsController.name);
 

--- a/backend/src/members/members.controller.ts
+++ b/backend/src/members/members.controller.ts
@@ -17,7 +17,7 @@ import { UpdateMembershipTierDto } from './dto/update-membership-tier.dto';
 
 @Controller('members')
 @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
-@Roles(ShopRole.shop_admin, ShopRole.super_admin)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 

--- a/backend/src/preorders/preorders.controller.ts
+++ b/backend/src/preorders/preorders.controller.ts
@@ -56,21 +56,21 @@ export class PreordersController {
 
   @Get('admin')
   @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
-  @Roles(ShopRole.shop_admin, ShopRole.super_admin)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   findAdminList(@Query() query: QueryPreordersDto, @CurrentTenantId() tenantId: string) {
     return this.preordersService.findAdminList(query, tenantId);
   }
 
   @Get('admin/summary')
   @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
-  @Roles(ShopRole.shop_admin, ShopRole.super_admin)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   getAdminSummary(@CurrentTenantId() tenantId: string) {
     return this.preordersService.getAdminSummary(tenantId);
   }
 
   @Get('admin/campaigns/:itemId/participants')
   @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
-  @Roles(ShopRole.shop_admin, ShopRole.super_admin)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   getParticipants(
     @Param('itemId') itemId: string,
     @CurrentTenantId() tenantId: string,

--- a/backend/src/preorders/preorders.controller.ts
+++ b/backend/src/preorders/preorders.controller.ts
@@ -20,7 +20,8 @@ export class PreordersController {
   constructor(private readonly preordersService: PreordersService) {}
 
   @Post()
-  @UseGuards(JwtAuthGuard, TenantGuard)
+  @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   create(
     @Body() dto: CreatePreorderDto,
     @CurrentTenantId() tenantId: string,
@@ -32,7 +33,8 @@ export class PreordersController {
   }
 
   @Patch(':id')
-  @UseGuards(JwtAuthGuard, TenantGuard)
+  @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   update(
     @Param('id') id: string,
     @Body() dto: UpdatePreorderDto,
@@ -45,7 +47,8 @@ export class PreordersController {
   }
 
   @Patch(':id/status')
-  @UseGuards(JwtAuthGuard, TenantGuard)
+  @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   transitionStatus(
     @Param('id') id: string,
     @Body() dto: TransitionPreorderStatusDto,

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -11,7 +11,7 @@ import { QueryReportTrendsDto } from './dto/query-report-trends.dto';
 
 @Controller('reports')
 @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
-@Roles(ShopRole.shop_admin, ShopRole.super_admin)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 

--- a/backend/src/shops/dto/add-shop-admin.dto.ts
+++ b/backend/src/shops/dto/add-shop-admin.dto.ts
@@ -43,5 +43,5 @@ export class AddShopAdminDto {
    */
   @IsOptional()
   @IsEnum([ShopRole.shop_admin, ShopRole.shop_staff])
-  role?: ShopRole.shop_admin | ShopRole.shop_staff;
+  role?: typeof ShopRole.shop_admin | typeof ShopRole.shop_staff;
 }

--- a/backend/src/shops/dto/add-shop-admin.dto.ts
+++ b/backend/src/shops/dto/add-shop-admin.dto.ts
@@ -1,4 +1,5 @@
-import { IsEmail, IsNotEmpty, IsOptional, IsString, IsUUID, MinLength, ValidateIf } from 'class-validator';
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID, MinLength, ValidateIf } from 'class-validator';
+import { ShopRole } from '../../generated/prisma/client';
 
 export class AddShopAdminDto {
   /**
@@ -34,5 +35,13 @@ export class AddShopAdminDto {
   @IsString()
   @IsNotEmpty()
   full_name?: string;
-}
 
+  /**
+   * Role to assign to the member in this shop.
+   * Defaults to shop_admin if not provided.
+   * Platform-level roles (platform_super) cannot be set via this endpoint.
+   */
+  @IsOptional()
+  @IsEnum([ShopRole.shop_admin, ShopRole.shop_staff])
+  role?: ShopRole.shop_admin | ShopRole.shop_staff;
+}

--- a/backend/src/shops/shops.controller.ts
+++ b/backend/src/shops/shops.controller.ts
@@ -12,22 +12,24 @@ import { QueryShopItemsDto } from './dto/query-shop-items.dto';
 import { QueryShopAuditLogsDto } from './dto/query-shop-audit-logs.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
-import { Roles } from '../common/decorators/roles.decorator';
+import { PlatformRoles } from '../common/decorators/platform-roles.decorator';
 import { CurrentUserId } from '../common/decorators/current-user-id.decorator';
-import { ShopRole } from '../generated/prisma/client';
+import { PlatformRole } from '../generated/prisma/client';
 
 /**
- * ShopsController — Super-admin only.
+ * ShopsController — Platform operator only.
  * Routes: /admin/shops
  *
- * Authorization: Restricted to users with 'super_admin' ShopRole across all routes.
+ * Authorization: Restricted to users with platform_role = platform_super.
+ * Uses @PlatformRoles (not @Roles) because shop management is a platform-level
+ * capability that does not require an active tenant context.
  *
  * Route order: longer / static path segments must be declared *before* `@X(':id')`
  * so e.g. `GET /:id/members` is not swallowed by `GET /:id` (Nest/Express param matching).
  */
 @Controller('admin/shops')
 @UseGuards(JwtAuthGuard, RolesGuard)
-@Roles(ShopRole.super_admin)
+@PlatformRoles(PlatformRole.platform_super)
 export class ShopsController {
   constructor(private readonly shopsService: ShopsService) {}
 

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -180,6 +180,95 @@ describe('ShopsService', () => {
       expect(prisma.user.create).not.toHaveBeenCalled();
       expect(prisma.userShopRole.upsert).toHaveBeenCalled();
     });
+
+    it('should assign shop_staff role when dto.role is shop_staff', async () => {
+      prisma.shop.findUnique.mockResolvedValue({ id: shopId });
+      prisma.user.findUnique.mockResolvedValue({ id: userId });
+      prisma.userShopRole.upsert.mockResolvedValue({
+        user_id: userId,
+        shop_id: shopId,
+        role: ShopRole.shop_staff,
+      });
+      prisma.shopAuditLog.create.mockResolvedValue({});
+
+      const dto: AddShopAdminDto = { user_id: userId, role: ShopRole.shop_staff };
+      const result = await service.addShopAdmin(shopId, dto);
+
+      expect(result.role).toBe(ShopRole.shop_staff);
+      expect(prisma.userShopRole.upsert).toHaveBeenCalledWith({
+        where: { user_id_shop_id: { user_id: userId, shop_id: shopId } },
+        create: { user_id: userId, shop_id: shopId, role: ShopRole.shop_staff },
+        update: { role: ShopRole.shop_staff },
+      });
+    });
+
+    it('should default to shop_admin when dto.role is omitted', async () => {
+      prisma.shop.findUnique.mockResolvedValue({ id: shopId });
+      prisma.user.findUnique.mockResolvedValue({ id: userId });
+      prisma.userShopRole.upsert.mockResolvedValue({
+        user_id: userId,
+        shop_id: shopId,
+        role: ShopRole.shop_admin,
+      });
+      prisma.shopAuditLog.create.mockResolvedValue({});
+
+      const dto: AddShopAdminDto = { user_id: userId };
+      await service.addShopAdmin(shopId, dto);
+
+      expect(prisma.userShopRole.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ role: ShopRole.shop_admin }),
+          update: { role: ShopRole.shop_admin },
+        }),
+      );
+    });
+
+    it('should use set_shop_member_role audit action when assigning role', async () => {
+      prisma.shop.findUnique.mockResolvedValue({ id: shopId });
+      prisma.user.findUnique.mockResolvedValue({ id: userId });
+      prisma.userShopRole.upsert.mockResolvedValue({
+        user_id: userId,
+        shop_id: shopId,
+        role: ShopRole.shop_staff,
+      });
+      prisma.shopAuditLog.create.mockResolvedValue({});
+
+      await service.addShopAdmin(shopId, { user_id: userId, role: ShopRole.shop_staff }, 'actor-1');
+
+      expect(prisma.shopAuditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'set_shop_member_role',
+            actor_user_id: 'actor-1',
+          }),
+        }),
+      );
+    });
+
+    it('should create new user with shop_staff role and use set_shop_member_role audit action', async () => {
+      prisma.shop.findUnique.mockResolvedValue({ id: shopId });
+      prisma.user.findUnique.mockResolvedValue(null);
+      prisma.user.create.mockResolvedValue({ id: 'new-user-id' });
+      prisma.userShopRole.upsert.mockResolvedValue({
+        user_id: 'new-user-id',
+        shop_id: shopId,
+        role: ShopRole.shop_staff,
+      });
+
+      const dto: AddShopAdminDto = {
+        email: 'staff@test.com',
+        password: 'password123',
+        role: ShopRole.shop_staff,
+      };
+
+      await service.addShopAdmin(shopId, dto);
+
+      expect(prisma.userShopRole.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ role: ShopRole.shop_staff }),
+        }),
+      );
+    });
   });
 
   describe('resetMemberPassword', () => {

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../common/prisma/prisma.service';
 import { AppException } from '../common/exceptions/http-exception.filter';
 import { ShopRole } from '../generated/prisma/client';
 import { AddShopAdminDto } from './dto/add-shop-admin.dto';
+import { RolesGuard } from '../common/guards/roles.guard';
 import * as bcrypt from 'bcrypt';
 
 jest.mock('bcrypt', () => ({
@@ -221,6 +222,27 @@ describe('ShopsService', () => {
           update: { role: ShopRole.shop_admin },
         }),
       );
+    });
+
+    it('should invalidate the RolesGuard cache for the affected user after role upsert', async () => {
+      prisma.shop.findUnique.mockResolvedValue({ id: shopId });
+      prisma.user.findUnique.mockResolvedValue({ id: userId });
+      prisma.userShopRole.upsert.mockResolvedValue({
+        user_id: userId,
+        shop_id: shopId,
+        role: ShopRole.shop_staff,
+      });
+      prisma.shopAuditLog.create.mockResolvedValue({});
+
+      // Pre-populate the shared cache to confirm it is cleared after addShopAdmin.
+      RolesGuard['shopRolesCache'].set(userId, {
+        expiresAt: Date.now() + 30_000,
+        shopRoles: [{ shop_id: shopId, role: ShopRole.shop_admin }],
+      });
+
+      await service.addShopAdmin(shopId, { user_id: userId, role: ShopRole.shop_staff });
+
+      expect(RolesGuard['shopRolesCache'].has(userId)).toBe(false);
     });
 
     it('should use set_shop_member_role audit action when assigning role', async () => {

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -330,7 +330,8 @@ export class ShopsService {
   }
 
   /**
-   * Add or update a user as `shop_admin` in a given shop.
+   * Add or update a user's role in a given shop.
+   * Accepts shop_admin or shop_staff (default: shop_admin).
    * Idempotent via `upsert` on composite key `(user_id, shop_id)`.
    */
   async addShopAdmin(shopId: string, dto: AddShopAdminDto, actorUserId?: string | null) {
@@ -339,6 +340,8 @@ export class ShopsService {
     if (dto.user_id && !isUUID(dto.user_id)) {
       throw new AppException(ErrorCode.VALIDATION_ERROR, 'user_id must be a valid UUID.');
     }
+
+    const assignedRole: ShopRole = dto.role ?? ShopRole.shop_admin;
 
     const user =
       dto.user_id != null
@@ -368,16 +371,16 @@ export class ShopsService {
 
         const upserted = await tx.userShopRole.upsert({
           where: { user_id_shop_id: { user_id: created.id, shop_id: shopId } },
-          create: { user_id: created.id, shop_id: shopId, role: ShopRole.shop_admin },
-          update: { role: ShopRole.shop_admin },
+          create: { user_id: created.id, shop_id: shopId, role: assignedRole },
+          update: { role: assignedRole },
         });
 
-        const safeMetadata = JSON.stringify({ email: dto.email, created_user: true });
+        const safeMetadata = JSON.stringify({ email: dto.email, created_user: true, role: assignedRole });
         await tx.shopAuditLog.create({
           data: {
             shop_id: shopId,
             actor_user_id: actorUserId ?? null,
-            action: ShopAuditAction.add_shop_admin,
+            action: ShopAuditAction.set_shop_member_role,
             target_type: 'user',
             target_id: created.id,
             metadata_json: safeMetadata,
@@ -390,16 +393,16 @@ export class ShopsService {
 
     const upserted = await this.prisma.userShopRole.upsert({
       where: { user_id_shop_id: { user_id: user.id, shop_id: shopId } },
-      create: { user_id: user.id, shop_id: shopId, role: ShopRole.shop_admin },
-      update: { role: ShopRole.shop_admin },
+      create: { user_id: user.id, shop_id: shopId, role: assignedRole },
+      update: { role: assignedRole },
     });
     await this.logAudit(
       shopId,
-      ShopAuditAction.add_shop_admin,
+      ShopAuditAction.set_shop_member_role,
       actorUserId ?? null,
       'user',
       user.id,
-      { email: dto.email ?? null, created_user: false },
+      { email: dto.email ?? null, created_user: false, role: assignedRole },
     );
     return upserted;
   }

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -14,6 +14,7 @@ import { isUUID } from 'class-validator';
 import { IStorageService } from '../storage/storage.interface';
 import { toNumber } from '../common/utils/decimal.utils';
 import { totalPagesFromCount } from '../common/utils/pagination.utils';
+import { RolesGuard } from '../common/guards/roles.guard';
 
 const MAX_SLUG_ALLOCATION_ATTEMPTS = 32;
 
@@ -387,6 +388,9 @@ export class ShopsService {
           },
         });
 
+        // Invalidate the shared shop-roles cache so the new user's role is enforced
+        // immediately on the next request rather than after the 30-second TTL expires.
+        RolesGuard.invalidateShopRolesCache(created.id);
         return upserted;
       });
     }
@@ -404,6 +408,8 @@ export class ShopsService {
       user.id,
       { email: dto.email ?? null, created_user: false, role: assignedRole },
     );
+    // Invalidate the shared shop-roles cache so the updated role is enforced immediately.
+    RolesGuard.invalidateShopRolesCache(user.id);
     return upserted;
   }
 

--- a/backend/src/spinner/spinner.controller.ts
+++ b/backend/src/spinner/spinner.controller.ts
@@ -21,10 +21,14 @@ import { UploadFrameDto } from './dto/upload-frame.dto';
 import { ReorderFramesDto } from './dto/reorder-frames.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TenantGuard } from '../common/guards/tenant.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { ShopRole } from '../generated/prisma/client';
 import { CurrentTenantId } from '../common/decorators/tenant.decorator';
 
 @Controller('items/:itemId/spin-sets')
-@UseGuards(JwtAuthGuard, TenantGuard)
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class SpinSetsController {
   constructor(private readonly spinnerService: SpinnerService) {}
 
@@ -47,7 +51,8 @@ export class SpinSetsController {
 }
 
 @Controller('spin-sets/:spinSetId')
-@UseGuards(JwtAuthGuard, TenantGuard)
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class SpinSetController {
   constructor(private readonly spinnerService: SpinnerService) {}
 

--- a/frontend/src/contexts/AuthContext.ts
+++ b/frontend/src/contexts/AuthContext.ts
@@ -14,16 +14,25 @@ export interface AllowedShopSummary {
   role?: string;
 }
 
+export type PlatformRole = 'platform_super' | null;
+
 export interface User {
   id: string;
   email: string;
   full_name?: string;
   role: string;
+  /** Platform-level authority (not tied to any specific shop). null = regular user. */
+  platform_role?: PlatformRole;
   allowed_shop_ids?: string[];
   shop_roles?: UserShopRole[];
   allowed_shops?: AllowedShopSummary[];
   /** Bound active tenant from JWT (set after switch-shop). */
   active_shop_id?: string | null;
+}
+
+/** Returns true if the user has platform operator access. */
+export function isPlatformSuper(user: User | null | undefined): boolean {
+  return user?.platform_role === 'platform_super';
 }
 
 export interface AuthContextType {

--- a/frontend/src/hooks/useIsSuperAdmin.ts
+++ b/frontend/src/hooks/useIsSuperAdmin.ts
@@ -1,16 +1,12 @@
 import { useMemo } from 'react';
 import { useAuth } from './useAuth';
+import { isPlatformSuper } from '../contexts/AuthContext';
 
+/**
+ * Returns true if the current user has platform operator access.
+ * After Phase 15, this is based on `platform_role === 'platform_super'`.
+ */
 export const useIsSuperAdmin = (): boolean => {
   const { user } = useAuth();
-
-  return useMemo(
-    () =>
-      Boolean(
-        user?.role === 'super_admin' ||
-          user?.shop_roles?.some((shopRole) => shopRole.role === 'super_admin'),
-      ),
-    [user],
-  );
+  return useMemo(() => isPlatformSuper(user), [user]);
 };
-

--- a/frontend/src/pages/admin/ShopsPage.tsx
+++ b/frontend/src/pages/admin/ShopsPage.tsx
@@ -16,6 +16,8 @@ function shopRoleLabel(role: string): string {
   switch (role) {
     case 'shop_admin':
       return 'Quản trị shop';
+    case 'shop_staff':
+      return 'Nhân viên shop';
     case 'super_admin':
       return 'Super admin';
     default:
@@ -37,6 +39,10 @@ function shopAuditActionLabel(action: ShopAuditLogRow['action']): string {
       return 'Tắt shop';
     case 'activate_shop':
       return 'Mở lại shop';
+    case 'set_platform_role':
+      return 'Gán quyền platform';
+    case 'set_shop_member_role':
+      return 'Phân quyền thành viên shop';
     default:
       return action;
   }
@@ -168,6 +174,7 @@ const ShopsPage: React.FC = () => {
   const [memberSuccess, setMemberSuccess] = useState<string | null>(null);
   const [memberEmailError, setMemberEmailError] = useState<string | null>(null);
   const [memberPasswordError, setMemberPasswordError] = useState<string | null>(null);
+  const [memberRole, setMemberRole] = useState<'shop_admin' | 'shop_staff'>('shop_admin');
   const memberEmailInputRef = useRef<HTMLInputElement | null>(null);
   const memberPasswordInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -185,6 +192,7 @@ const ShopsPage: React.FC = () => {
     setMemberEmail('');
     setMemberPassword('');
     setMemberFullName('');
+    setMemberRole('shop_admin');
     setMemberEmailError(null);
     setMemberPasswordError(null);
     setMemberModalShopId(shopId);
@@ -470,14 +478,16 @@ const ShopsPage: React.FC = () => {
 
       const payload = {
         email,
+        role: memberRole,
         ...(password ? { password } : {}),
         ...(full_name ? { full_name } : {}),
       };
 
       await apiClient.post(`/admin/shops/${shopId}/members`, payload);
 
+      const roleSuccessLabel = memberRole === 'shop_staff' ? 'Nhân viên shop' : 'Quản trị shop';
       setShopActionError(null);
-      setShopActionSuccess('Đã cấp shop_admin thành công.');
+      setShopActionSuccess(`Đã thêm thành viên (${roleSuccessLabel}) thành công.`);
       setMemberModalShopId(null);
       setMemberEmailError(null);
       setMemberPasswordError(null);
@@ -828,6 +838,7 @@ const ShopsPage: React.FC = () => {
         memberFullName={memberFullName}
         memberEmail={memberEmail}
         memberEmailError={memberEmailError}
+        memberRole={memberRole}
         adding={Boolean(memberModalShopId && memberAddingForShopId === memberModalShopId)}
         memberEmailInputRef={memberEmailInputRef}
         onClose={closeMemberModal}
@@ -849,6 +860,7 @@ const ShopsPage: React.FC = () => {
             setMemberEmailError(null);
           }
         }}
+        onRoleChange={setMemberRole}
         onSubmit={() => {
           if (!memberModalShopId) return;
           void handleAddShopAdmin(memberModalShopId);

--- a/frontend/src/pages/admin/shops/ShopCard.tsx
+++ b/frontend/src/pages/admin/shops/ShopCard.tsx
@@ -98,8 +98,8 @@ const ShopCard: React.FC<Props> = ({
             }}
             disabled={memberAddingForShopId === shop.id}
             onClick={() => onOpenAddMember(shop.id)}
-            title="Thêm quản lý — gán shop_admin (email / tạo tài khoản)"
-            aria-label="Thêm quản lý cho shop"
+            title="Thêm thành viên — gán shop_admin hoặc shop_staff"
+            aria-label="Thêm thành viên cho shop"
           >
             {memberAddingForShopId === shop.id ? (
               <Loader2 size={18} className="animate-spin" aria-hidden />
@@ -147,8 +147,8 @@ const ShopCard: React.FC<Props> = ({
               style={{ ...styles.iconBtnSuccess, opacity: memberAddingForShopId === shop.id ? 0.7 : 1 }}
               disabled={memberAddingForShopId === shop.id}
               onClick={() => onOpenAddMember(shop.id)}
-              title="Thêm quản lý — gán shop_admin (email / tạo tài khoản)"
-              aria-label="Thêm quản lý cho shop"
+              title="Thêm thành viên — gán shop_admin hoặc shop_staff"
+              aria-label="Thêm thành viên cho shop"
             >
               {memberAddingForShopId === shop.id ? (
                 <Loader2 size={18} className="animate-spin" aria-hidden />

--- a/frontend/src/pages/admin/shops/modals/AddMemberModal.tsx
+++ b/frontend/src/pages/admin/shops/modals/AddMemberModal.tsx
@@ -9,15 +9,22 @@ type Props = {
   memberFullName: string;
   memberEmail: string;
   memberEmailError: string | null;
+  memberRole: 'shop_admin' | 'shop_staff';
   adding: boolean;
   memberEmailInputRef: React.RefObject<HTMLInputElement | null>;
   onClose: () => void;
   onFullNameChange: (v: string) => void;
   onEmailChange: (v: string) => void;
   onEmailBlur: () => void;
+  onRoleChange: (v: 'shop_admin' | 'shop_staff') => void;
   onSubmit: () => void | Promise<void>;
   passwordField: React.ReactNode;
 };
+
+const ROLE_OPTIONS: { value: 'shop_admin' | 'shop_staff'; label: string; hint: string }[] = [
+  { value: 'shop_admin', label: 'Quản trị shop', hint: 'Toàn quyền quản lý dữ liệu shop' },
+  { value: 'shop_staff', label: 'Nhân viên shop', hint: 'Chỉ xem — không thể tạo/sửa/xóa' },
+];
 
 const AddMemberModal: React.FC<Props> = ({
   open,
@@ -27,12 +34,14 @@ const AddMemberModal: React.FC<Props> = ({
   memberFullName,
   memberEmail,
   memberEmailError,
+  memberRole,
   adding,
   memberEmailInputRef,
   onClose,
   onFullNameChange,
   onEmailChange,
   onEmailBlur,
+  onRoleChange,
   onSubmit,
   passwordField,
 }) => {
@@ -41,7 +50,7 @@ const AddMemberModal: React.FC<Props> = ({
   return (
     <div style={styles.modalOverlay} onClick={onClose}>
       <div style={styles.modal} onClick={(e) => e.stopPropagation()}>
-        <div style={styles.modalTitle}>Thêm quản trị shop</div>
+        <div style={styles.modalTitle}>Thêm thành viên shop</div>
 
         {memberError && <p style={styles.error}>{memberError}</p>}
         {memberSuccess && <p style={styles.success}>{memberSuccess}</p>}
@@ -87,6 +96,24 @@ const AddMemberModal: React.FC<Props> = ({
           />
         </div>
 
+        <div style={styles.formRow}>
+          <label style={styles.modalLabel} htmlFor={`member-role-${shopId}`}>
+            Vai trò <span style={{ color: '#b91c1c' }}>*</span>
+          </label>
+          <select
+            id={`member-role-${shopId}`}
+            style={{ ...styles.modalInput, cursor: 'pointer' }}
+            value={memberRole}
+            onChange={(e) => onRoleChange(e.target.value as 'shop_admin' | 'shop_staff')}
+          >
+            {ROLE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label} — {opt.hint}
+              </option>
+            ))}
+          </select>
+        </div>
+
         <div style={styles.formRow}>{passwordField}</div>
 
         <div style={styles.modalActions}>
@@ -94,7 +121,7 @@ const AddMemberModal: React.FC<Props> = ({
             Hủy
           </button>
           <button type="button" style={styles.modalConfirmBtn} onClick={onSubmit} disabled={adding}>
-            {adding ? 'Đang thêm...' : 'Thêm quản trị shop'}
+            {adding ? 'Đang thêm...' : 'Thêm thành viên'}
           </button>
         </div>
       </div>

--- a/frontend/src/pages/admin/shops/types.ts
+++ b/frontend/src/pages/admin/shops/types.ts
@@ -35,7 +35,9 @@ export interface ShopAuditLogRow {
     | 'set_member_active'
     | 'update_shop'
     | 'deactivate_shop'
-    | 'activate_shop';
+    | 'activate_shop'
+    | 'set_platform_role'
+    | 'set_shop_member_role';
   target_type: string;
   target_id: string | null;
   metadata: Record<string, unknown> | null;

--- a/frontend/tests/e2e/rbac.spec.ts
+++ b/frontend/tests/e2e/rbac.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * E2E: Phase 15 RBAC smoke tests
+ *
+ * Covers:
+ * 1. Platform user (platform_role = platform_super) sees "Quản lý shop" nav
+ * 2. Regular shop_admin does NOT see "Quản lý shop" nav
+ * 3. AddMemberModal renders role picker with shop_admin and shop_staff options
+ * 4. Role picker defaults to shop_admin
+ * 5. Role picker can be changed to shop_staff
+ */
+import { test, expect, apiOk, authMePayload, stubAuthCsrf, type Route } from './fixtures';
+import type { MockUser, MockShop } from './fixtures';
+
+// ---------------------------------------------------------------------------
+// Mock payloads
+// ---------------------------------------------------------------------------
+
+const PLATFORM_SHOP: MockShop = {
+  id: 'shop-platform',
+  name: 'Platform Shop',
+  slug: 'platform-shop',
+  is_active: true,
+  role: 'shop_admin',
+};
+
+const PLATFORM_USER: MockUser & { platform_role: string } = {
+  id: 'u-platform',
+  email: 'platform@example.com',
+  full_name: 'Platform Super',
+  role: 'admin',
+  platform_role: 'platform_super',
+  active_shop_id: 'shop-platform',
+  allowed_shop_ids: ['shop-platform'],
+  allowed_shops: [PLATFORM_SHOP],
+};
+
+const SHOP_ADMIN_USER: MockUser = {
+  id: 'u-shop-admin',
+  email: 'shopadmin@example.com',
+  full_name: 'Shop Admin',
+  role: 'admin',
+  active_shop_id: 'shop-platform',
+  allowed_shop_ids: ['shop-platform'],
+  allowed_shops: [PLATFORM_SHOP],
+};
+
+function mockShopsList(page: import('@playwright/test').Page) {
+  return page.route('**/api/v1/admin/shops', (route: Route) =>
+    route.fulfill({
+      json: apiOk([
+        {
+          id: 'shop-platform',
+          name: 'Platform Shop',
+          slug: 'platform-shop',
+          is_active: true,
+          _count: { items: 3, user_roles: 2 },
+        },
+      ]),
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('RBAC — platform role capability gate', () => {
+  test('platform_super user sees "Quản lý shop" nav link', async ({ page }) => {
+    await stubAuthCsrf(page);
+    await page.route('**/api/v1/auth/me', (route: Route) =>
+      route.fulfill({ json: authMePayload(PLATFORM_USER as unknown as MockUser) }),
+    );
+    await page.route('**/api/v1/reports/**', (route: Route) =>
+      route.fulfill({ json: apiOk({ total_items: 0, total_revenue: 0, items_by_status: [], revenue_trend: [] }) }),
+    );
+
+    await page.goto('/admin/reports');
+
+    await expect(page.getByRole('link', { name: /Quản lý shop/i })).toBeVisible();
+  });
+
+  test('shop_admin user (no platform_role) does NOT see "Quản lý shop" nav link', async ({ page }) => {
+    await stubAuthCsrf(page);
+    await page.route('**/api/v1/auth/me', (route: Route) =>
+      route.fulfill({ json: authMePayload(SHOP_ADMIN_USER) }),
+    );
+    await page.route('**/api/v1/reports/**', (route: Route) =>
+      route.fulfill({ json: apiOk({ total_items: 0, total_revenue: 0, items_by_status: [], revenue_trend: [] }) }),
+    );
+
+    await page.goto('/admin/reports');
+
+    await expect(page.getByRole('link', { name: /Quản lý shop/i })).not.toBeVisible();
+  });
+});
+
+test.describe('RBAC — AddMemberModal role picker', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubAuthCsrf(page);
+    await page.route('**/api/v1/auth/me', (route: Route) =>
+      route.fulfill({ json: authMePayload(PLATFORM_USER as unknown as MockUser) }),
+    );
+    await mockShopsList(page);
+    await page.route('**/api/v1/admin/shops/*/members', (route: Route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          json: apiOk({ members: [], pagination: { page: 1, page_size: 20, total: 0, total_pages: 1 } }),
+        });
+      }
+      return route.fulfill({ json: apiOk({ user_id: 'new-u', shop_id: 'shop-platform', role: 'shop_staff' }) });
+    });
+    await page.route('**/api/v1/admin/shops/*/items**', (route: Route) =>
+      route.fulfill({ json: apiOk({ items: [], pagination: { page: 1, page_size: 20, total: 0, total_pages: 1 } }) }),
+    );
+    await page.route('**/api/v1/admin/shops/*/audit-logs**', (route: Route) =>
+      route.fulfill({ json: apiOk({ logs: [], pagination: { page: 1, page_size: 20, total: 0, total_pages: 1 } }) }),
+    );
+    await page.route('**/api/v1/admin/shops/*', (route: Route) =>
+      route.fulfill({
+        json: apiOk({ id: 'shop-platform', name: 'Platform Shop', slug: 'platform-shop', is_active: true }),
+      }),
+    );
+  });
+
+  test('AddMemberModal shows role picker with shop_admin and shop_staff options', async ({ page }) => {
+    await page.goto('/admin/shops');
+
+    await page.getByRole('button', { name: /Thêm thành viên cho shop/i }).first().click();
+
+    const roleSelect = page.locator('select[id^="member-role-"]');
+    await expect(roleSelect).toBeVisible();
+    await expect(roleSelect.locator('option[value="shop_admin"]')).toHaveCount(1);
+    await expect(roleSelect.locator('option[value="shop_staff"]')).toHaveCount(1);
+  });
+
+  test('AddMemberModal defaults to shop_admin role', async ({ page }) => {
+    await page.goto('/admin/shops');
+
+    await page.getByRole('button', { name: /Thêm thành viên cho shop/i }).first().click();
+
+    const roleSelect = page.locator('select[id^="member-role-"]');
+    await expect(roleSelect).toHaveValue('shop_admin');
+  });
+
+  test('AddMemberModal can select shop_staff role', async ({ page }) => {
+    await page.goto('/admin/shops');
+
+    await page.getByRole('button', { name: /Thêm thành viên cho shop/i }).first().click();
+
+    const roleSelect = page.locator('select[id^="member-role-"]');
+    await roleSelect.selectOption('shop_staff');
+    await expect(roleSelect).toHaveValue('shop_staff');
+  });
+
+  test('AddMemberModal submit sends selected role in API payload', async ({ page }) => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    await page.route('**/api/v1/admin/shops/*/members', async (route: Route) => {
+      if (route.request().method() === 'POST') {
+        capturedBody = route.request().postDataJSON() as Record<string, unknown>;
+        return route.fulfill({ json: apiOk({ user_id: 'new-u', shop_id: 'shop-platform', role: 'shop_staff' }) });
+      }
+      return route.fulfill({
+        json: apiOk({ members: [], pagination: { page: 1, page_size: 20, total: 0, total_pages: 1 } }),
+      });
+    });
+
+    await page.goto('/admin/shops');
+    await page.getByRole('button', { name: /Thêm thành viên cho shop/i }).first().click();
+
+    const roleSelect = page.locator('select[id^="member-role-"]');
+    await roleSelect.selectOption('shop_staff');
+
+    await page.locator('input[type="email"]').fill('staff@example.com');
+    // Click the "Thêm thành viên" confirm button (last button in the modal)
+    await page.getByRole('button', { name: /^Thêm thành viên$/ }).click();
+
+    await page.waitForTimeout(500);
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody?.role).toBe('shop_staff');
+    expect(capturedBody?.email).toBe('staff@example.com');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Phase 15: Admin RBAC & Tenant Authorization

Tách quyền platform khỏi quyền theo shop, thêm `shop_staff` role, và đồng bộ API + admin UI.

---

### Tổng quan thay đổi

| Plan | Nội dung |
|------|---------|
| 15-01 | Schema: `PlatformRole` enum, `User.platform_role`, `ShopRole.shop_staff`, migration + backfill |
| 15-02 | Backend: dual-layer `RolesGuard`, `@PlatformRoles`, `shop_staff` read-only, shops DTO/service |
| 15-03 | Frontend: auth types, `isPlatformSuper`, `AddMemberModal` role picker |

---

### Concerns đã resolve

| Concern | Status | Commit |
|---------|--------|--------|
| `platform_role` đọc từ JWT cũ? | ✅ DB-loaded per request qua `validateUser()` | `eaa28cf` |
| Backfill scope — thiếu `is_active` filter? | ✅ `user_shop_roles` không có soft-delete; rows hard-delete on CASCADE | `ec86cce` |
| Legacy `@Roles(super_admin)` chưa migrate? | ✅ Tất cả đã chuyển sang `@PlatformRoles` | `ec86cce` |
| Cache không share giữa guard instances? | ✅ Cache đổi sang `static` process-wide | `ebd263e` |
| Cache không invalidate sau role mutation? | ✅ `RolesGuard.invalidateShopRolesCache()` được gọi sau `addShopAdmin` | `ebd263e` |
| Không có escape hatch cho staff write tương lai? | ✅ `@AllowStaffWrite()` decorator — opt-in per-route | `011ac06` |
| Thiếu `RolesGuard` trên các TenantGuard-only controllers? | ✅ Thêm vào `items`, `images`, `spinner`, `ai`, `ai-draft`, preorders write routes | `eaa28cf` |

---

### Kiến trúc `RolesGuard` (dual-layer)

```
Request → JwtAuthGuard → TenantGuard → RolesGuard
                                          │
                          @PlatformRoles? ├─ check user.platform_role (DB per-request)
                                          │
                             @Roles(...)? ├─ check UserShopRole membership
                                          │
                       shop_staff + write ├─ deny (unless @AllowStaffWrite())
                                          │
                                          └─ allow
```

### Test coverage

- **Backend**: 438/438 tests pass
- **Frontend build**: 0 TS errors
- **Frontend unit**: 55/55 tests pass
- **E2E Playwright** (`rbac.spec.ts`): 6/6 tests pass
  - Platform user thấy "Quản lý shop" nav
  - shop_admin không có platform_role không thấy nav
  - AddMemberModal hiện role picker
  - Default shop_admin, có thể chọn shop_staff
  - Submit gửi đúng role trong payload

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dev-z3g6024.slack.com/archives/D0B0H3R8B1U/p1777459426906109?thread_ts=1777459426.906109&cid=D0B0H3R8B1U)

<div><a href="https://cursor.com/agents/bc-1cdd76cc-4948-5a6f-b427-aa1153eafd25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cdd76cc-4948-5a6f-b427-aa1153eafd25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

