### PR TITLE
fix(auth): SameSite=None cho cookie khi UI và API khác domain

### DIFF
--- a/backend/src/common/security/runtime-security.ts
+++ b/backend/src/common/security/runtime-security.ts
@@ -13,8 +13,13 @@ export function validateRuntimeSecurityConfig(env: NodeJS.ProcessEnv = process.e
   }
 
   const sameSite = (env.COOKIE_SAME_SITE || 'lax').trim().toLowerCase();
-  if (!['lax', 'strict'].includes(sameSite)) {
-    throw new Error('COOKIE_SAME_SITE must be "lax" or "strict" in production');
+  if (!['lax', 'strict', 'none'].includes(sameSite)) {
+    throw new Error(
+      'COOKIE_SAME_SITE must be "lax", "strict", or "none" in production',
+    );
+  }
+  if (sameSite === 'none' && !cookieSecure) {
+    throw new Error('COOKIE_SAME_SITE "none" requires COOKIE_SECURE=true (browser rule)');
   }
 
   const allowLanCors = normalizeEnvBoolean(env.CORS_ALLOW_LAN);

--- a/backend/src/common/security/runtime-security.ts
+++ b/backend/src/common/security/runtime-security.ts
@@ -8,18 +8,19 @@ export function validateRuntimeSecurityConfig(env: NodeJS.ProcessEnv = process.e
   if (!isProduction) return;
 
   const cookieSecure = normalizeEnvBoolean(env.COOKIE_SECURE);
-  if (!cookieSecure) {
-    throw new Error('COOKIE_SECURE must be true in production');
-  }
-
   const sameSite = (env.COOKIE_SAME_SITE || 'lax').trim().toLowerCase();
   if (!['lax', 'strict', 'none'].includes(sameSite)) {
     throw new Error(
       'COOKIE_SAME_SITE must be "lax", "strict", or "none" in production',
     );
   }
+  // Browsers reject SameSite=None without Secure — check before generic COOKIE_SECURE rule
+  // so tests and operators get an actionable message.
   if (sameSite === 'none' && !cookieSecure) {
     throw new Error('COOKIE_SAME_SITE "none" requires COOKIE_SECURE=true (browser rule)');
+  }
+  if (!cookieSecure) {
+    throw new Error('COOKIE_SECURE must be true in production');
   }
 
   const allowLanCors = normalizeEnvBoolean(env.CORS_ALLOW_LAN);

--- a/backend/src/main.security.spec.ts
+++ b/backend/src/main.security.spec.ts
@@ -20,7 +20,18 @@ describe('validateRuntimeSecurityConfig', () => {
     ).toThrow('COOKIE_SECURE must be true in production');
   });
 
-  it('rejects production when COOKIE_SAME_SITE is none', () => {
+  it('rejects production when COOKIE_SAME_SITE is none but COOKIE_SECURE is false', () => {
+    expect(() =>
+      validateRuntimeSecurityConfig({
+        NODE_ENV: 'production',
+        COOKIE_SECURE: 'false',
+        COOKIE_SAME_SITE: 'none',
+        CORS_ALLOW_LAN: 'false',
+      }),
+    ).toThrow('COOKIE_SAME_SITE "none" requires COOKIE_SECURE=true');
+  });
+
+  it('allows production when COOKIE_SAME_SITE is none with secure cookies', () => {
     expect(() =>
       validateRuntimeSecurityConfig({
         NODE_ENV: 'production',
@@ -28,7 +39,18 @@ describe('validateRuntimeSecurityConfig', () => {
         COOKIE_SAME_SITE: 'none',
         CORS_ALLOW_LAN: 'false',
       }),
-    ).toThrow('COOKIE_SAME_SITE must be "lax" or "strict" in production');
+    ).not.toThrow();
+  });
+
+  it('rejects production when COOKIE_SAME_SITE is invalid', () => {
+    expect(() =>
+      validateRuntimeSecurityConfig({
+        NODE_ENV: 'production',
+        COOKIE_SECURE: 'true',
+        COOKIE_SAME_SITE: 'invalid',
+        CORS_ALLOW_LAN: 'false',
+      }),
+    ).toThrow('COOKIE_SAME_SITE must be "lax", "strict", or "none" in production');
   });
 
   it('rejects production when LAN CORS is enabled', () => {

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -83,7 +83,7 @@ Luân phiên key định kỳ: tạo cặp mới, cập nhật secret + `authori
 HTTPS và certificate do Cloudflare lo; trên backend production nên:
 
 - `COOKIE_SECURE=true`
-- `COOKIE_SAME_SITE` phù hợp (thường `lax` hoặc `strict` tùy subdomain/cookie cross-site)
+- `COOKIE_SAME_SITE`: nếu UI (Vercel/domain shop) và API **khác site** → `none` + `COOKIE_SECURE=true`; cùng site → `lax` hoặc `strict`
 
 ## 4. Frontend (hosting khác)
 

--- a/docs/COOKIE_AUTH.md
+++ b/docs/COOKIE_AUTH.md
@@ -27,7 +27,7 @@ FRONTEND_URL=http://localhost:5173
 |------|-------------|--------------|-------|
 | `COOKIE_SECRET` | random string | **MUST CHANGE** | Khóa bí mật để ký cookies |
 | `COOKIE_SECURE` | `false` | `true` | Chỉ gửi cookies qua HTTPS |
-| `COOKIE_SAME_SITE` | `lax` | `strict` | Chống CSRF attacks |
+| `COOKIE_SAME_SITE` | `lax` | `strict`, `lax`, hoặc **`none`** | `none` chỉ khi **frontend và API khác domain** (vd UI `www.shop.com`, API `api.shop.com`); bắt buộc `COOKIE_SECURE=true` và CORS đúng. Cùng site (subpath / reverse proxy) dùng `lax` hoặc `strict`. |
 | `FRONTEND_URL` | `http://localhost:5173` | Your domain | CORS origin |
 
 ## Cookies được sử dụng
@@ -160,6 +160,21 @@ async function bootstrap() {
 
 ## Troubleshooting
 
+### Vào admin ~1 giây rồi bị đá về login (UI và API khác domain)
+
+Khi trang web chạy trên **domain A** (vd `https://www.dhtoys.store`) còn API trên **domain B** (vd `https://nhtin.name.vn`), request XHR là **cross-site**. Cookie `SameSite=Lax` hoặc `Strict` **không** được gửi kèm các request đó → API trả 401 → frontend thử refresh → không có `refresh_token` trong request → chuyển về `/admin/login`.
+
+**Cách sửa trên backend (`.env` production):**
+
+```env
+COOKIE_SECURE=true
+COOKIE_SAME_SITE=none
+```
+
+Rồi restart API. Giữ `FRONTEND_URL` / `FRONTEND_URLS` khớp origin thật của UI (đã có CORS `credentials: true`). CSRF double-submit vẫn bảo vệ các request đổi trạng thái.
+
+**Cách khác (không cần `SameSite=None`):** phục vụ UI và API **cùng một site** (cùng eTLD+1 hoặc reverse proxy một domain, vd `https://www.dhtoys.store` + API `https://www.dhtoys.store/api`).
+
 ### Cookies không được set
 - Kiểm tra CORS: `credentials: true` ở cả backend và frontend
 - Kiểm tra `FRONTEND_URL` khớp với origin của frontend
@@ -171,7 +186,7 @@ async function bootstrap() {
 ### Production checklist
 - [ ] `COOKIE_SECRET` là chuỗi ngẫu nhiên dài > 32 ký tự
 - [ ] `COOKIE_SECURE=true`
-- [ ] `COOKIE_SAME_SITE=strict` hoặc `lax`
+- [ ] `COOKIE_SAME_SITE` phù hợp: **`none`** nếu frontend và API **khác domain**, ngược lại `lax` hoặc `strict`
 - [ ] HTTPS được sử dụng
 - [ ] `FRONTEND_URL` là domain production
 

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -27,7 +27,7 @@ Diecast360 dùng PostgreSQL làm chuẩn cho runtime và Prisma CLI:
 | FRONTEND_URL | Frontend origin cho CORS | `http://localhost:5173` | Phải khớp với origin frontend |
 | COOKIE_SECRET | Secret ký cookies | random 32+ chars | Bắt buộc, đổi trong production |
 | COOKIE_SECURE | Chỉ gửi cookies qua HTTPS | `false` (dev) / `true` (prod) | Bật khi deploy HTTPS |
-| COOKIE_SAME_SITE | SameSite attribute cho cookies | `lax` (dev) / `strict` (prod) | Chống CSRF |
+| COOKIE_SAME_SITE | SameSite attribute cho cookies | `lax` (dev) / `strict` hoặc `none` (prod) | Dùng **`none`** khi frontend và API **khác domain**; bắt buộc `COOKIE_SECURE=true` |
 | FACEBOOK_PAGE_ID | Facebook Page ID cho publish | `123456789` | Tùy chọn (bắt buộc cho FB publish) |
 | FACEBOOK_PAGE_ACCESS_TOKEN | Long-lived Page Access Token | `EAA...` | Tùy chọn (bắt buộc cho FB publish) |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cross-site cookie auth: allow `COOKIE_SAME_SITE=none` in production when `COOKIE_SECURE=true`, with docs.

## CI fix

`main.security.spec.ts` expects `SameSite=none` + insecure cookies to throw **`COOKIE_SAME_SITE "none" requires COOKIE_SECURE=true`** before the generic `COOKIE_SECURE must be true` message. Validation order in `runtime-security.ts` was updated accordingly (commit after rebase onto `main`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66a5a6f8-f8f7-4409-a141-e3e3ae981915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66a5a6f8-f8f7-4409-a141-e3e3ae981915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

