### PR TITLE
ci: auto-run Prisma migrations on Neon when main updates

### DIFF
--- a/.github/workflows/migrate-neon.yml
+++ b/.github/workflows/migrate-neon.yml
@@ -1,0 +1,57 @@
+# Runs Prisma migrations against production Neon when `main` is updated (e.g. after merge).
+#
+# Required repo secret:
+#   NEON_DATABASE_URL — pooled connection (…-pooler…), same role as app DATABASE_URL.
+#
+# Optional repo secret:
+#   NEON_DIRECT_URL — non-pooler host for Prisma migrate. If omitted, the workflow derives it
+#   from NEON_DATABASE_URL by stripping `-pooler` from the hostname (Neon’s usual pattern).
+#
+# Configure: GitHub → Settings → Secrets and variables → Actions → New repository secret.
+# Do not commit real URLs or passwords to the repository. Rotate credentials if they were exposed.
+
+name: Migrate Neon (main)
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  migrate:
+    name: Prisma migrate deploy
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.NEON_DIRECT_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATABASE_URL}" ]; then
+            echo "::error::Missing Actions secret NEON_DATABASE_URL (pooled Neon URL)."
+            exit 1
+          fi
+          DIRECT="${DIRECT_URL:-}"
+          if [ -z "${DIRECT}" ]; then
+            DIRECT="$(echo "${DATABASE_URL}" | sed 's/-pooler\.ap-/\.ap-/')"
+            echo "NEON_DIRECT_URL not set; using derived direct URL for Prisma CLI."
+          fi
+          export DIRECT_URL="${DIRECT}"
+          npx prisma migrate deploy

--- a/.github/workflows/migrate-neon.yml
+++ b/.github/workflows/migrate-neon.yml
@@ -1,4 +1,4 @@
-# Runs Prisma migrations against production Neon when `main` is updated (e.g. after merge).
+# Runs Prisma migrations against Neon only after the "CI" workflow completes successfully on `main`.
 #
 # Required repo secret:
 #   NEON_DATABASE_URL — pooled connection (…-pooler…), same role as app DATABASE_URL.
@@ -8,25 +8,30 @@
 #   from NEON_DATABASE_URL by stripping `-pooler` from the hostname (Neon’s usual pattern).
 #
 # Configure: GitHub → Settings → Secrets and variables → Actions → New repository secret.
-# Do not commit real URLs or passwords to the repository. Rotate credentials if they were exposed.
+# Do not commit real URLs or passwords to the repository.
 
 name: Migrate Neon (main)
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
 
 jobs:
   migrate:
     name: Prisma migrate deploy
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     defaults:
       run:
         working-directory: ./backend
 
     steps:
-      - name: Checkout
+      - name: Checkout (same commit as green CI)
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Runs `prisma migrate deploy` on Neon **only after** the default **CI** workflow completes successfully on `main` (via `workflow_run`). Checkout uses the same commit as the green CI run (`head_sha`).

## Secrets

- **Required:** `NEON_DATABASE_URL` (pooled Neon URL).
- **Optional:** `NEON_DIRECT_URL`; if unset, derived from pooled URL by removing `-pooler` from the hostname.

## Security

Rotate Neon credentials if they were ever exposed outside secrets.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dev-z3g6024.slack.com/archives/C0AMW0SECN7/p1777661052352439?thread_ts=1777661052.352439&cid=C0AMW0SECN7)

<div><a href="https://cursor.com/agents/bc-3979d2db-667a-50c0-8acf-dec83af02937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3979d2db-667a-50c0-8acf-dec83af02937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

