### PR TITLE
fix(cors): normalize frontend origins for Vercel + Pi deploy

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,8 +9,9 @@ DIRECT_URL="postgresql://postgres:postgres@localhost:5432/diecast360"
 # Application Settings
 PORT=3000
 FRONTEND_URL="http://localhost:5173"
-# Optional comma-separated extra origins (CORS + cookies). localhost/127.0.0.1 variants are auto-added from FRONTEND_URL.
-# FRONTEND_URLS="https://preview.example.com"
+# Optional comma-separated extra origins (CORS). Trailing slashes and URL paths are normalized.
+# Production: set to your real UI origin(s), e.g. FRONTEND_URL="https://your-app.vercel.app"
+# FRONTEND_URLS="https://preview-branch.vercel.app,https://custom-domain.com"
 # Vite --host (LAN): set true in dev, keep false in production unless you need it.
 # CORS_ALLOW_LAN=true
 UPLOAD_DIR="./uploads"

--- a/backend/src/cors-origins.util.spec.ts
+++ b/backend/src/cors-origins.util.spec.ts
@@ -1,0 +1,52 @@
+import { buildCorsAllowedOrigins, normalizeFrontendOrigin } from './cors-origins.util';
+
+describe('normalizeFrontendOrigin', () => {
+  it('strips trailing slash from full URL', () => {
+    expect(normalizeFrontendOrigin('https://diecast360-frontend.vercel.app/')).toBe(
+      'https://diecast360-frontend.vercel.app',
+    );
+  });
+
+  it('drops path and query from URL', () => {
+    expect(
+      normalizeFrontendOrigin('https://app.example.com/foo?x=1#hash'),
+    ).toBe('https://app.example.com');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeFrontendOrigin('  http://localhost:5173/  ')).toBe(
+      'http://localhost:5173',
+    );
+  });
+});
+
+describe('buildCorsAllowedOrigins', () => {
+  it('includes primary and extras with trailing slashes normalized', () => {
+    const origins = buildCorsAllowedOrigins({
+      FRONTEND_URL: 'https://diecast360-frontend.vercel.app/',
+      FRONTEND_URLS: 'https://preview.vercel.app/,',
+    });
+    expect(origins).toEqual(
+      expect.arrayContaining([
+        'https://diecast360-frontend.vercel.app',
+        'https://preview.vercel.app',
+      ]),
+    );
+  });
+
+  it('adds localhost and 127.0.0.1 variants for primary', () => {
+    const origins = buildCorsAllowedOrigins({
+      FRONTEND_URL: 'http://localhost:5173/',
+    });
+    expect(origins.sort()).toEqual(
+      ['http://127.0.0.1:5173', 'http://localhost:5173'].sort(),
+    );
+  });
+
+  it('defaults when FRONTEND_URL is unset', () => {
+    const origins = buildCorsAllowedOrigins({});
+    expect(origins.sort()).toEqual(
+      ['http://127.0.0.1:5173', 'http://localhost:5173'].sort(),
+    );
+  });
+});

