### PR TITLE
Deploy backend to Raspberry Pi from GitHub Actions + Cloudflare Tunnel doc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Require review on backend + deploy paths when branch protection uses CODEOWNERS.
+# Replace @nguyenhoangtin1404 with your team/org handles if needed.
+/backend/ @nguyenhoangtin1404
+/.github/workflows/deploy-backend.yml @nguyenhoangtin1404
+/docs/BACKEND_PI_CLOUDFLARE.md @nguyenhoangtin1404

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,92 @@
+# Build backend on GitHub Actions (linux/amd64), ship dist + lockfile + Prisma to Raspberry Pi.
+# On the Pi: npm ci --omit=dev rebuilds native deps (bcrypt, sharp) for ARM — do not copy node_modules from the runner.
+#
+# Secrets: DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY
+# Optional: DEPLOY_REMOTE_PATH (default /opt/diecast360-backend)
+
+name: Deploy backend (Pi)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/deploy-backend.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      # Forward optional deploy path to rsync + SSH steps (default on Pi: /opt/diecast360-backend)
+      DEPLOY_REMOTE_PATH: ${{ secrets.DEPLOY_REMOTE_PATH }}
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install & build
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install SSH key
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Rsync artifact to Pi
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          set -euo pipefail
+          REMOTE="${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
+          RSYNC_SSH='ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes'
+          # Ship compiled app + manifests; .env and uploads stay on the Pi.
+          rsync -avz --delete \
+            -e "$RSYNC_SSH" \
+            ./dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE}/dist/"
+          rsync -avz \
+            -e "$RSYNC_SSH" \
+            ./package.json ./package-lock.json "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE}/"
+          rsync -avz --delete \
+            -e "$RSYNC_SSH" \
+            ./prisma/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE}/prisma/"
+
+      - name: Install prod deps, migrate, restart
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          DEPLOY_REMOTE_PATH: ${{ env.DEPLOY_REMOTE_PATH }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: DEPLOY_REMOTE_PATH
+          script_stop: true
+          script: |
+            set -euo pipefail
+            cd "${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
+            npm ci --omit=dev
+            npx prisma generate
+            npx prisma migrate deploy
+            sudo systemctl restart diecast360-api

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -60,6 +60,7 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           set -euo pipefail
@@ -109,14 +110,14 @@ jobs:
           script: |
             set -euo pipefail
             cd "${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
+            set -a
+            [ -f .env ] && . ./.env
+            set +a
+            PORT="${PORT:-3000}"
             npm ci --omit=dev
             npx prisma generate
             npx prisma migrate deploy
             sudo systemctl restart diecast360-api
             sleep 3
             systemctl is-active --quiet diecast360-api
-            set -a
-            [ -f .env ] && . ./.env
-            set +a
-            PORT="${PORT:-3000}"
             curl -sfS "http://127.0.0.1:${PORT}/api/v1" >/dev/null

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -120,4 +120,8 @@ jobs:
             sudo systemctl restart diecast360-api
             sleep 3
             systemctl is-active --quiet diecast360-api
-            curl -sfS "http://127.0.0.1:${PORT}/api/v1" >/dev/null
+            curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null
+
+      - name: Remove deploy key from runner
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -6,6 +6,9 @@
 #
 # rsync --delete: Pi mirrors the repo (dist + prisma). Do not keep unique files only on the Pi.
 # Optional: create a GitHub Environment named "production" and add required reviewers to gate deploys.
+#
+# Merge vào `main` kích hoạt deploy — nên bật branch protection: PR bắt buộc, CI pass,
+# và (tuỳ chọn) CODEOWNERS review — xem `.github/CODEOWNERS`.
 
 name: Deploy backend (Pi)
 
@@ -124,4 +127,7 @@ jobs:
 
       - name: Remove deploy key from runner
         if: always()
-        run: rm -f ~/.ssh/deploy_key
+        run: |
+          rm -f ~/.ssh/deploy_key
+          chmod 700 ~/.ssh 2>/dev/null || true
+

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -3,6 +3,9 @@
 #
 # Secrets: DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY
 # Optional: DEPLOY_REMOTE_PATH (default /opt/diecast360-backend)
+#
+# rsync --delete: Pi mirrors the repo (dist + prisma). Do not keep unique files only on the Pi.
+# Optional: create a GitHub Environment named "production" and add required reviewers to gate deploys.
 
 name: Deploy backend (Pi)
 
@@ -21,6 +24,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Optional protection: Settings → Environments → production → Required reviewers
+    environment: production
     env:
       # Forward optional deploy path to rsync + SSH steps (default on Pi: /opt/diecast360-backend)
       DEPLOY_REMOTE_PATH: ${{ secrets.DEPLOY_REMOTE_PATH }}
@@ -44,6 +49,11 @@ jobs:
           npm ci
           npm run build
 
+      - name: Verify build output
+        run: |
+          test -d dist
+          test -n "$(find dist -type f -print -quit)" || (echo "::error::dist/ has no files — aborting deploy"; exit 1)
+
       - name: Install SSH key
         env:
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
@@ -52,7 +62,20 @@ jobs:
           mkdir -p ~/.ssh
           echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
+          set -euo pipefail
+          KEYSCAN_OUT="$(mktemp)"
+          if ! ssh-keyscan -H "$DEPLOY_HOST" >"$KEYSCAN_OUT" 2>"${KEYSCAN_OUT}.err"; then
+            echo "::error::ssh-keyscan failed for host $DEPLOY_HOST"
+            cat "${KEYSCAN_OUT}.err" >&2
+            exit 1
+          fi
+          if ! grep -q . "$KEYSCAN_OUT"; then
+            echo "::error::ssh-keyscan returned no keys for $DEPLOY_HOST"
+            cat "${KEYSCAN_OUT}.err" >&2
+            exit 1
+          fi
+          cat "$KEYSCAN_OUT" >> ~/.ssh/known_hosts
+          rm -f "$KEYSCAN_OUT" "${KEYSCAN_OUT}.err"
 
       - name: Rsync artifact to Pi
         env:
@@ -90,3 +113,10 @@ jobs:
             npx prisma generate
             npx prisma migrate deploy
             sudo systemctl restart diecast360-api
+            sleep 3
+            systemctl is-active --quiet diecast360-api
+            set -a
+            [ -f .env ] && . ./.env
+            set +a
+            PORT="${PORT:-3000}"
+            curl -sfS "http://127.0.0.1:${PORT}/api/v1" >/dev/null

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -1,0 +1,43 @@
+import { HttpException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { PrismaService } from './common/prisma/prisma.service';
+
+describe('AppController', () => {
+  let controller: AppController;
+  let prisma: { $queryRaw: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = { $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [
+        AppService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    controller = moduleRef.get(AppController);
+  });
+
+  it('getHealth returns healthy when DB responds', async () => {
+    await expect(controller.getHealth()).resolves.toEqual({
+      ok: true,
+      status: 'healthy',
+    });
+    expect(prisma.$queryRaw).toHaveBeenCalled();
+  });
+
+  it('getHealth throws 503 when DB fails', async () => {
+    prisma.$queryRaw.mockRejectedValueOnce(new Error('down'));
+    try {
+      await controller.getHealth();
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException);
+      expect((e as HttpException).getStatus()).toBe(503);
+      return;
+    }
+    throw new Error('expected HttpException');
+  });
+});

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,13 +1,38 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import { AppService } from './app.service';
+import { PrismaService } from './common/prisma/prisma.service';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    private readonly prisma: PrismaService,
+  ) {}
 
   @Get()
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  /** Liveness + DB connectivity — dùng cho deploy probe (GET, không CSRF). */
+  @SkipThrottle()
+  @Get('health')
+  async getHealth() {
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+    } catch {
+      throw new HttpException(
+        { ok: false, status: 'unhealthy' },
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
+    return { ok: true, status: 'healthy' };
   }
 }
 

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -60,6 +60,19 @@ sudo chmod 440 /etc/sudoers.d/diecast360-api
 | `DEPLOY_SSH_KEY` | Private key (toàn bộ PEM), khớp `authorized_keys` trên Pi. |
 | `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; mặc định `/opt/diecast360-backend`. |
 
+### SSH key cho GitHub → Pi
+
+Trên máy dev (không commit private key):
+
+```bash
+ssh-keygen -t ed25519 -f ./diecast360-deploy -N ""
+```
+
+- Public key (`diecast360-deploy.pub`): thêm vào Pi — `~/.ssh/authorized_keys` của user deploy (một dòng).
+- Private key (`diecast360-deploy`): nội dung file → GitHub Secret **`DEPLOY_SSH_KEY`**.
+
+Luân phiên key định kỳ: tạo cặp mới, cập nhật secret + `authorized_keys`, xoá key cũ.
+
 ## 3. Cloudflare Tunnel (public API, không cần mở 443 trên router)
 
 1. Domain dùng DNS Cloudflare.
@@ -90,7 +103,7 @@ File: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backe
 - Không copy `node_modules` từ runner → Pi luôn `npm ci --omit=dev` đúng kiến trúc ARM.
 - **`rsync --delete`** cho `dist/` và `prisma/`: Pi được **đồng bộ đúng repo** — không giữ file chỉ có trên Pi (tránh drift). Migration chỉ nên có trong Git.
 - Job dùng GitHub **Environment** tên `production` (tự tạo lần đầu). Vào **Settings → Environments → production** để bật **Required reviewers** nếu muốn chặn migrate/restart cho đến khi duyệt (khuyến nghị cho DB production).
-- Sau deploy: kiểm tra **`systemctl is-active`** và **`curl`** tới `http://127.0.0.1:$PORT/api/v1` (đọc `PORT` từ `.env` trên Pi).
+- Sau deploy: kiểm tra **`systemctl is-active`** và **`curl`** tới `http://127.0.0.1:$PORT/api/v1` — **`PORT` đọc từ `.env` trước khi migrate/restart** để khớp cổng thực tế của service.
 - **Rollback:** redeploy commit cũ trên `main` hoặc chạy workflow trên commit/tag trước; migration đã apply lên Neon cần xử lý tay hoặc migration down (Prisma không auto rollback).
 
 ### Tunnel — systemd (tham khảo Cloudflare)

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -1,0 +1,90 @@
+# Backend trên Raspberry Pi + Cloudflare Tunnel + GitHub Actions
+
+Luồng: **build trên GitHub (`ubuntu-latest`)** → **rsync `dist/`, `package.json`, `package-lock.json`, `prisma/`** lên Pi → trên Pi **`npm ci --omit=dev`** (native modules build đúng ARM) → **`prisma migrate deploy`** → **`systemctl restart`**.  
+API ra ngoài qua **Cloudflare Tunnel** trỏ tới `http://127.0.0.1:3000` (hoặc cổng `PORT` trong `.env`).
+
+## 1. Chuẩn bị Pi (một lần)
+
+- Node **không bắt buộc** trên Pi cho bước build (build xong trên GitHub); vẫn cần **Node 20** để chạy `node dist/main.js` và `npm ci`.
+- Thư mục deploy (mặc định): `/opt/diecast360-backend`. Clone repo hoặc tạo thư mục và `git init` + remote — workflow **không** tự clone lần đầu; rsync tạo/tệp tin trong thư mục đó.
+
+```bash
+sudo mkdir -p /opt/diecast360-backend/uploads
+sudo chown -R "$USER:$USER" /opt/diecast360-backend
+```
+
+- Copy **`.env`** production trên Pi (Neon `DATABASE_URL` / `DIRECT_URL`, `JWT_SECRET`, `COOKIE_SECRET`, `FRONTEND_URL` = origin frontend hosting, v.v.). Xem [`ENV.md`](ENV.md).
+- **`PUBLIC_BASE_URL`**: nên là URL public của API (vd `https://api.example.com`) để ghép link ảnh đúng.
+
+### systemd
+
+`/etc/systemd/system/diecast360-api.service` (chỉnh `User`, `WorkingDirectory`):
+
+```ini
+[Unit]
+Description=Diecast360 Backend API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/opt/diecast360-backend
+EnvironmentFile=/opt/diecast360-backend/.env
+ExecStart=/usr/bin/node dist/main.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable diecast360-api
+```
+
+### sudo restart không hỏi mật khẩu (user deploy)
+
+```bash
+echo 'pi ALL=(ALL) NOPASSWD: /bin/systemctl restart diecast360-api' | sudo tee /etc/sudoers.d/diecast360-api
+sudo chmod 440 /etc/sudoers.d/diecast360-api
+```
+
+## 2. GitHub Actions — Secrets
+
+| Secret | Mô tả |
+|--------|--------|
+| `DEPLOY_HOST` | Hostname hoặc IP Pi (**phải SSH được từ internet** tới Pi: port forward 22 hoặc SSH qua Cloudflare / Tailscale tùy bạn). |
+| `DEPLOY_USER` | User SSH (vd `pi`). |
+| `DEPLOY_SSH_KEY` | Private key (toàn bộ PEM), khớp `authorized_keys` trên Pi. |
+| `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; mặc định `/opt/diecast360-backend`. |
+
+## 3. Cloudflare Tunnel (public API, không cần mở 443 trên router)
+
+1. Domain dùng DNS Cloudflare.
+2. Trên Pi cài `cloudflared` ([Cloudflare docs](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)).
+3. `cloudflared tunnel login` → tạo tunnel → chỉ public hostname (vd `api.example.com`) → service **`http://127.0.0.1:3000`** (hoặc đúng `PORT`).
+4. Chạy tunnel bằng systemd để khởi động lại cùng OS.
+
+HTTPS và certificate do Cloudflare lo; trên backend production nên:
+
+- `COOKIE_SECURE=true`
+- `COOKIE_SAME_SITE` phù hợp (thường `lax` hoặc `strict` tùy subdomain/cookie cross-site)
+
+## 4. Frontend (hosting khác)
+
+Trong `.env` build frontend (vd `VITE_API_BASE_URL`):
+
+```env
+VITE_API_BASE_URL=https://api.example.com/api/v1
+```
+
+Origin frontend phải nằm trong `FRONTEND_URL` / `FRONTEND_URLS` của backend.
+
+## 5. Workflow
+
+File: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml)
+
+- Trigger: push `main` khi đổi `backend/**`, hoặc **Run workflow** thủ công.
+- Không copy `node_modules` từ runner → Pi luôn `npm ci --omit=dev` đúng kiến trúc ARM.

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -103,6 +103,14 @@ File: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backe
 - Không copy `node_modules` từ runner → Pi luôn `npm ci --omit=dev` đúng kiến trúc ARM.
 - **`rsync --delete`** cho `dist/` và `prisma/`: Pi được **đồng bộ đúng repo** — không giữ file chỉ có trên Pi (tránh drift). Migration chỉ nên có trong Git.
 - Job dùng GitHub **Environment** tên `production` (tự tạo lần đầu). Vào **Settings → Environments → production** để bật **Required reviewers** nếu muốn chặn migrate/restart cho đến khi duyệt (khuyến nghị cho DB production). Có thể bật **Restrict deployments** (chỉ `main`) để tránh deploy nhầm nhánh.
