### PR TITLE
Phase 16: Per-shop public catalog (complete)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -24,7 +24,10 @@ A seller can create and publish a diecast listing with complete media and ready-
 - [ ] Pre-order lifecycle management (Issue #13, Phase 9)
 - [ ] Transaction-based inventory with audit trail (Issue #46, Phase 8)
 - [ ] Reporting and analytics dashboard (Issue #49, Phase 10)
-- [ ] Per-shop public homepage and catalog URLs (Phase 16 — PBLC-03)
+
+### Completed (milestone note)
+
+- [x] Per-shop public homepage and catalog URLs (Phase 16 — PBLC-03)
 
 ### Out of Scope
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -20,7 +20,7 @@
 
 - [x] **PBLC-01**: Visitor can browse public items and open item detail pages.
 - [x] **PBLC-02**: Public item detail shows cover/status and spinner when available.
-- [ ] **PBLC-03**: Public catalog and item URLs resolve to a single shop tenant (slug or id); visitors cannot infer or list other shops' inventory from public endpoints when shop context is set.
+- [x] **PBLC-03**: Public catalog and item URLs resolve to a single shop tenant (slug or id); visitors cannot infer or list other shops' inventory from public endpoints when shop context is set.
 
 ### AI and Social
 
@@ -41,7 +41,7 @@
 - [x] **MULT-01**: System supports multiple isolated shop tenants with distinct inventory, media, and settings.
 - [x] **MULT-02**: Admin users can be assigned to one or more shops with role-based access.
 - [x] **MULT-03**: API requests are scoped to the active tenant via header or token context.
-- [ ] **MULT-04**: Platform operators are distinguished from per-shop roles; tenant staff roles support read vs write separation without breaking isolation.
+- [x] **MULT-04**: Platform operators are distinguished from per-shop roles; tenant staff roles support read vs write separation without breaking isolation.
 
 ### UX and Operations
 
@@ -84,7 +84,7 @@
 | MEDI-03 | Phase 3 | Complete (2026-03-10) |
 | PBLC-01 | Phase 3 | Complete (2026-03-10) |
 | PBLC-02 | Phase 3 | Complete (2026-03-10) |
-| PBLC-03 | Phase 16 | Pending |
+| PBLC-03 | Phase 16 | Complete (2026-04-30) |
 | AISO-01 | Phase 4 | Complete (2026-03-13) |
 | AISO-02 | Phase 4 | Complete (2026-03-13) |
 | AISO-03 | Phase 4 | Complete (2026-03-13) |
@@ -97,7 +97,7 @@
 | MULT-01 | Phase 14 | Complete (2026-03-23) |
 | MULT-02 | Phase 14 | Complete (2026-03-23) |
 | MULT-03 | Phase 14 | Complete (2026-03-23) |
-| MULT-04 | Phase 15 | Pending |
+| MULT-04 | Phase 15 | Complete |
 | STOK-01 | Phase 8 | Pending |
 | PORD-01 | Phase 9 | Pending |
 | PORD-01a | Phase 9 | Pending |
@@ -118,4 +118,4 @@
 
 ---
 *Requirements defined: 2026-03-04*
-*Last updated: 2026-04-08 after docs normalization*
+*Last updated: 2026-04-30 — PBLC-03 closed with Phase 16*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -177,7 +177,7 @@ Plans:
 | 13. Issue #33 - Playwright Phase 2 | 3/3 | Complete | 2026-04-29 |
 | 14. Multi-Tenant Shop | 3/3 | Complete | 2026-03-23 |
 | 15. Admin RBAC & Tenant Authorization | 3/3 | Complete | 2026-04-29 |
-| 16. Per-Shop Public Homepage | 0/3 | Planned | — |
+| 16. Per-Shop Public Homepage | 1/3 | In Progress | — |
 
 ## Execution Update (2026-03-04)
 
@@ -339,10 +339,10 @@ Plans:
 **Goal:** Public visitors always see catalog and item detail scoped to exactly one shop; shareable URLs identify the shop without relying on admin JWT `active_shop_id`.
 **Requirements:** PBLC-03, MULT-01, MULT-03
 **Depends on:** Phase 14 (multi-tenant foundation); coordinates with Phase 15 only if public resolution must respect new platform vs shop role semantics (prefer no hard dependency).
-**Plans:** 3 plans
+**Plans:** 1/3 plans executed
 
 Plans:
-- [ ] 16-01: Backend — optional `shop_id` on public item list/detail; resolve by UUID or `Shop.slug`; 404 for unknown/inactive shop; tests + contract docs
+- [x] 16-01: Backend — optional `shop_id` on public item list/detail; resolve by UUID or `Shop.slug`; 404 for unknown/inactive shop; tests + contract docs
 - [ ] 16-02: Frontend — route or query resolution for shop context; catalog + detail + deep links preserve `shop_id`; optional default shop env for single-tenant deploys
 - [ ] 16-03: E2E + regression — Playwright scenarios for two shops, cross-tenant negative case, link builder smoke for public nav
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -21,7 +21,7 @@ This roadmap organizes Diecast360 delivery from core product foundations to oper
 - [x] **Phase 13: Issue #33 - Playwright Phase 2** - Extended E2E coverage and quality-gate hardening. *(2026-04-29)*
 - [x] **Phase 14: Multi-Tenant Shop** - Support multiple isolated diecast shops on a single deployment with scoped access.
 - [x] **Phase 15: Admin RBAC & Tenant Authorization** - Separate platform operator permissions from per-shop roles; extend shop roles (e.g. read-only staff) and align API + admin UI.
-- [ ] **Phase 16: Per-Shop Public Homepage** - Resolve public catalog and item detail to a single shop tenant via URL or explicit query param, aligned with existing multi-tenant isolation.
+- [x] **Phase 16: Per-Shop Public Homepage** - Resolve public catalog and item detail to a single shop tenant via URL or explicit query param, aligned with existing multi-tenant isolation. (completed 2026-04-30)
 
 ## Phase Details
 
@@ -177,7 +177,7 @@ Plans:
 | 13. Issue #33 - Playwright Phase 2 | 3/3 | Complete | 2026-04-29 |
 | 14. Multi-Tenant Shop | 3/3 | Complete | 2026-03-23 |
 | 15. Admin RBAC & Tenant Authorization | 3/3 | Complete | 2026-04-29 |
-| 16. Per-Shop Public Homepage | 1/3 | In Progress | — |
+| 16. Per-Shop Public Homepage | 3/3 | Complete | 2026-04-30 |
 
 ## Execution Update (2026-03-04)
 
@@ -305,7 +305,7 @@ Implemented in codebase for Phase 13:
 ## Remaining Work Snapshot (By Phase)
 
 Phases not yet complete and pending tasks:
-- Phase 16: Per-Shop Public Homepage — plans authored; execution pending (`16-01` through `16-03`).
+- None (Phase 16 shipped 2026-04-30).
 
 Partially executed phases (still pending full completion):
 - None.
@@ -339,12 +339,12 @@ Plans:
 **Goal:** Public visitors always see catalog and item detail scoped to exactly one shop; shareable URLs identify the shop without relying on admin JWT `active_shop_id`.
 **Requirements:** PBLC-03, MULT-01, MULT-03
 **Depends on:** Phase 14 (multi-tenant foundation); coordinates with Phase 15 only if public resolution must respect new platform vs shop role semantics (prefer no hard dependency).
-**Plans:** 1/3 plans executed
+**Plans:** 3/3 plans complete
 
 Plans:
 - [x] 16-01: Backend — optional `shop_id` on public item list/detail; resolve by UUID or `Shop.slug`; 404 for unknown/inactive shop; tests + contract docs
-- [ ] 16-02: Frontend — route or query resolution for shop context; catalog + detail + deep links preserve `shop_id`; optional default shop env for single-tenant deploys
-- [ ] 16-03: E2E + regression — Playwright scenarios for two shops, cross-tenant negative case, link builder smoke for public nav
+- [x] 16-02: Frontend — route or query resolution for shop context; catalog + detail + deep links preserve `shop_id`; optional default shop env for single-tenant deploys
+- [x] 16-03: E2E + regression — Playwright scenarios for two shops, cross-tenant negative case, link builder smoke for public nav
 
 ## Execution Update (2026-04-20) — Security / media follow-up (ngoài số phase)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,14 +5,14 @@
 See: .planning/PROJECT.md (updated 2026-03-04)
 
 **Core value:** A seller can publish a diecast listing with complete media and ready-to-post content in one flow.
-**Current focus:** Phase 15 (Admin RBAC & Tenant Authorization) shipped 2026-04-29; Phase 16 (Per-Shop Public Homepage) planned and ready to execute.
+**Current focus:** Phase 16 (Per-Shop Public Homepage) in progress; plan 16-01 complete.
 
 ## Current Position
 
-Phase: **15 complete** → **16 next** (per-shop public catalog/homepage, PBLC-03)
-Plan: Phase 15 **đã hoàn thành** (15-01, 15-02, 15-03)
-Status: Phase 15 complete (2026-04-29). Platform RBAC, shop_staff role, dual-layer guard, modal role picker.
-Last activity: 2026-04-29 — PlatformRole schema+migration, RolesGuard Option C, @PlatformRoles decorator, frontend platform gates.
+Phase: **16 in progress** (per-shop public catalog — PBLC-03)
+Plan: **16-01 complete** → **16-02 next**
+Status: Wave 1 backend shipped; frontend wiring pending.
+Last activity: 2026-04-30 — Public API optional `shop_id`, resolver, contract docs.
 
 Progress: [##########] 100% (roadmap)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,18 +1,31 @@
+---
+gsd_state_version: 1.0
+milestone: v1.0
+milestone_name: milestone
+status: complete
+last_updated: "2026-04-30T12:00:00.000Z"
+progress:
+  total_phases: 16
+  completed_phases: 16
+  total_plans: 36
+  completed_plans: 21
+---
+
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-03-04)
+See: .planning/PROJECT.md (updated 2026-04-30)
 
 **Core value:** A seller can publish a diecast listing with complete media and ready-to-post content in one flow.
-**Current focus:** Phase 16 (Per-Shop Public Homepage) in progress; plan 16-01 complete.
+**Current focus:** Phase 16 (Per-Shop Public Homepage) **complete** 2026-04-30; no further phases in v1.0 roadmap after 16.
 
 ## Current Position
 
-Phase: **16 in progress** (per-shop public catalog — PBLC-03)
-Plan: **16-01 complete** → **16-02 next**
-Status: Wave 1 backend shipped; frontend wiring pending.
-Last activity: 2026-04-30 — Public API optional `shop_id`, resolver, contract docs.
+Phase: **16 complete** (per-shop public catalog / PBLC-03)
+Plan: **16-01, 16-02, 16-03** all delivered
+Status: Backend `shop_id` resolution, frontend `usePublicShopContext` + nav, Playwright multi-tenant catalog E2E, verification doc in phase folder.
+Last activity: 2026-04-30 — closed Phase 16, updated ROADMAP / REQUIREMENTS / PROJECT.
 
 Progress: [##########] 100% (roadmap)
 
@@ -53,6 +66,7 @@ Progress: [##########] 100% (roadmap)
 - (2026-04-24) Completed Phase 12 Playwright baseline: shared fixture layer (`fixtures/index.ts`), auth/items/public-catalog smoke specs (10 passing E2E tests total with 32 across full suite), CI Playwright report artifact upload on failure, HTML reporter, QA workflow docs.
 - (2026-04-29) Completed Phase 13: advanced Playwright specs (`spinner`, `social-selling`, `responsive`), CI runner tuning (retries/workers), E2E triage notes in `docs/TODO.md`, `stubAuthCsrf` helper for admin mocks.
 - (2026-04-29) Completed Phase 15: PlatformRole enum + User.platform_role migration+backfill; dual-layer RolesGuard (platform_role check + shop_staff HTTP-method enforcement — Option C); @PlatformRoles decorator; AddShopAdminDto extended with role field; frontend isPlatformSuper + useIsSuperAdmin updated; AddMemberModal role picker (shop_admin/shop_staff); audit labels for new actions.
+- (2026-04-30) **Phase 16:** Public catalog/detail accept optional `shop_id` (UUID or slug); explicit query overrides JWT for reads; frontend propagates `shop_id` via URL, `VITE_PUBLIC_CATALOG_SHOP_ID`, or JWT after auth settles (`shopContextReady`); Playwright two-shop mock proves UI isolation.
 
 ### Pending Todos
 
@@ -64,6 +78,6 @@ Progress: [##########] 100% (roadmap)
 
 ## Session Continuity
 
-Last session: 2026-04-29 (Phase 15 Admin RBAC & Tenant Authorization)
-Stopped at: Phase 15 complete; all 15 roadmap phases done
-Resume file: `.planning/phases/15-admin-rbac-tenant-refinement/15-03-PLAN.md`
+Last session: 2026-04-30 (Phase 16 Per-Shop Public Homepage — complete)
+Stopped at: **All roadmap phases through 16 shipped**; next work is product backlog / Phase 9+ items outside current roadmap numbering.
+Resume file: `.planning/phases/16-per-shop-public-homepage/16-VERIFICATION.md`

--- a/.planning/phases/16-per-shop-public-homepage/16-01-SUMMARY.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-01-SUMMARY.md
@@ -1,0 +1,75 @@
+---
+phase: 16-per-shop-public-homepage
+plan: 01
+subsystem: api
+tags: [nest, prisma, multi-tenant, public-api]
+
+requires:
+  - phase: 14-multi-tenant-shop
+    provides: Shop model, slug, is_active, tenant concepts
+provides:
+  - Public GET /public/items and /public/items/:id accept optional shop_id (UUID or exact slug) for active shops; explicit param overrides JWT active_shop_id
+  - PublicShopResolverService + API contract documentation
+affects: [16-02, 16-03]
+
+tech-stack:
+  added: []
+  patterns: [Explicit public shop context via query string before JWT tenant fallback]
+
+key-files:
+  created:
+    - backend/src/public/public-shop-resolver.service.ts
+    - backend/src/public/public.controller.spec.ts
+    - backend/src/public/public-shop-resolver.service.spec.ts
+  modified:
+    - backend/src/public/public.controller.ts
+    - backend/src/public/public.module.ts
+    - backend/src/public/dto/query-public-items.dto.ts
+    - backend/src/public/dto/query-public-items.dto.spec.ts
+    - backend/src/public/public.service.spec.ts
+    - docs/API_CONTRACT.md
+
+key-decisions:
+  - "Slug match is case-sensitive and exact; invalid or inactive shop returns NOT_FOUND with message 'Shop not found'"
+
+patterns-established:
+  - "resolveCanonicalShopId(raw) returns null to mean fall back to JWT; non-null means single effective shop filter"
+
+requirements-completed: [PBLC-03, MULT-01, MULT-03]
+
+duration: 30min
+completed: 2026-04-30
+---
+
+# Phase 16 Plan 01 Summary
+
+**Optional `shop_id` on public item list/detail resolves to an active shop (UUID or slug) and overrides JWT for catalog scoping; unknown shops return 404.**
+
+## Performance
+
+- **Duration:** ~30 min
+- **Tasks:** 3
+- **Files modified:** 10
+
+## Accomplishments
+
+- Added `PublicShopResolverService` (Prisma lookup by id or slug, `is_active: true` only).
+- Extended `QueryPublicItemsDto` with `shop_id`; `findOne` reads `@Query('shop_id')`.
+- Documented behavior in `docs/API_CONTRACT.md` and added unit coverage (resolver, controller, DTO, service cross-tenant detail).
+
+## Task Commits
+
+1. **Task 1: DTO + resolver** — `702002f` (feat)
+2. **Task 2–3: Controller + contract + tests** — `d86ed2a` (feat)
+
+## Deviations from Plan
+
+None — plan executed as written.
+
+## Next Phase Readiness
+
+Backend contract is ready for frontend to pass `shop_id` on all public catalog and detail requests (16-02).
+
+---
+*Phase: 16-per-shop-public-homepage*
+*Completed: 2026-04-30*

--- a/.planning/phases/16-per-shop-public-homepage/16-02-SUMMARY.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-02-SUMMARY.md
@@ -1,0 +1,59 @@
+---
+phase: 16-per-shop-public-homepage
+plan: 02
+subsystem: ui
+tags: [react-router, react-query, vite, multi-tenant]
+
+requires:
+  - phase: 16-per-shop-public-homepage
+    provides: Backend accepts shop_id on GET /public/items
+provides:
+  - usePublicShopContext hook (query → VITE_PUBLIC_CATALOG_SHOP_ID → JWT active_shop_id)
+  - Catalog URL state preserves shop_id; catalog/detail/API calls append shop_id
+  - Layout public nav preserves shop_id across routes
+affects: [16-03]
+
+tech-stack:
+  added: []
+  patterns: [Same precedence as PreOrdersPage for shop resolution]
+
+key-files:
+  created:
+    - frontend/src/hooks/usePublicShopContext.ts
+    - frontend/src/api/config.ts
+  modified:
+    - frontend/src/config/api.ts
+    - frontend/src/pages/publicCatalogUrlState.ts
+    - frontend/src/pages/PublicCatalogPage.tsx
+    - frontend/src/pages/PublicItemDetailPage.tsx
+    - frontend/src/components/catalog/ItemCard.tsx
+    - frontend/src/components/Layout.tsx
+    - frontend/.env.example
+
+key-decisions:
+  - "Back navigates to catalog home with current query string so shop_id is preserved"
+
+patterns-established:
+  - "effectiveShopId in React Query keys for public-items and public-item"
+
+requirements-completed: [PBLC-03, MULT-03]
+
+duration: 40min
+completed: 2026-04-30
+---
+
+# Phase 16 Plan 02 Summary
+
+**Public catalog and detail use a shared `effectiveShopId` (URL, env default, then JWT) and pass `shop_id` on all public item API calls; nav and item links keep the param.**
+
+## Task Commits
+
+1. **Implementation** — (this commit) feat(frontend): per-shop public catalog context (16-02)
+
+## Deviations from Plan
+
+None.
+
+---
+*Phase: 16-per-shop-public-homepage*
+*Completed: 2026-04-30*

--- a/.planning/phases/16-per-shop-public-homepage/16-03-SUMMARY.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-03-SUMMARY.md
@@ -1,0 +1,54 @@
+---
+phase: 16-per-shop-public-homepage
+plan: 03
+subsystem: testing
+tags: [playwright, e2e, multi-tenant, public-catalog]
+
+requires:
+  - phase: 16-per-shop-public-homepage
+    provides: Backend shop_id + frontend wiring from 16-01 and 16-02
+provides:
+  - Playwright mock keyed by shop_id with negative assertions across shop A / shop B
+  - Regression cases for aggregate catalog without shop_id and nav preorder link with shop_id
+affects: []
+
+tech-stack:
+  added: []
+  patterns: [Route handler parses URLSearchParams for shop_id to fulfill tenant-specific fixtures]
+
+key-files:
+  created: []
+  modified:
+    - frontend/tests/e2e/public-catalog.spec.ts
+
+key-decisions:
+  - "Inactive slug / NOT_FOUND covered at resolver unit tests (16-01); no duplicate service-layer tests required"
+
+patterns-established: []
+
+requirements-completed: [PBLC-03, MULT-01]
+
+duration: 25min
+completed: 2026-04-30
+---
+
+# Phase 16 Plan 03 Summary
+
+**Playwright mocks `/api/v1/public/items` by `shop_id` so shop A never renders shop B titles; smoke paths without `shop_id` and preorder nav link preserve regression.**
+
+## Verification commands run
+
+- `cd frontend && pnpm exec playwright install chromium` (once per environment missing browsers)
+- `cd frontend && pnpm exec playwright test public-catalog.spec.ts --reporter=line` → **9 passed**
+- `cd backend && npx jest src/public/` → **pass** (resolver + service coverage from phase)
+
+## Task commits
+
+Documented in repo commit completing this summary.
+
+## Backend regression slice
+
+Slug case-sensitivity and inactive shop → NOT_FOUND are asserted in `public-shop-resolver.service.spec.ts` (16-01); no additional `public.service.spec.ts` duplication.
+
+---
+*Phase: 16-per-shop-public-homepage · Completed: 2026-04-30*

--- a/.planning/phases/16-per-shop-public-homepage/16-VERIFICATION.md
+++ b/.planning/phases/16-per-shop-public-homepage/16-VERIFICATION.md
@@ -1,0 +1,39 @@
+---
+phase: 16-per-shop-public-homepage
+status: passed
+date: 2026-04-30
+---
+
+# Phase 16 Verification Report
+
+## Scope
+
+Per-shop public catalog: optional `shop_id` on API and client; URL/env/JWT precedence; E2E proving isolation under mocked API.
+
+## Automated checks
+
+| Command | Result |
+|---------|--------|
+| `cd backend && npx jest src/public/` | Pass |
+| `cd frontend && pnpm exec tsc --noEmit` | Pass |
+| `cd frontend && pnpm run build` | Pass |
+| `cd frontend && pnpm exec vitest run` | Pass |
+| `cd frontend && pnpm exec playwright test public-catalog.spec.ts --reporter=line` | **9 passed** (requires `pnpm exec playwright install chromium` locally if browsers missing) |
+
+## Must-haves verified
+
+- With `?shop_id=shop-a`, UI shows shop A fixture titles and **does not** show shop B exclusive title.
+- With `?shop_id=shop-b`, converse holds.
+- Without `shop_id`, aggregate fixture still renders (legacy deployment behavior).
+- Preorder nav link on catalog preserves `shop_id` query.
+
+## Requirements
+
+- **PBLC-03**: Satisfied for API + UX when shop context is set; aggregate-without-context documented in API contract.
+- **MULT-01 / MULT-03**: Public read path honors explicit shop scope without JWT overriding query.
+- **QATE-02**: Additional Playwright coverage for per-shop public catalog (`public-catalog.spec.ts`). Organization-wide “release gate” enforcement remains as defined in CI / Phase 13 scope.
+
+## Residual risks / notes
+
+- E2E uses mocked responses (does not hit live Postgres); integration truth remains backend resolver + Prisma.
+- Full Playwright suite not re-run in this report slice; CI should run full `tests/e2e` job.

--- a/backend/src/public/dto/query-public-items.dto.spec.ts
+++ b/backend/src/public/dto/query-public-items.dto.spec.ts
@@ -60,4 +60,20 @@ describe('QueryPublicItemsDto', () => {
 
     expect(errors).toHaveLength(0);
   });
+
+  it('should accept optional shop_id (uuid or slug)', async () => {
+    const errorsUuid = await validateDto({
+      shop_id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+    });
+    const errorsSlug = await validateDto({ shop_id: 'my-shop-slug' });
+
+    expect(errorsUuid).toHaveLength(0);
+    expect(errorsSlug).toHaveLength(0);
+  });
+
+  it('should reject shop_id longer than 200 chars', async () => {
+    const errors = await validateDto({ shop_id: 's'.repeat(201) });
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
 });

--- a/backend/src/public/dto/query-public-items.dto.ts
+++ b/backend/src/public/dto/query-public-items.dto.ts
@@ -24,6 +24,12 @@ export class QueryPublicItemsDto {
   @MaxLength(200)
   q?: string;
 
+  /** Optional shop scope: UUID (`Shop.id`) or exact `Shop.slug` for active shops only. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  shop_id?: string;
+
   @IsOptional()
   @IsString()
   @MaxLength(100)

--- a/backend/src/public/public-shop-resolver.service.spec.ts
+++ b/backend/src/public/public-shop-resolver.service.spec.ts
@@ -1,0 +1,66 @@
+import { PublicShopResolverService } from './public-shop-resolver.service';
+import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
+
+describe('PublicShopResolverService', () => {
+  let service: PublicShopResolverService;
+  const prisma = {
+    shop: {
+      findFirst: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PublicShopResolverService(prisma as never);
+  });
+
+  it('returns null when shop_id is omitted or blank', async () => {
+    await expect(service.resolveCanonicalShopId(undefined)).resolves.toBeNull();
+    await expect(service.resolveCanonicalShopId('   ')).resolves.toBeNull();
+    expect(prisma.shop.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('resolves active shop by UUID', async () => {
+    const id = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+    prisma.shop.findFirst.mockResolvedValue({ id });
+
+    await expect(service.resolveCanonicalShopId(id)).resolves.toBe(id);
+    expect(prisma.shop.findFirst).toHaveBeenCalledWith({
+      where: { id, is_active: true },
+      select: { id: true },
+    });
+  });
+
+  it('resolves active shop by exact slug (case-sensitive)', async () => {
+    prisma.shop.findFirst.mockResolvedValue({ id: 'shop-uuid-1' });
+
+    await expect(service.resolveCanonicalShopId('my-store')).resolves.toBe('shop-uuid-1');
+    expect(prisma.shop.findFirst).toHaveBeenCalledWith({
+      where: { slug: 'my-store', is_active: true },
+      select: { id: true },
+    });
+  });
+
+  it('throws NOT_FOUND for unknown shop', async () => {
+    prisma.shop.findFirst.mockResolvedValue(null);
+
+    try {
+      await service.resolveCanonicalShopId('nope');
+      throw new Error('expected NOT_FOUND');
+    } catch (e) {
+      if (e instanceof Error && e.message === 'expected NOT_FOUND') {
+        throw e;
+      }
+      expect(e).toBeInstanceOf(AppException);
+      expect((e as AppException).errorCode).toBe(ErrorCode.NOT_FOUND);
+    }
+  });
+
+  it('throws NOT_FOUND when shop is inactive (not returned by query)', async () => {
+    prisma.shop.findFirst.mockResolvedValue(null);
+
+    await expect(service.resolveCanonicalShopId('inactive-slug')).rejects.toBeInstanceOf(
+      AppException,
+    );
+  });
+});

--- a/backend/src/public/public-shop-resolver.service.ts
+++ b/backend/src/public/public-shop-resolver.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { isUUID } from 'class-validator';
+import { PrismaService } from '../common/prisma/prisma.service';
+import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
+
+/**
+ * Resolves public catalog `shop_id` query (UUID or Shop.slug) to a canonical shop UUID.
+ * Only active shops are served; unknown/inactive → NOT_FOUND.
+ */
+@Injectable()
+export class PublicShopResolverService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * When the client omits `shop_id`, returns null (caller falls back to JWT `active_shop_id`).
+   * When present, returns the shop UUID; explicit query overrides JWT for public reads.
+   */
+  async resolveCanonicalShopId(raw: string | undefined): Promise<string | null> {
+    const trimmed = raw?.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const shop = isUUID(trimmed)
+      ? await this.prisma.shop.findFirst({
+          where: { id: trimmed, is_active: true },
+          select: { id: true },
+        })
+      : await this.prisma.shop.findFirst({
+          where: { slug: trimmed, is_active: true },
+          select: { id: true },
+        });
+
+    if (!shop) {
+      throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
+    }
+
+    return shop.id;
+  }
+}

--- a/backend/src/public/public.controller.spec.ts
+++ b/backend/src/public/public.controller.spec.ts
@@ -1,0 +1,55 @@
+import { PublicController } from './public.controller';
+import { PublicService } from './public.service';
+import { PublicShopResolverService } from './public-shop-resolver.service';
+import { QueryPublicItemsDto } from './dto/query-public-items.dto';
+
+describe('PublicController', () => {
+  const publicService = {
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+  };
+  const resolver = {
+    resolveCanonicalShopId: jest.fn(),
+  };
+
+  const controller = new PublicController(
+    publicService as unknown as PublicService,
+    resolver as unknown as PublicShopResolverService,
+  );
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('uses explicit shop_id over JWT active_shop_id for list', async () => {
+    resolver.resolveCanonicalShopId.mockResolvedValue('shop-from-query');
+    publicService.findAll.mockResolvedValue({ items: [], pagination: {} });
+
+    const req = { user: { active_shop_id: 'shop-from-jwt' } } as never;
+    await controller.findAll({} as QueryPublicItemsDto, req);
+
+    expect(publicService.findAll).toHaveBeenCalledWith(
+      {},
+      'shop-from-query',
+    );
+  });
+
+  it('falls back to JWT when shop_id query is absent', async () => {
+    resolver.resolveCanonicalShopId.mockResolvedValue(null);
+    publicService.findAll.mockResolvedValue({ items: [], pagination: {} });
+
+    const req = { user: { active_shop_id: 'shop-jwt' } } as never;
+    await controller.findAll({} as QueryPublicItemsDto, req);
+
+    expect(publicService.findAll).toHaveBeenCalledWith({}, 'shop-jwt');
+  });
+
+  it('uses explicit shop_id over JWT for detail', async () => {
+    resolver.resolveCanonicalShopId.mockResolvedValue('shop-a');
+    publicService.findOne.mockResolvedValue({ item: {} });
+
+    const req = { user: { active_shop_id: 'shop-b' } } as never;
+    await controller.findOne('item-1', 'my-slug', req);
+
+    expect(resolver.resolveCanonicalShopId).toHaveBeenCalledWith('my-slug');
+    expect(publicService.findOne).toHaveBeenCalledWith('item-1', 'shop-a');
+  });
+});

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -1,26 +1,36 @@
 import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
 import { Request } from 'express';
 import { PublicService } from './public.service';
+import { PublicShopResolverService } from './public-shop-resolver.service';
 import { QueryPublicItemsDto } from './dto/query-public-items.dto';
 import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 
 @Controller('public')
 export class PublicController {
-  constructor(private readonly publicService: PublicService) {}
+  constructor(
+    private readonly publicService: PublicService,
+    private readonly publicShopResolver: PublicShopResolverService,
+  ) {}
 
   @Get('items')
   @UseGuards(OptionalJwtAuthGuard)
-  findAll(@Query() queryDto: QueryPublicItemsDto, @Req() req: Request) {
+  async findAll(@Query() queryDto: QueryPublicItemsDto, @Req() req: Request) {
     const user = req.user as { active_shop_id?: string | null } | undefined;
-    const tenantId = user?.active_shop_id ?? null;
+    const explicitShopId = await this.publicShopResolver.resolveCanonicalShopId(queryDto.shop_id);
+    const tenantId = explicitShopId ?? user?.active_shop_id ?? null;
     return this.publicService.findAll(queryDto, tenantId);
   }
 
   @Get('items/:id')
   @UseGuards(OptionalJwtAuthGuard)
-  findOne(@Param('id') id: string, @Req() req: Request) {
+  async findOne(
+    @Param('id') id: string,
+    @Query('shop_id') shopId: string | undefined,
+    @Req() req: Request,
+  ) {
     const user = req.user as { active_shop_id?: string | null } | undefined;
-    const tenantId = user?.active_shop_id ?? null;
+    const explicitShopId = await this.publicShopResolver.resolveCanonicalShopId(shopId);
+    const tenantId = explicitShopId ?? user?.active_shop_id ?? null;
     return this.publicService.findOne(id, tenantId);
   }
 }

--- a/backend/src/public/public.module.ts
+++ b/backend/src/public/public.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { PublicService } from './public.service';
+import { PublicShopResolverService } from './public-shop-resolver.service';
 import { PublicController } from './public.controller';
 import { PrismaModule } from '../common/prisma/prisma.module';
 import { StorageModule } from '../storage/storage.module';
@@ -7,7 +8,7 @@ import { StorageModule } from '../storage/storage.module';
 @Module({
   imports: [PrismaModule, StorageModule],
   controllers: [PublicController],
-  providers: [PublicService],
+  providers: [PublicService, PublicShopResolverService],
 })
 export class PublicModule {}
 

--- a/backend/src/public/public.service.spec.ts
+++ b/backend/src/public/public.service.spec.ts
@@ -321,6 +321,12 @@ describe('PublicService', () => {
       expect(findFirstCall.where.shop_id).toBeUndefined();
     });
 
+    it('should return NOT_FOUND when item exists in another shop than tenantId', async () => {
+      prisma.item.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne('item-1', 'other-shop-tenant')).rejects.toThrow(AppException);
+    });
+
     it('should scope item lookup by tenant when tenantId is provided', async () => {
       prisma.item.findFirst.mockResolvedValue(null);
 

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -392,14 +392,20 @@ Các route dưới đây yêu cầu JWT đã gắn **active shop** (`active_shop
 
 ## Public
 ### GET /api/v1/public/items
-- Query: `page`, `page_size`, `status` (optional), `q`.
-- Chỉ trả item `is_public=true` và chưa soft delete.
-- Response 200: `data: { items: Item[], pagination }` (kèm `has_spinner` và `cover_image_url`).
+- Query: `page`, `page_size`, `status` (optional), `q`, và các filter catalog khác như contract admin/public đã liệt kê.
+- **`shop_id` (optional):** giới hạn catalog theo một shop. Giá trị hợp lệ:
+  - UUID của `Shop.id`, hoặc
+  - Chuỗi **khớp chính xác** `Shop.slug` (phân biệt hoa thường).
+- Shop phải `is_active: true`. Slug/UUID không tồn tại hoặc shop không active → **`NOT_FOUND (404)`**, message ổn định (ví dụ shop không tìm thấy).
+- **Ưu tiên:** Nếu request có `shop_id` hợp lệ, server **bỏ qua** `active_shop_id` từ JWT khi lọc catalog (tránh lệch tenant khi admin đang switch shop trong cùng trình duyệt).
+- **Khi bỏ qua `shop_id`:** Hành vi như trước: nếu có JWT với `active_shop_id` thì lọc theo shop đó; nếu không (khách) thì trả **toàn bộ** item public trên deployment (aggregate). Single-tenant / dev có thể dùng biến frontend `VITE_PUBLIC_CATALOG_SHOP_ID` để luôn gửi `shop_id` (xem Phase 16 frontend).
 
 ### GET /api/v1/public/items/:id
+- Query: **`shop_id` (optional)** — cùng quy tắc như `GET /public/items` (UUID hoặc slug, shop active, 404 nếu không resolve được).
+- **Ưu tiên** giống list: `shop_id` query ghi đè `active_shop_id` của JWT cho việc lọc theo shop.
 - Response 200: `data: { item, images: ItemImage[], spinner: SpinSet|null }`.
 - `spinner` lấy spin set default (nếu có). Nếu `null` → client dùng gallery ảnh thường.
-- Errors: `NOT_FOUND (404)`.
+- Errors: `NOT_FOUND (404)` khi item không tồn tại, không public, đã xóa mềm, hoặc **không thuộc shop** đã chọn khi đang lọc theo shop.
 
 ## Pre-orders (planned - Phase 9, MVP scope)
 Ghi chu: nhom endpoint nay la ke hoach de trien khai MVP pre-order, chua mac dinh la da ton tai trong codebase hien tai.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,5 @@ VITE_API_BASE_URL=http://localhost:3000/api/v1
 VITE_ADMIN_SEMANTIC_SEARCH_ENABLED=false
 # Optional: default shop for public /preorders when visitor has no ?shop_id= and is not logged in
 VITE_PUBLIC_PREORDER_SHOP_ID=
+# Optional: default shop for public catalog (/) when no ?shop_id= in URL (single-tenant deploys)
+VITE_PUBLIC_CATALOG_SHOP_ID=

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -1,0 +1,7 @@
+import { API_CONFIG } from '../config/api';
+import { sanitizeShopIdQueryParam } from '../utils/sanitizeShopId';
+
+/** Build-time default for public catalog scope (see `VITE_PUBLIC_CATALOG_SHOP_ID`). */
+export function getPublicCatalogShopIdFromEnv(): string {
+  return sanitizeShopIdQueryParam(API_CONFIG.PUBLIC_CATALOG_SHOP_ID);
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   ChartNoAxesColumn,
@@ -22,6 +22,7 @@ import {
   isAdminPreordersHubActive,
 } from '../config/routes';
 import { cn } from '../lib/utils';
+import { usePublicShopContext } from '../hooks/usePublicShopContext';
 import ShopSelector from './admin/ShopSelector';
 
 interface LayoutProps {
@@ -46,10 +47,19 @@ export const Layout = ({ children }: LayoutProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, logout } = useAuth();
+  const { effectiveShopId, shopContextReady } = usePublicShopContext();
   const isAdmin = location.pathname.startsWith('/admin');
   const isSuperAdmin = useIsSuperAdmin();
   const [menuState, setMenuState] = useState({ open: false, pathname: location.pathname });
   const isMenuOpen = menuState.open && menuState.pathname === location.pathname;
+
+  /** Same resolution as catalog (query / env / JWT), not only current URL — keeps nav aligned with VITE_PUBLIC_CATALOG_SHOP_ID. */
+  const publicShopNavSuffix = useMemo(() => {
+    if (!shopContextReady || !effectiveShopId) {
+      return '';
+    }
+    return `?shop_id=${encodeURIComponent(effectiveShopId)}`;
+  }, [shopContextReady, effectiveShopId]);
 
   const handleLogout = async () => {
     setMenuState({ open: false, pathname: location.pathname });
@@ -78,7 +88,7 @@ export const Layout = ({ children }: LayoutProps) => {
   const renderPublicHeaderNav = () => (
     <>
       <Link
-        to={ROUTES.home}
+        to={`${ROUTES.home}${publicShopNavSuffix}`}
         className={cn(publicNavLinkBase, pathname === ROUTES.home && publicNavLinkActive)}
         onClick={closeMobileMenu}
       >
@@ -86,7 +96,7 @@ export const Layout = ({ children }: LayoutProps) => {
         <span>Trang chủ</span>
       </Link>
       <Link
-        to={ROUTES.preorders}
+        to={`${ROUTES.preorders}${publicShopNavSuffix}`}
         className={cn(publicNavLinkBase, pathname.startsWith(ROUTES.preorders) && publicNavLinkActive)}
         onClick={closeMobileMenu}
       >
@@ -96,7 +106,7 @@ export const Layout = ({ children }: LayoutProps) => {
         <span>Đặt trước</span>
       </Link>
       <Link
-        to={ROUTES.myOrders}
+        to={`${ROUTES.myOrders}${publicShopNavSuffix}`}
         className={cn(publicNavLinkBase, pathname.startsWith(ROUTES.myOrders) && publicNavLinkActive)}
         onClick={closeMobileMenu}
       >
@@ -106,7 +116,7 @@ export const Layout = ({ children }: LayoutProps) => {
         <span>Đơn hàng của tôi</span>
       </Link>
       <Link
-        to={ROUTES.contact}
+        to={`${ROUTES.contact}${publicShopNavSuffix}`}
         className={cn(publicNavLinkBase, pathname === ROUTES.contact && publicNavLinkActive)}
         onClick={closeMobileMenu}
       >

--- a/frontend/src/components/catalog/ItemCard.tsx
+++ b/frontend/src/components/catalog/ItemCard.tsx
@@ -12,9 +12,11 @@ interface ItemCardProps {
     condition?: string | null;
   };
   index?: number;
+  /** e.g. `?shop_id=slug` — appended to item link for public catalog scope */
+  shopSearch?: string;
 }
 
-export const ItemCard = ({ item, index = 0 }: ItemCardProps) => {
+export const ItemCard = ({ item, index = 0, shopSearch = '' }: ItemCardProps) => {
   const statusText =
     item.status === 'con_hang' ? 'Còn hàng' : item.status === 'giu_cho' ? 'Giữ chỗ' : 'Đã bán';
 
@@ -37,7 +39,7 @@ export const ItemCard = ({ item, index = 0 }: ItemCardProps) => {
 
   return (
     <Link
-      to={`/items/${item.id}`}
+      to={`/items/${item.id}${shopSearch}`}
       className="group relative block opacity-0 animate-fade-in rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
       style={{ animationDelay: `${index * 50}ms` }}
     >

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -17,6 +17,8 @@ export const API_CONFIG = {
   BASE_URL: baseUrl,
   ADMIN_SEMANTIC_SEARCH_ENABLED: String(import.meta.env.VITE_ADMIN_SEMANTIC_SEARCH_ENABLED || 'false').toLowerCase() === 'true',
   PUBLIC_PREORDER_SHOP_ID: import.meta.env.VITE_PUBLIC_PREORDER_SHOP_ID || '',
+  /** Default shop for public catalog when visitor has no ?shop_id= (single-tenant deploys). */
+  PUBLIC_CATALOG_SHOP_ID: import.meta.env.VITE_PUBLIC_CATALOG_SHOP_ID || '',
   TIMEOUT: 30000,
   HEADERS: {
     'Content-Type': 'application/json',

--- a/frontend/src/hooks/usePublicShopContext.ts
+++ b/frontend/src/hooks/usePublicShopContext.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useAuth } from './useAuth';
+import { sanitizeShopIdQueryParam } from '../utils/sanitizeShopId';
+import { getPublicCatalogShopIdFromEnv } from '../api/config';
+
+/**
+ * Effective public catalog shop id: URL `shop_id` → env default → JWT `active_shop_id`.
+ * Query wins over JWT so admin shop switch does not skew a shared public URL.
+ *
+ * `shopContextReady`: false while auth is loading and shop is not yet known from URL/env —
+ * avoids one aggregate catalog fetch before JWT resolves (multi-tenant + logged-in).
+ */
+export function usePublicShopContext(): {
+  effectiveShopId: string;
+  queryShopId: string;
+  envShopId: string;
+  authLoading: boolean;
+  /** When false, defer public catalog/detail API calls until auth settles or URL/env fixes shop. */
+  shopContextReady: boolean;
+} {
+  const [searchParams] = useSearchParams();
+  const { user, loading: authLoading } = useAuth();
+
+  const queryShopId = useMemo(
+    () => sanitizeShopIdQueryParam(searchParams.get('shop_id')),
+    [searchParams],
+  );
+
+  const envShopId = useMemo(() => getPublicCatalogShopIdFromEnv(), []);
+
+  const jwtShopId = useMemo(
+    () => sanitizeShopIdQueryParam(user?.active_shop_id ?? null),
+    [user?.active_shop_id],
+  );
+
+  const effectiveShopId = useMemo(
+    () => queryShopId || envShopId || jwtShopId || '',
+    [queryShopId, envShopId, jwtShopId],
+  );
+
+  const hasDeterministicShop = Boolean(queryShopId || envShopId);
+  const shopContextReady = hasDeterministicShop || !authLoading;
+
+  return { effectiveShopId, queryShopId, envShopId, authLoading, shopContextReady };
+}

--- a/frontend/src/pages/PublicCatalogPage.tsx
+++ b/frontend/src/pages/PublicCatalogPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
 import { apiClient } from '../api/client';
+import { usePublicShopContext } from '../hooks/usePublicShopContext';
 import { ItemCard } from '../components/catalog/ItemCard';
 import { CatalogSearchInput } from '../components/catalog/CatalogSearchInput';
 import { CatalogFilters } from '../components/catalog/CatalogFilters';
@@ -18,6 +19,7 @@ import {
 
 export const PublicCatalogPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { effectiveShopId, shopContextReady } = usePublicShopContext();
   const urlState = useMemo(() => parseCatalogUrlState(searchParams), [searchParams]);
   const [searchInput, setSearchInput] = useState(() => urlState.search);
   const debouncedSearch = useDebounce(searchInput, 300);
@@ -51,6 +53,22 @@ export const PublicCatalogPage = () => {
     updateSearchInUrl(debouncedSearch);
   }, [debouncedSearch, updateSearchInUrl]);
 
+  useEffect(() => {
+    if (!effectiveShopId || urlState.shopId === effectiveShopId) {
+      return;
+    }
+    setSearchParams(
+      (prev) => {
+        const state = parseCatalogUrlState(prev);
+        if (state.shopId === effectiveShopId) {
+          return prev;
+        }
+        return buildCatalogSearchParams({ ...state, shopId: effectiveShopId });
+      },
+      { replace: true },
+    );
+  }, [effectiveShopId, urlState.shopId, setSearchParams]);
+
   const updateUrlState = useCallback((
     patch: Partial<{
       carBrand: string | null;
@@ -76,6 +94,7 @@ export const PublicCatalogPage = () => {
   } = useInfiniteQuery({
     queryKey: [
       'public-items',
+      effectiveShopId,
       urlState.search,
       urlState.carBrand,
       urlState.modelBrand,
@@ -88,6 +107,9 @@ export const PublicCatalogPage = () => {
         page: pageParam.toString(),
         page_size: '20',
       });
+      if (effectiveShopId) {
+        params.append('shop_id', effectiveShopId);
+      }
       if (urlState.search) params.append('q', urlState.search);
       if (urlState.carBrand) params.append('car_brand', urlState.carBrand);
       if (urlState.modelBrand) params.append('model_brand', urlState.modelBrand);
@@ -106,6 +128,7 @@ export const PublicCatalogPage = () => {
       return undefined;
     },
     initialPageParam: 1,
+    enabled: shopContextReady,
   });
 
   const items = useMemo(() => {
@@ -122,6 +145,8 @@ export const PublicCatalogPage = () => {
     });
   };
 
+  const waitingForShopContext = !shopContextReady;
+
   if (error) {
     console.error('Error loading catalog:', error);
     return (
@@ -130,6 +155,19 @@ export const PublicCatalogPage = () => {
           <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-4 text-rose-800 shadow-corporate-card">
             <p className="font-semibold">Không tải được catalog</p>
             <p className="mt-1 text-sm text-rose-700/90">Vui lòng thử lại sau.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (waitingForShopContext) {
+    return (
+      <div className="relative min-h-[50vh] px-4 py-16 sm:px-6">
+        <div className="mx-auto max-w-7xl">
+          <div className="py-16 text-center">
+            <div className="mx-auto h-10 w-10 animate-spin rounded-full border-2 border-indigo-200 border-t-indigo-600" />
+            <p className="mt-4 text-sm font-medium text-slate-500">Đang tải catalog…</p>
           </div>
         </div>
       </div>
@@ -208,7 +246,12 @@ export const PublicCatalogPage = () => {
             <>
               <div className="mt-8 grid grid-cols-1 gap-5 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3 xl:grid-cols-4">
                 {items.map((item: PublicItem, index: number) => (
-                  <ItemCard key={item.id} item={item} index={index} />
+                  <ItemCard
+                    key={item.id}
+                    item={item}
+                    index={index}
+                    shopSearch={effectiveShopId ? `?shop_id=${encodeURIComponent(effectiveShopId)}` : ''}
+                  />
                 ))}
               </div>
 

--- a/frontend/src/pages/PublicItemDetailPage.tsx
+++ b/frontend/src/pages/PublicItemDetailPage.tsx
@@ -1,7 +1,9 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
+import { ROUTES } from '../config/routes';
 import { apiClient } from '../api/client';
+import { usePublicShopContext } from '../hooks/usePublicShopContext';
 import { Spinner360 } from '../components/Spinner360/Spinner360';
 import { Gallery } from '../components/Gallery';
 import { ItemCard } from '../components/catalog/ItemCard';
@@ -30,17 +32,28 @@ const MOBILE_SPINNER_HORIZONTAL_PADDING = 84;
 
 export const PublicItemDetailPage = () => {
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { effectiveShopId, shopContextReady } = usePublicShopContext();
   const isMobile = useIsMobile();
   const viewportWidth = useViewportWidth();
 
+  const shopQuery = useMemo(
+    () => (effectiveShopId ? `?shop_id=${encodeURIComponent(effectiveShopId)}` : ''),
+    [effectiveShopId],
+  );
+
   const { data, isLoading, error } = useQuery({
-    queryKey: ['public-item', id],
+    queryKey: ['public-item', id, effectiveShopId],
     queryFn: async () => {
-      const response = await apiClient.get(`/public/items/${id}`);
+      const path =
+        effectiveShopId.length > 0
+          ? `/public/items/${id}?shop_id=${encodeURIComponent(effectiveShopId)}`
+          : `/public/items/${id}`;
+      const response = await apiClient.get(path);
       return response.data;
     },
-    enabled: !!id,
+    enabled: !!id && shopContextReady,
   });
 
   // Response structure: {item, images, spinner} (already unwrapped by apiClient)
@@ -52,6 +65,10 @@ export const PublicItemDetailPage = () => {
         .filter((frame: SpinFrame) => Boolean(frame?.image_url)),
     [spinner],
   );
+
+  if (!shopContextReady) {
+    return <div style={{ padding: '40px', textAlign: 'center' }}>Đang tải...</div>;
+  }
 
   if (isLoading) return <div style={{ padding: '40px', textAlign: 'center' }}>Đang tải...</div>;
   if (error) {
@@ -90,7 +107,10 @@ export const PublicItemDetailPage = () => {
       {/* Back Button */}
       <div style={{ marginBottom: '24px' }}>
         <button
-          onClick={() => navigate(-1)}
+          onClick={() => {
+            const catalogSearch = searchParams.toString();
+            navigate(catalogSearch ? `${ROUTES.home}?${catalogSearch}` : ROUTES.home);
+          }}
           style={{
             padding: isMobile ? '12px 16px' : '10px 20px',
             border: '1px solid #ddd',
@@ -430,23 +450,32 @@ export const PublicItemDetailPage = () => {
       <Gallery images={images} itemName={item.name} />
 
       {/* Related Items Section */}
-      <RelatedItemsSection 
-        currentItemId={item.id} 
-        carBrand={item.car_brand} 
+      <RelatedItemsSection
+        currentItemId={item.id}
+        carBrand={item.car_brand}
         modelBrand={item.model_brand}
+        effectiveShopId={effectiveShopId}
+        shopSearch={shopQuery}
+        shopContextReady={shopContextReady}
       />
     </div>
   );
 };
 
-const RelatedItemsSection = ({ 
-  currentItemId, 
-  carBrand, 
+const RelatedItemsSection = ({
+  currentItemId,
+  carBrand,
   modelBrand,
-}: { 
-  currentItemId: string; 
-  carBrand?: string | null; 
-  modelBrand?: string | null; 
+  effectiveShopId,
+  shopSearch,
+  shopContextReady,
+}: {
+  currentItemId: string;
+  carBrand?: string | null;
+  modelBrand?: string | null;
+  effectiveShopId: string;
+  shopSearch: string;
+  shopContextReady: boolean;
 }) => {
   const isMobile = useIsMobile();
   const shouldQueryCar = Boolean(currentItemId && carBrand);
@@ -454,38 +483,44 @@ const RelatedItemsSection = ({
 
   // Query 1: Items with same Car Brand
   const { data: carData, isLoading: carLoading, isFetched: carFetched } = useQuery({
-    queryKey: ['related-items-car', currentItemId, carBrand],
+    queryKey: ['related-items-car', currentItemId, carBrand, effectiveShopId],
     queryFn: async () => {
       if (!carBrand) return { items: [], pagination: { total: 0 } };
-      
+
       const params = new URLSearchParams({
         page_size: '6',
         sort_by: 'created_at',
         sort_order: 'desc',
         car_brand: carBrand,
       });
+      if (effectiveShopId) {
+        params.set('shop_id', effectiveShopId);
+      }
       const response = await apiClient.get(`/public/items?${params.toString()}`);
       return response.data;
     },
-    enabled: shouldQueryCar,
+    enabled: shopContextReady && shouldQueryCar,
   });
 
   // Query 2: Items with same Model Brand
   const { data: modelData, isLoading: modelLoading, isFetched: modelFetched } = useQuery({
-    queryKey: ['related-items-model', currentItemId, modelBrand],
+    queryKey: ['related-items-model', currentItemId, modelBrand, effectiveShopId],
     queryFn: async () => {
       if (!modelBrand) return { items: [], pagination: { total: 0 } };
-      
+
       const params = new URLSearchParams({
         page_size: '6',
         sort_by: 'created_at',
         sort_order: 'desc',
         model_brand: modelBrand,
       });
+      if (effectiveShopId) {
+        params.set('shop_id', effectiveShopId);
+      }
       const response = await apiClient.get(`/public/items?${params.toString()}`);
       return response.data;
     },
-    enabled: shouldQueryModel,
+    enabled: shopContextReady && shouldQueryModel,
   });
 
   const uniqueSeedCount = useMemo(() => {
@@ -510,17 +545,21 @@ const RelatedItemsSection = ({
 
   // Query 3: Fallback to recent items
   const { data: recentData, isLoading: recentLoading } = useQuery({
-    queryKey: ['related-items-recent', currentItemId],
+    queryKey: ['related-items-recent', currentItemId, effectiveShopId],
     queryFn: async () => {
       const params = new URLSearchParams({
         page_size: '6',
         sort_by: 'created_at',
         sort_order: 'desc',
       });
+      if (effectiveShopId) {
+        params.set('shop_id', effectiveShopId);
+      }
       const response = await apiClient.get(`/public/items?${params.toString()}`);
       return response.data;
     },
-    enabled: !!currentItemId && readyForFallbackQuery && uniqueSeedCount < 5,
+    enabled:
+      shopContextReady && !!currentItemId && readyForFallbackQuery && uniqueSeedCount < 5,
   });
 
   const finalItems = useMemo(() => {
@@ -573,7 +612,7 @@ const RelatedItemsSection = ({
         gap: isMobile ? '14px' : '20px' 
       }}>
         {finalItems.map((item: RelatedItem, index: number) => (
-          <ItemCard key={item.id} item={item} index={index} />
+          <ItemCard key={item.id} item={item} index={index} shopSearch={shopSearch} />
         ))}
       </div>
     </div>

--- a/frontend/src/pages/publicCatalogUrlState.ts
+++ b/frontend/src/pages/publicCatalogUrlState.ts
@@ -1,7 +1,11 @@
+import { sanitizeShopIdQueryParam } from '../utils/sanitizeShopId';
+
 export type CatalogSortBy = 'name' | 'price' | 'created_at';
 export type CatalogSortOrder = 'asc' | 'desc';
 
 export interface CatalogUrlState {
+  /** Sanitized public shop scope; empty = omit from URL. */
+  shopId: string;
   search: string;
   carBrand: string | null;
   modelBrand: string | null;
@@ -51,6 +55,7 @@ export const parseCatalogUrlState = (searchParams: URLSearchParams): CatalogUrlS
   const rawSearch = searchParams.get('q');
 
   return {
+    shopId: sanitizeShopIdQueryParam(searchParams.get('shop_id')),
     search: (rawSearch?.trim() ?? '').slice(0, MAX_SEARCH_LENGTH),
     carBrand: toNullable(searchParams.get('car_brand')),
     modelBrand: toNullable(searchParams.get('model_brand')),
@@ -63,6 +68,10 @@ export const parseCatalogUrlState = (searchParams: URLSearchParams): CatalogUrlS
 export const buildCatalogSearchParams = (state: CatalogUrlState): URLSearchParams => {
   const params = new URLSearchParams();
   const trimmedSearch = state.search.trim();
+
+  if (state.shopId) {
+    params.set('shop_id', state.shopId);
+  }
 
   if (trimmedSearch) {
     params.set('q', trimmedSearch);

--- a/frontend/tests/e2e/public-catalog.spec.ts
+++ b/frontend/tests/e2e/public-catalog.spec.ts
@@ -1,36 +1,85 @@
 import { test, expect, apiOk, type Route } from './fixtures';
 
-const publicItemsResponse = apiOk({
-  items: [
-    {
-      id: 'pub-1',
-      name: 'Porsche 911 GT3 1:18',
-      price: 5_000_000,
-      status: 'con_hang',
-      is_public: true,
-      images: [{ id: 'img-1', url: 'https://placehold.co/400x300', order: 0 }],
-      categories: [{ id: 'cat-1', name: 'Sports' }],
-      created_at: '2026-04-01T00:00:00.000Z',
+/** Shared shapes — list API returns snake_case fields used by catalog cards */
+const aggregateItems = [
+  {
+    id: 'pub-1',
+    name: 'Porsche 911 GT3 1:18',
+    price: 5_000_000,
+    status: 'con_hang',
+    is_public: true,
+    cover_image_url: 'https://placehold.co/400x300',
+    has_spinner: false,
+    created_at: '2026-04-01T00:00:00.000Z',
+  },
+  {
+    id: 'pub-2',
+    name: 'McLaren 720S 1:64',
+    price: 1_800_000,
+    status: 'con_hang',
+    is_public: true,
+    cover_image_url: null,
+    has_spinner: false,
+    created_at: '2026-04-02T00:00:00.000Z',
+  },
+];
+
+const shopAExclusive = {
+  id: 'pub-shop-a',
+  name: 'Shop A Exclusive Tomica',
+  price: 99_000,
+  status: 'con_hang' as const,
+  is_public: true,
+  cover_image_url: null,
+  has_spinner: false,
+  created_at: '2026-04-03T00:00:00.000Z',
+};
+
+const shopBExclusive = {
+  id: 'pub-shop-b',
+  name: 'Shop B Exclusive Hot Wheels',
+  price: 120_000,
+  status: 'con_hang' as const,
+  is_public: true,
+  cover_image_url: null,
+  has_spinner: false,
+  created_at: '2026-04-04T00:00:00.000Z',
+};
+
+function publicItemsEnvelope(items: typeof aggregateItems) {
+  return apiOk({
+    items,
+    pagination: {
+      total: items.length,
+      page: 1,
+      page_size: 20,
+      total_pages: items.length > 0 ? 1 : 0,
     },
-    {
-      id: 'pub-2',
-      name: 'McLaren 720S 1:64',
-      price: 1_800_000,
-      status: 'con_hang',
-      is_public: true,
-      images: [],
-      categories: [],
-      created_at: '2026-04-02T00:00:00.000Z',
-    },
-  ],
-  pagination: { total: 2, page: 1, page_size: 20, total_pages: 1 },
-});
+  });
+}
+
+/**
+ * Mock GET /api/v1/public/items: response depends on `shop_id` query (slug),
+ * matching backend tenant isolation for public catalog.
+ */
+async function routePublicItemsByShop(page: import('@playwright/test').Page) {
+  await page.route('**/api/v1/public/items**', (route: Route) => {
+    const url = new URL(route.request().url());
+    const shopId = url.searchParams.get('shop_id');
+    if (shopId === 'shop-a') {
+      return route.fulfill({ json: publicItemsEnvelope([aggregateItems[0], shopAExclusive]) });
+    }
+    if (shopId === 'shop-b') {
+      return route.fulfill({ json: publicItemsEnvelope([aggregateItems[1], shopBExclusive]) });
+    }
+    // No shop context: aggregate across tenants (legacy behavior)
+    return route.fulfill({ json: publicItemsEnvelope([...aggregateItems]) });
+  });
+}
 
 test.describe('Public catalog smoke', () => {
   test.beforeEach(async ({ page }) => {
-    await page.route('**/api/v1/public/items**', (route: Route) =>
-      route.fulfill({ json: publicItemsResponse }),
-    );
+    await routePublicItemsByShop(page);
   });
 
   test('renders product names from public API', async ({ page }) => {
@@ -75,5 +124,36 @@ test.describe('Public catalog smoke', () => {
     await page.goto('/');
 
     await expect(page.getByText('Không tải được catalog')).toBeVisible();
+  });
+});
+
+test.describe('Public catalog multi-tenant (shop_id)', () => {
+  test.beforeEach(async ({ page }) => {
+    await routePublicItemsByShop(page);
+  });
+
+  test('with shop-a shows only shop A inventory (not shop B exclusive title)', async ({ page }) => {
+    await page.goto('/?shop_id=shop-a');
+    await expect(page.getByText('Shop A Exclusive Tomica')).toBeVisible();
+    await expect(page.getByText('Shop B Exclusive Hot Wheels')).not.toBeVisible();
+    await expect(page.getByText('Porsche 911 GT3 1:18')).toBeVisible();
+  });
+
+  test('with shop-b shows only shop B inventory (not shop A exclusive title)', async ({ page }) => {
+    await page.goto('/?shop_id=shop-b');
+    await expect(page.getByText('Shop B Exclusive Hot Wheels')).toBeVisible();
+    await expect(page.getByText('Shop A Exclusive Tomica')).not.toBeVisible();
+  });
+
+  test('without shop_id shows aggregate items (smoke regression)', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('Porsche 911 GT3 1:18')).toBeVisible();
+    await expect(page.getByText('McLaren 720S 1:64')).toBeVisible();
+  });
+
+  test('public nav preserves shop_id on preorder link', async ({ page }) => {
+    await page.goto('/?shop_id=shop-a');
+    const preorderLink = page.getByRole('link', { name: /Đặt trước/i });
+    await expect(preorderLink).toHaveAttribute('href', /shop_id=shop-a/);
   });
 });

--- a/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
+++ b/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
@@ -18,6 +18,10 @@ vi.mock('@tanstack/react-query', () => ({
   useInfiniteQuery: (options: unknown) => useInfiniteQueryMock(options),
 }));
 
+vi.mock('../../src/hooks/useAuth', () => ({
+  useAuth: () => ({ user: null, loading: false, isAuthenticated: false, login: vi.fn(), logout: vi.fn() }),
+}));
+
 vi.mock('../../src/components/catalog/ItemCard', () => ({
   ItemCard: () => <div>item-card</div>,
 }));
@@ -83,6 +87,7 @@ describe('PublicCatalogPage URL sync', () => {
     const firstCallArgs = useInfiniteQueryMock.mock.calls[0][0] as { queryKey: unknown[] };
     expect(firstCallArgs.queryKey).toEqual([
       'public-items',
+      '',
       'civic',
       'Toyota',
       null,

--- a/frontend/tests/unit/publicCatalogUrlState.test.ts
+++ b/frontend/tests/unit/publicCatalogUrlState.test.ts
@@ -20,6 +20,7 @@ describe('publicCatalogUrlState', () => {
     const parsed = parseCatalogUrlState(params);
 
     expect(parsed).toEqual({
+      shopId: '',
       search: 'civic',
       carBrand: 'Toyota',
       modelBrand: null,
@@ -31,6 +32,7 @@ describe('publicCatalogUrlState', () => {
 
   it('should build compact URL params and omit defaults', () => {
     const params = buildCatalogSearchParams({
+      shopId: '',
       search: '  skyline  ',
       carBrand: 'Nissan',
       modelBrand: null,
@@ -55,6 +57,14 @@ describe('publicCatalogUrlState', () => {
     );
   });
 
+  it('should round-trip shop_id in URL when present', () => {
+    const params = new URLSearchParams('shop_id=my-shop&q=test');
+    const parsed = parseCatalogUrlState(params);
+    const rebuilt = buildCatalogSearchParams(parsed);
+    expect(rebuilt.get('shop_id')).toBe('my-shop');
+    expect(rebuilt.get('q')).toBe('test');
+  });
+
   it('should truncate very long search query from URL', () => {
     const longQuery = 'a'.repeat(300);
     const parsed = parseCatalogUrlState(new URLSearchParams(`q=${longQuery}`));
@@ -67,6 +77,7 @@ describe('publicCatalogUrlState', () => {
     const parsed = parseCatalogUrlState(new URLSearchParams(''));
 
     expect(parsed).toEqual({
+      shopId: '',
       search: '',
       carBrand: null,
       modelBrand: null,
@@ -94,6 +105,7 @@ describe('publicCatalogUrlState', () => {
 
     const built = buildCatalogSearchParams({
       ...parsed,
+      shopId: '',
       carBrand: "' OR 1=1 --",
       modelBrand: null,
       condition: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **Phase 16 (Per-Shop Public Homepage)** end-to-end:

- **Backend:** Optional `shop_id` (UUID or slug) on `GET /public/items` and detail; resolver + tests + `docs/API_CONTRACT.md`.
- **Frontend:** `usePublicShopContext`, URL/env/JWT precedence, `shopContextReady` to avoid aggregate flash before auth, Layout nav uses effective shop id.
- **E2E (16-03):** `public-catalog.spec.ts` mocks API responses **by `shop_id`** — shop A never shows shop B exclusive titles; regression without `shop_id`; preorder link preserves query.

## Planning / traceability

- `16-01-SUMMARY.md`, `16-02-SUMMARY.md`, `16-03-SUMMARY.md`
- `16-VERIFICATION.md`
- ROADMAP: Phase 16 **3/3 Complete**; PBLC-03 marked complete in REQUIREMENTS.md; PROJECT.md updated.

## Testing

- Backend: `npx jest src/public/`
- Frontend: `pnpm exec tsc --noEmit`, `pnpm run build`, `pnpm exec vitest run`
- E2E: `pnpm exec playwright install chromium` (if needed), then `pnpm exec playwright test public-catalog.spec.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b99e3762-6f90-4ddd-8781-0a4f9560efdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b99e3762-6f90-4ddd-8781-0a4f9560efdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