--- a/backend/src/cors-origins.util.ts
+++ b/backend/src/cors-origins.util.ts
@@ -1,0 +1,46 @@
+/**
+ * Normalize a frontend origin from env (trim, strip trailing slash, drop path/query/hash).
+ * Accepts values like `https://app.vercel.app/` so they match browser `Origin` headers.
+ */
+export function normalizeFrontendOrigin(raw: string): string {
+  const s = raw.trim();
+  if (!s) return s;
+  try {
+    const u = new URL(s);
+    u.hash = '';
+    u.pathname = '';
+    u.search = '';
+    return u.origin;
+  } catch {
+    return s.replace(/\/+$/, '');
+  }
+}
+
+/** Merge FRONTEND_URL + FRONTEND_URLS and add localhost ↔ 127.0.0.1 variants (same port). */
+export function buildCorsAllowedOrigins(env: NodeJS.ProcessEnv = process.env): string[] {
+  const primary = normalizeFrontendOrigin(
+    env.FRONTEND_URL || 'http://localhost:5173',
+  );
+  const extras = (env.FRONTEND_URLS || '')
+    .split(',')
+    .map((s) => normalizeFrontendOrigin(s))
+    .filter(Boolean);
+  const out = new Set<string>();
+  for (const raw of [primary, ...extras]) {
+    if (!raw) continue;
+    out.add(raw);
+    try {
+      const u = new URL(raw);
+      if (u.hostname === 'localhost') {
+        u.hostname = '127.0.0.1';
+        out.add(u.origin);
+      } else if (u.hostname === '127.0.0.1') {
+        u.hostname = 'localhost';
+        out.add(u.origin);
+      }
+    } catch {
+      /* ignore malformed */
+    }
+  }
+  return [...out];
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,33 +8,7 @@ import * as sharp from 'sharp';
 import * as cookieParser from 'cookie-parser';
 import { createCsrfMiddleware } from './common/middleware/csrf.middleware';
 import { validateRuntimeSecurityConfig } from './common/security/runtime-security';
-
-/** Merge FRONTEND_URL + FRONTEND_URLS and add localhost ↔ 127.0.0.1 variants (same port). */
-function buildCorsAllowedOrigins(): string[] {
-  const primary = (process.env.FRONTEND_URL || 'http://localhost:5173').trim();
-  const extras = (process.env.FRONTEND_URLS || '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-  const out = new Set<string>();
-  for (const raw of [primary, ...extras]) {
-    if (!raw) continue;
-    out.add(raw);
-    try {
-      const u = new URL(raw);
-      if (u.hostname === 'localhost') {
-        u.hostname = '127.0.0.1';
-        out.add(u.origin);
-      } else if (u.hostname === '127.0.0.1') {
-        u.hostname = 'localhost';
-        out.add(u.origin);
-      }
-    } catch {
-      /* ignore malformed */
-    }
-  }
-  return [...out];
-}
+import { buildCorsAllowedOrigins } from './cors-origins.util';
 
 function isPrivateLanOrigin(origin: string): boolean {
   try {
@@ -83,7 +57,7 @@ async function bootstrap() {
   app.useGlobalFilters(new AllExceptionsFilter());
   app.useGlobalInterceptors(new ResponseInterceptor());
 
-  const corsOrigins = buildCorsAllowedOrigins();
+  const corsOrigins = buildCorsAllowedOrigins(process.env);
   const allowLanCors =
     process.env.NODE_ENV !== 'production' &&
     process.env.CORS_ALLOW_LAN === 'true';

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -93,7 +93,18 @@ Trong `.env` build frontend (vd `VITE_API_BASE_URL`):
 VITE_API_BASE_URL=https://api.example.com/api/v1
 ```
 
-Origin frontend phải nằm trong `FRONTEND_URL` / `FRONTEND_URLS` của backend.
+Origin frontend phải nằm trong `FRONTEND_URL` / `FRONTEND_URLS` của backend (khớp **scheme + host + port**, không có path). Ví dụ Vercel:
+
+```env
+FRONTEND_URL=https://diecast360-frontend.vercel.app
+# Hoặc nhiều origin (preview + production), cách nhau bằng dấu phẩy:
+# FRONTEND_URL=https://www.example.com
+# FRONTEND_URLS=https://diecast360-git-main-team.vercel.app
+```
+
+Lưu ý: mỗi origin preview Vercel là URL riêng; thêm từng URL vào `FRONTEND_URLS` nếu cần (không có wildcard).
+
+Sau khi sửa `.env` trên Pi: `sudo systemctl restart diecast360-api` (hoặc service tương đương).
 
 ## 5. Workflow
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -24,7 +24,8 @@ Diecast360 dùng PostgreSQL làm chuẩn cho runtime và Prisma CLI:
 | MAX_UPLOAD_MB | Giới hạn kích thước upload | `10` | Áp dụng cho ảnh thường và frame spinner |
 | ALLOWED_MIME | MIME type cho upload | `image/jpeg,image/png` | Server validate trước khi lưu |
 | PUBLIC_BASE_URL | Base public URL | `http://localhost:5173` | Dùng để ghép URL ảnh/thumbnail |
-| FRONTEND_URL | Frontend origin cho CORS | `http://localhost:5173` | Phải khớp với origin frontend |
+| FRONTEND_URL | Frontend origin cho CORS | `http://localhost:5173` | Phải khớp scheme + host + port với trình duyệt (path/query bị bỏ qua khi normalize) |
+| FRONTEND_URLS | Thêm nhiều origin CORS (cách nhau bằng dấu phẩy) | `https://preview.vercel.app` | Tuỳ chọn; dùng cho preview URL hoặc domain phụ |
 | COOKIE_SECRET | Secret ký cookies | random 32+ chars | Bắt buộc, đổi trong production |
 | COOKIE_SECURE | Chỉ gửi cookies qua HTTPS | `false` (dev) / `true` (prod) | Bật khi deploy HTTPS |
 | COOKIE_SAME_SITE | SameSite attribute cho cookies | `lax` (dev) / `strict` (prod) | Chống CSRF |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cross-origin requests from `https://diecast360-frontend.vercel.app` to the Pi API failed because the backend only reflects `Access-Control-Allow-Origin` when the request `Origin` is listed in `FRONTEND_URL` / `FRONTEND_URLS`. Common misconfigurations include a trailing slash or a full page URL in env, which does not match the browser origin.

## Changes

- **Normalize** `FRONTEND_URL` and each entry in `FRONTEND_URLS`: trim, parse as URL when possible, use `origin` only (drops path/query/hash and trailing slash mismatch).
- **Extract** `buildCorsAllowedOrigins` into `cors-origins.util.ts` with unit tests.
- **Docs**: Pi / Cloudflare guide and `ENV.md` clarify Vercel example and `FRONTEND_URLS` for preview URLs.

## Deploy note (Raspberry Pi)

After merging or cherry-picking, set on the Pi `.env` (exact example for this project):

```env
FRONTEND_URL=https://diecast360-frontend.vercel.app
```

Restart the API service. The `runtime.lastError` Chrome extension message is unrelated to CORS and can be ignored for this issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66a5a6f8-f8f7-4409-a141-e3e3ae981915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66a5a6f8-f8f7-4409-a141-e3e3ae981915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