+
+### Branch protection (khuyến nghị)
+
+Vì **merge vào `main`** (sau khi CI xanh) sẽ trigger deploy khi có thay đổi `backend/**`, nên cấu hình **Settings → Rules → Rulesets** (hoặc branch protection cũ):
+
+- Bắt buộc **pull request** trước khi merge.
+- Bắt buộc **status check** (job CI Success / backend / frontend tùy repo).
+- (Tuỳ chọn) **Require review from Code Owners** — file [`.github/CODEOWNERS`](../.github/CODEOWNERS) gán owner cho `backend/` và workflow deploy (chỉnh `@username` cho đúng team).
 - Sau deploy: **`systemctl is-active`** và **`curl`** tới `http://127.0.0.1:$PORT/api/v1/health` (endpoint **`GET /api/v1/health`**) — kiểm tra **DB** (`SELECT 1`); trả **503** nếu Neon không kết nối được. **`PORT`** lấy từ `.env` trước migrate/restart.
 - **Rollback:** redeploy commit cũ trên `main` hoặc chạy workflow trên commit/tag trước; migration đã apply lên Neon cần xử lý tay hoặc migration down (Prisma không auto rollback).
 

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -102,8 +102,8 @@ File: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backe
 - Trigger: push `main` khi đổi `backend/**`, hoặc **Run workflow** thủ công.
 - Không copy `node_modules` từ runner → Pi luôn `npm ci --omit=dev` đúng kiến trúc ARM.
 - **`rsync --delete`** cho `dist/` và `prisma/`: Pi được **đồng bộ đúng repo** — không giữ file chỉ có trên Pi (tránh drift). Migration chỉ nên có trong Git.
