### PR TITLE
fix(vercel): SPA rewrite cho route /admin sau login

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Vấn đề

Sau khi đăng nhập admin thành công, điều hướng tới `/admin/reports` (và các route `/admin/*` khác) trên Vercel trả **404 NOT_FOUND** với ID kiểu `hkg1::...` — đây là trang lỗi **Vercel Edge**, không phải response từ Nest trên Raspberry Pi.

Nguyên nhân: deploy Vite là SPA một file `index.html`; request trực tiếp tới `/admin/reports` không khớp file tĩnh nên Vercel trả 404 trước khi React chạy.

## Giải pháp

Thêm `frontend/vercel.json` với rewrite mọi path về `/index.html` để Vercel luôn phục vụ SPA.

## Triển khai

Merge → redeploy frontend trên Vercel (root thư mục `frontend` nếu monorepo).

## Log Raspberry Pi

Lỗi này **không** xuất hiện trên Pi API; vẫn có thể xem log service khi debug khác:

```bash
sudo journalctl -u diecast360-api -f
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66a5a6f8-f8f7-4409-a141-e3e3ae981915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66a5a6f8-f8f7-4409-a141-e3e3ae981915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

