### PR TITLE
ci: CD deploy frontend to Vercel after CI on main

### DIFF
--- a/.github/workflows/deploy-frontend-vercel.yml
+++ b/.github/workflows/deploy-frontend-vercel.yml
@@ -1,0 +1,57 @@
+# Continuous deployment: Vite app in `frontend/` → Vercel (production).
+#
+# Chạy sau khi workflow "CI" hoàn thành thành công trên nhánh `main`, với sự kiện `push`
+# (tránh deploy khi chỉ chạy CI cho pull request). Checkout dùng đúng `head_sha` của lần chạy CI.
+#
+# Cấu hình Vercel (một lần):
+# 1. Tạo project trên Vercel trỏ vào repo, **Root Directory** = `frontend`, hoặc dùng CLI: `cd frontend && npx vercel link`
+# 2. Lấy token: Vercel → Account Settings → Tokens
+# 3. Lấy org/project id: sau khi `vercel link`, xem `.vercel/project.json` (local, không commit) hoặc Project Settings → General
+#
+# GitHub repository secrets (Settings → Secrets → Actions):
+#   VERCEL_TOKEN
+#   VERCEL_ORG_ID
+#   VERCEL_PROJECT_ID
+#
+# Biến build Vite (`VITE_*`): Vercel → Project → Settings → Environment Variables (Production).
+
+name: Deploy frontend (Vercel)
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+    branches: [main]
+
+concurrency:
+  group: deploy-frontend-vercel-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Chỉ deploy khi CI trên main pass sau push (không deploy theo PR hay push develop).
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    environment:
+      name: production-frontend
+      url: ${{ steps.deploy.outputs.preview-url }}
+
+    steps:
+      - name: Checkout (commit đã qua CI)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Deploy to Vercel
+        id: deploy
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: frontend
+          vercel-args: "--prod --yes"

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "github": {
+    "enabled": false
+  },
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds continuous deployment for the Vite React app in `frontend/` to Vercel when `main` receives a push and the existing **CI** workflow completes successfully. The deploy job checks out the same commit SHA that CI validated (`workflow_run.head_sha`), then runs `amondnet/vercel-action@v25` with `working-directory: frontend` and `--prod`.

## Repo changes

- **`.github/workflows/deploy-frontend-vercel.yml`** — `workflow_run` on workflow name `CI`, branch `main`, only when `conclusion == success` and `event == push` (skips PR-only CI runs).
- **`frontend/vercel.json`** — SPA rewrite to `index.html`, Vite framework hint, and `github.enabled: false` so Vercel’s GitHub app does not double-deploy if the integration is installed.

## Required setup (repository maintainer)

1. **Vercel** — Create a project for this repo with **Root Directory** = `frontend` (or link locally: `cd frontend && npx vercel link` and read `.vercel/project.json` for IDs).
2. **GitHub Actions secrets** — `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.
3. **Optional** — GitHub Environment `production-frontend` (workflow references it for deployment URL); add protection rules if desired.
4. **Vercel Environment Variables (Production)** — Set `VITE_*` values (e.g. `VITE_API_BASE_URL`) per `frontend/.env.example`.

After merge to `main`, the next push to `main` that runs CI will trigger a production deploy when CI succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbbcfa9a-5df8-4ae3-9e21-7025275a1865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbbcfa9a-5df8-4ae3-9e21-7025275a1865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