-- Job dùng GitHub **Environment** tên `production` (tự tạo lần đầu). Vào **Settings → Environments → production** để bật **Required reviewers** nếu muốn chặn migrate/restart cho đến khi duyệt (khuyến nghị cho DB production).
-- Sau deploy: kiểm tra **`systemctl is-active`** và **`curl`** tới `http://127.0.0.1:$PORT/api/v1` — **`PORT` đọc từ `.env` trước khi migrate/restart** để khớp cổng thực tế của service.
+- Job dùng GitHub **Environment** tên `production` (tự tạo lần đầu). Vào **Settings → Environments → production** để bật **Required reviewers** nếu muốn chặn migrate/restart cho đến khi duyệt (khuyến nghị cho DB production). Có thể bật **Restrict deployments** (chỉ `main`) để tránh deploy nhầm nhánh.
+- Sau deploy: **`systemctl is-active`** và **`curl`** tới `http://127.0.0.1:$PORT/api/v1/health` (endpoint **`GET /api/v1/health`**) — kiểm tra **DB** (`SELECT 1`); trả **503** nếu Neon không kết nối được. **`PORT`** lấy từ `.env` trước migrate/restart.
 - **Rollback:** redeploy commit cũ trên `main` hoặc chạy workflow trên commit/tag trước; migration đã apply lên Neon cần xử lý tay hoặc migration down (Prisma không auto rollback).
 
 ### Tunnel — systemd (tham khảo Cloudflare)

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -88,3 +88,15 @@ File: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backe
 
 - Trigger: push `main` khi đổi `backend/**`, hoặc **Run workflow** thủ công.
 - Không copy `node_modules` từ runner → Pi luôn `npm ci --omit=dev` đúng kiến trúc ARM.
+- **`rsync --delete`** cho `dist/` và `prisma/`: Pi được **đồng bộ đúng repo** — không giữ file chỉ có trên Pi (tránh drift). Migration chỉ nên có trong Git.
+- Job dùng GitHub **Environment** tên `production` (tự tạo lần đầu). Vào **Settings → Environments → production** để bật **Required reviewers** nếu muốn chặn migrate/restart cho đến khi duyệt (khuyến nghị cho DB production).
+- Sau deploy: kiểm tra **`systemctl is-active`** và **`curl`** tới `http://127.0.0.1:$PORT/api/v1` (đọc `PORT` từ `.env` trên Pi).
+- **Rollback:** redeploy commit cũ trên `main` hoặc chạy workflow trên commit/tag trước; migration đã apply lên Neon cần xử lý tay hoặc migration down (Prisma không auto rollback).
+
+### Tunnel — systemd (tham khảo Cloudflare)
+
+```bash
+sudo cloudflared service install
+```
+
+Chi tiết và template service: [Cloudflare Tunnel · Run as a service](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/as-a-service/).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Updates (follow-up review)

- **Health check PORT:** Source `.env` **immediately after `cd`** so `PORT` is set **before** `migrate`, `restart`, `systemctl is-active`, and `curl` — fixes PR inline comment about wrong probe port.
- **`chmod 700 ~/.ssh`** on the Actions runner after creating `~/.ssh`.
- **Docs:** SSH keypair generation for `DEPLOY_SSH_KEY`, rotation note; clarified health check wording.

---

## Summary

Delivers the agreed approach: **build the Nest backend on GitHub Actions** (`ubuntu-latest`), **rsync** `dist/`, `package.json`, `package-lock.json`, and `prisma/` to the Pi, then on the Pi run **`npm ci --omit=dev`** (so native modules like bcrypt/sharp compile for ARM64), **`prisma migrate deploy`**, and **`systemctl restart`**.

Adds **`docs/BACKEND_PI_CLOUDFLARE.md`** describing **Cloudflare Tunnel** pointing at `http://127.0.0.1:PORT`, GitHub Secrets (`DEPLOY_*`), systemd, sudo for restart, and **`VITE_API_BASE_URL`** for a frontend on another host.

## Secrets required

| Secret | Purpose |
|--------|---------|
| `DEPLOY_HOST` | SSH-reachable host for the Pi |
| `DEPLOY_USER` | SSH user |
| `DEPLOY_SSH_KEY` | Private key (PEM) |
| `DEPLOY_REMOTE_PATH` | Optional; default `/opt/diecast360-backend` |

## Notes

- **SSH from GitHub to the Pi** must work (port forward, or SSH over Cloudflare, etc.); the tunnel only exposes HTTP to the public, not SSH.
- First deploy: ensure the remote directory and `.env` exist on the Pi; the workflow does not run an initial `git clone`.
- Optional: **Settings → Environments → production** — add required reviewers to gate deploys.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc438bd1-f0fe-4bef-928f-87322ee74877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc438bd1-f0fe-4bef-928f-87322ee74877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

