### PR TITLE
ci(deploy): self-hosted runner on Pi for backend deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,14 +1,13 @@
-# Build backend on GitHub Actions (linux/amd64), ship dist + lockfile + Prisma to Raspberry Pi.
-# On the Pi: npm ci --omit=dev rebuilds native deps (bcrypt, sharp) for ARM — do not copy node_modules from the runner.
+# Deploy backend: build on a self-hosted runner on the Raspberry Pi, then sync into
+# DEPLOY_REMOTE_PATH (default /opt/diecast360-backend), npm ci, migrate, restart.
 #
-# Secrets: DEPLOY_HOST, DEPLOY_USER, DEPLOY_SSH_KEY
-# Optional: DEPLOY_REMOTE_PATH (default /opt/diecast360-backend)
+# Requires a registered self-hosted runner with labels: self-hosted, diecast360-pi
+# (see docs/BACKEND_SELF_HOSTED_RUNNER.md).
 #
-# rsync --delete: Pi mirrors the repo (dist + prisma). Do not keep unique files only on the Pi.
-# Optional: create a GitHub Environment named "production" and add required reviewers to gate deploys.
+# Optional secret: DEPLOY_REMOTE_PATH (default /opt/diecast360-backend)
 #
-# Merge vào `main` kích hoạt deploy — nên bật branch protection: PR bắt buộc, CI pass,
-# và (tuỳ chọn) CODEOWNERS review — xem `.github/CODEOWNERS`.
+# Legacy SSH deploy from GitHub-hosted runners is removed — use self-hosted on the Pi
+# or adapt a fork if you still need rsync over SSH.
 
 name: Deploy backend (Pi)
 
@@ -26,11 +25,9 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    # Optional protection: Settings → Environments → production → Required reviewers
+    runs-on: [self-hosted, diecast360-pi]
     environment: production
     env:
-      # Forward optional deploy path to rsync + SSH steps (default on Pi: /opt/diecast360-backend)
       DEPLOY_REMOTE_PATH: ${{ secrets.DEPLOY_REMOTE_PATH }}
     defaults:
       run:
@@ -57,77 +54,28 @@ jobs:
           test -d dist
           test -n "$(find dist -type f -print -quit)" || (echo "::error::dist/ has no files — aborting deploy"; exit 1)
 
-      - name: Install SSH key
-        env:
-          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-        run: |
-          mkdir -p ~/.ssh
-          chmod 700 ~/.ssh
-          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          set -euo pipefail
-          KEYSCAN_OUT="$(mktemp)"
-          if ! ssh-keyscan -H "$DEPLOY_HOST" >"$KEYSCAN_OUT" 2>"${KEYSCAN_OUT}.err"; then
-            echo "::error::ssh-keyscan failed for host $DEPLOY_HOST"
-            cat "${KEYSCAN_OUT}.err" >&2
-            exit 1
-          fi
-          if ! grep -q . "$KEYSCAN_OUT"; then
-            echo "::error::ssh-keyscan returned no keys for $DEPLOY_HOST"
-            cat "${KEYSCAN_OUT}.err" >&2
-            exit 1
-          fi
-          cat "$KEYSCAN_OUT" >> ~/.ssh/known_hosts
-          rm -f "$KEYSCAN_OUT" "${KEYSCAN_OUT}.err"
-
-      - name: Rsync artifact to Pi
-        env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      - name: Sync artifact to deploy directory
         run: |
           set -euo pipefail
-          REMOTE="${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
-          RSYNC_SSH='ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes'
-          # Ship compiled app + manifests; .env and uploads stay on the Pi.
-          rsync -avz --delete \
-            -e "$RSYNC_SSH" \
-            ./dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE}/dist/"
-          rsync -avz \
-            -e "$RSYNC_SSH" \
-            ./package.json ./package-lock.json "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE}/"
-          rsync -avz --delete \
-            -e "$RSYNC_SSH" \
-            ./prisma/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE}/prisma/"
+          REDIR="${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
+          mkdir -p "${REDIR}/dist" "${REDIR}/prisma"
+          rsync -a --delete ./dist/ "${REDIR}/dist/"
+          rsync -a ./package.json ./package-lock.json "${REDIR}/"
+          rsync -a --delete ./prisma/ "${REDIR}/prisma/"
 
       - name: Install prod deps, migrate, restart
-        uses: appleboy/ssh-action@v1.2.0
-        env:
-          DEPLOY_REMOTE_PATH: ${{ env.DEPLOY_REMOTE_PATH }}
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          envs: DEPLOY_REMOTE_PATH
-          script_stop: true
-          script: |
-            set -euo pipefail
-            cd "${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
-            set -a
-            [ -f .env ] && . ./.env
-            set +a
-            PORT="${PORT:-3000}"
-            npm ci --omit=dev
-            npx prisma generate
-            npx prisma migrate deploy
-            sudo systemctl restart diecast360-api
-            sleep 3
-            systemctl is-active --quiet diecast360-api
-            curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null
-
-      - name: Remove deploy key from runner
-        if: always()
         run: |
-          rm -f ~/.ssh/deploy_key
-          chmod 700 ~/.ssh 2>/dev/null || true
-
+          set -euo pipefail
+          REDIR="${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
+          cd "$REDIR"
+          set -a
+          [ -f .env ] && . ./.env
+          set +a
+          PORT="${PORT:-3000}"
+          npm ci --omit=dev
+          npx prisma generate
+          npx prisma migrate deploy
+          sudo systemctl restart diecast360-api
+          sleep 3
+          systemctl is-active --quiet diecast360-api
+          curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -59,7 +59,7 @@ Workflow [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-ba
 
 | Secret / biến | Mô tả |
 |----------------|--------|
-| `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; mặc định `/opt/diecast360-backend`. Có thể đặt trong Environment `production` thay vì secret. |
+| `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; mặc định `/opt/diecast360-backend`. Ví dụ `/opt/diecast360-api` → set secret = `/opt/diecast360-api`. Có thể đặt trong Environment `production` thay vì secret. |
 
 Không cần `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY` khi dùng self-hosted trên Pi như hiện tại.
 

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -51,27 +51,17 @@ echo 'pi ALL=(ALL) NOPASSWD: /bin/systemctl restart diecast360-api' | sudo tee /
 sudo chmod 440 /etc/sudoers.d/diecast360-api
 ```
 
-## 2. GitHub Actions — Secrets
+## 2. GitHub Actions — deploy backend (self-hosted runner trên Pi)
 
-| Secret | Mô tả |
-|--------|--------|
-| `DEPLOY_HOST` | Hostname hoặc IP Pi (**phải SSH được từ internet** tới Pi: port forward 22 hoặc SSH qua Cloudflare / Tailscale tùy bạn). |
-| `DEPLOY_USER` | User SSH (vd `pi`). |
-| `DEPLOY_SSH_KEY` | Private key (toàn bộ PEM), khớp `authorized_keys` trên Pi. |
-| `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; mặc định `/opt/diecast360-backend`. |
+Workflow [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml) chạy trên runner **đặt trên Pi** (`runs-on: [self-hosted, diecast360-pi]`), **không** SSH từ internet vào nhà.
 
-### SSH key cho GitHub → Pi
+**Hướng dẫn từng bước cài runner + nhãn:** [`BACKEND_SELF_HOSTED_RUNNER.md`](BACKEND_SELF_HOSTED_RUNNER.md).
 
-Trên máy dev (không commit private key):
+| Secret / biến | Mô tả |
+|----------------|--------|
+| `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; mặc định `/opt/diecast360-backend`. Có thể đặt trong Environment `production` thay vì secret. |
 
-```bash
-ssh-keygen -t ed25519 -f ./diecast360-deploy -N ""
-```
-
-- Public key (`diecast360-deploy.pub`): thêm vào Pi — `~/.ssh/authorized_keys` của user deploy (một dòng).
-- Private key (`diecast360-deploy`): nội dung file → GitHub Secret **`DEPLOY_SSH_KEY`**.
-
-Luân phiên key định kỳ: tạo cặp mới, cập nhật secret + `authorized_keys`, xoá key cũ.
+Không cần `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY` khi dùng self-hosted trên Pi như hiện tại.
 
 ## 3. Cloudflare Tunnel (public API, không cần mở 443 trên router)
 
@@ -100,8 +90,9 @@ Origin frontend phải nằm trong `FRONTEND_URL` / `FRONTEND_URLS` của backen
 File: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml)
 
 - Trigger: push `main` khi đổi `backend/**`, hoặc **Run workflow** thủ công.
-- Không copy `node_modules` từ runner → Pi luôn `npm ci --omit=dev` đúng kiến trúc ARM.
-- **`rsync --delete`** cho `dist/` và `prisma/`: Pi được **đồng bộ đúng repo** — không giữ file chỉ có trên Pi (tránh drift). Migration chỉ nên có trong Git.
+- Job chạy trên **self-hosted runner trên Pi** (label `diecast360-pi`): checkout → build ARM → `rsync` vào `DEPLOY_REMOTE_PATH` → `npm ci --omit=dev` → migrate → restart.
+- Không copy `node_modules` giữa máy khác và Pi: luôn `npm ci --omit=dev` tại thư mục deploy.
+- **`rsync --delete`** cho `dist/` và `prisma/`: thư mục deploy **khớp repo** — không giữ file chỉ có local (tránh drift). Migration chỉ nên có trong Git.
 - Job dùng GitHub **Environment** tên `production` (tự tạo lần đầu). Vào **Settings → Environments → production** để bật **Required reviewers** nếu muốn chặn migrate/restart cho đến khi duyệt (khuyến nghị cho DB production). Có thể bật **Restrict deployments** (chỉ `main`) để tránh deploy nhầm nhánh.
 
 ### Branch protection (khuyến nghị)

--- a/docs/BACKEND_SELF_HOSTED_RUNNER.md
+++ b/docs/BACKEND_SELF_HOSTED_RUNNER.md
@@ -9,6 +9,7 @@ Khi runner chạy **trực tiếp trên Pi**, workflow **không** SSH từ inter
 ## Yêu cầu trước
 
 - Pi **64-bit** (khuyến nghị), **Node 20** (`node -v`).
+- **`git`** đã cài (`sudo apt install git`) — `actions/checkout` cần.
 - Thư mục deploy (mặc định `/opt/diecast360-backend`) có `.env`, `uploads/`, và service `diecast360-api` như [`BACKEND_PI_CLOUDFLARE.md`](BACKEND_PI_CLOUDFLARE.md).
 - User chạy runner (thường `pi`) có quyền:
   - **Ghi** vào `DEPLOY_REMOTE_PATH` (sở hữu thư mục hoặc ACL phù hợp).
@@ -73,6 +74,8 @@ User runner phải ghi được `dist/`, `prisma/`, `package.json` trong `DEPLOY
 sudo chown -R pi:pi /opt/diecast360-backend
 ```
 
+(Thay bằng đường dẫn thật của bạn, ví dụ `/opt/diecast360-api`, nếu dùng `DEPLOY_REMOTE_PATH` khác mặc định.)
+
 Sudoers (một dòng, đã có trong doc Pi — chỉnh user nếu khác):
 
 ```bash
@@ -86,7 +89,15 @@ sudo chmod 440 /etc/sudoers.d/diecast360-api
 
 | Secret | Mô tả |
 |--------|--------|
-| `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; nếu **không** set → mặc định `/opt/diecast360-backend`. |
+| `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; nếu **không** set → mặc định `/opt/diecast360-backend`. Ví dụ bạn dùng `/opt/diecast360-api` → đặt secret này thành **`/opt/diecast360-api`** (đúng dấu `/` đầu). |
+
+### Thư mục deploy là `/opt/diecast360-api` (không phải `-backend`)
+
+1. GitHub → **Settings → Secrets and variables → Actions** (hoặc Environment **production**): tạo secret **`DEPLOY_REMOTE_PATH`** = `/opt/diecast360-api`.
+2. Trên Pi: tạo thư mục, `.env`, `uploads/`, quyền sở hữu — thay mọi chỗ doc viết `/opt/diecast360-backend` bằng **`/opt/diecast360-api`**.
+3. **systemd** (`diecast360-api.service`): `WorkingDirectory` và `EnvironmentFile` phải trỏ tới **`/opt/diecast360-api`** (và `ExecStart` vẫn `node dist/main.js` trong thư mục đó).
+
+Workflow chỉ đọc biến này; **không** bắt buộc đổi tên service `diecast360-api`.
 
 **Không cần** `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY` khi chỉ dùng self-hosted như workflow mới.
 

--- a/docs/BACKEND_SELF_HOSTED_RUNNER.md
+++ b/docs/BACKEND_SELF_HOSTED_RUNNER.md
@@ -1,0 +1,129 @@
+# GitHub Actions self-hosted runner trên Raspberry Pi (deploy backend)
+
+Khi runner chạy **trực tiếp trên Pi**, workflow **không** SSH từ internet vào nhà: chỉ `checkout` → `build` trên ARM → `rsync` nội bộ vào thư mục deploy → `npm ci` → migrate → `systemctl restart`.
+
+**Nhãn runner bắt buộc:** workflow dùng `runs-on: [self-hosted, diecast360-pi]`. Khi đăng ký runner, thêm nhãn tùy chọn **`diecast360-pi`** (Settings → Actions → Runners → runner của bạn → labels), hoặc thêm lúc cấu hình lần đầu.
+
+---
+
+## Yêu cầu trước
+
+- Pi **64-bit** (khuyến nghị), **Node 20** (`node -v`).
+- Thư mục deploy (mặc định `/opt/diecast360-backend`) có `.env`, `uploads/`, và service `diecast360-api` như [`BACKEND_PI_CLOUDFLARE.md`](BACKEND_PI_CLOUDFLARE.md).
+- User chạy runner (thường `pi`) có quyền:
+  - **Ghi** vào `DEPLOY_REMOTE_PATH` (sở hữu thư mục hoặc ACL phù hợp).
+  - **`sudo systemctl restart diecast360-api`** không mật khẩu (sudoers một lệnh như trong doc Pi).
+
+---
+
+## Bước 1 — Tạo runner trên GitHub
+
+1. Repo → **Settings** → **Actions** → **Runners** → **New self-hosted runner**.
+2. Chọn **Linux** và **ARM64** (Pi 4 OS 64-bit).
+3. GitHub hiển thị lệnh tải `actions-runner-*.tar.gz` và `./config.sh ...` — **chưa chạy**; làm bước 2 trên Pi.
+
+---
+
+## Bước 2 — Cài runner trên Pi (SSH vào Pi)
+
+Tạo thư mục (ví dụ home của user `pi`):
+
+```bash
+mkdir -p ~/actions-runner && cd ~/actions-runner
+```
+
+Tải và giải nén **đúng** gói **linux-arm64** mà trang GitHub hiển thị (phiên bản thay đổi — luôn copy lệnh từ **New self-hosted runner**), ví dụ:
+
+```bash
+# Thay URL/tên file bằng lệnh copy từ GitHub (ARM64)
+curl -o actions-runner-linux-arm64.tar.gz -L 'https://github.com/actions/runner/releases/download/vX.Y.Z/actions-runner-linux-arm64-X.Y.Z.tar.gz'
+tar xzf ./actions-runner-linux-arm64.tar.gz
+```
+
+Cấu hình (dán token từ trang GitHub — token **hết hạn nhanh**, chỉ dùng một lần):
+
+```bash
+./config.sh --url https://github.com/OWNER/REPO --token RUNNER_TOKEN_TU_GITHUB
+```
+
+Trong wizard:
+
+- **Runner group:** mặc định `Default` (hoặc nhóm bạn dùng).
+- **Tên runner:** ví dụ `pi-diecast360`.
+- **Labels:** thêm **`diecast360-pi`** (bắt buộc khớp workflow; có thể thêm `self-hosted`, `linux`, `arm64` nếu muốn).
+- **Work folder:** Enter (mặc định `_work`).
+
+Cài service để runner tự chạy khi boot:
+
+```bash
+sudo ./svc.sh install
+sudo ./svc.sh start
+sudo ./svc.sh status
+```
+
+Kiểm tra trên GitHub: runner hiện **Idle** (màu xanh).
+
+---
+
+## Bước 3 — Quyền deploy (trên Pi)
+
+User runner phải ghi được `dist/`, `prisma/`, `package.json` trong `DEPLOY_REMOTE_PATH` và restart service:
+
+```bash
+sudo chown -R pi:pi /opt/diecast360-backend
+```
+
+Sudoers (một dòng, đã có trong doc Pi — chỉnh user nếu khác):
+
+```bash
+echo 'pi ALL=(ALL) NOPASSWD: /bin/systemctl restart diecast360-api' | sudo tee /etc/sudoers.d/diecast360-api
+sudo chmod 440 /etc/sudoers.d/diecast360-api
+```
+
+---
+
+## Bước 4 — GitHub Secrets (tuỳ chọn)
+
+| Secret | Mô tả |
+|--------|--------|
+| `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; nếu **không** set → mặc định `/opt/diecast360-backend`. |
+
+**Không cần** `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY` khi chỉ dùng self-hosted như workflow mới.
+
+Environment **production** (nếu workflow gắn `environment: production`): có thể thêm biến `DEPLOY_REMOTE_PATH` ở đó thay vì secret.
+
+---
+
+## Bước 5 — Kích hoạt deploy
+
+- **Push `main`** có thay đổi `backend/**` hoặc `.github/workflows/deploy-backend.yml`.
+- Hoặc **Actions** → **Deploy backend (Pi)** → **Run workflow**.
+
+Job chỉ chạy khi có runner **online** với label **`diecast360-pi`**. Nếu không có runner, job sẽ **treo chờ** — cần bật Pi + `sudo ./svc.sh start`.
+
+---
+
+## Gỡ runner (khi cần)
+
+Trên Pi, trong thư mục runner:
+
+```bash
+cd ~/actions-runner
+sudo ./svc.sh stop
+sudo ./svc.sh uninstall
+./config.sh remove --token TOKEN_GITHUB_REMOVE
+```
+
+(Token remove lấy tại GitHub: Runner → … → Remove.)
+
+---
+
+## So với deploy qua SSH (runner trên GitHub)
+
+| | Self-hosted trên Pi | SSH từ `ubuntu-latest` |
+|--|---------------------|-------------------------|
+| Mở port 22 / tunnel | Không cần cho GitHub | Cần host public hoặc tunnel |
+| Build backend | Trên ARM Pi (đúng kiến trúc) | Trên AMD64 rồi rsync `dist` (đã hỗ trợ) |
+| Tải repo mỗi lần | Có (`checkout` full clone shallow) | Chỉ rsync artifact nhỏ |
+
+Nếu Pi hoặc mạng nhà chậm, có thể cân nhắc giữ build trên GitHub + chỉ self-hosted cho bước copy (workflow tách job) — hiện tại workflow **build toàn bộ trên Pi** để đơn giản một job.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -130,11 +130,13 @@ Chi tiết Facebook, OpenAI, Pinecone: tùy tính năng bật — vẫn trong [`
 4. Cập nhật `VITE_API_BASE_URL` trên host frontend, deploy lại frontend.
 5. Kiểm tra đăng nhập, upload nhỏ, catalog; đọc [`COOKIE_AUTH.md`](COOKIE_AUTH.md) nếu cookie cross-site lỗi.
 
+Tự động deploy backend khi merge `main`: cài [GitHub self-hosted runner trên Pi](BACKEND_SELF_HOSTED_RUNNER.md) và dùng workflow [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml).
+
 ---
 
 ## 6. CI và migration
 
-Workflow CI mặc định: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). Nếu repository có thêm workflow migrate Neon kích hoạt sau CI xanh trên `main`, cấu hình secret `NEON_DATABASE_URL` (và tùy chọn `NEON_DIRECT_URL`) trong GitHub Actions — không ghi secret vào git.
+Workflow CI mặc định: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). Deploy backend lên Pi (self-hosted runner): [`BACKEND_SELF_HOSTED_RUNNER.md`](BACKEND_SELF_HOSTED_RUNNER.md) và [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml). Nếu repository có thêm workflow migrate Neon kích hoạt sau CI xanh trên `main`, cấu hình secret `NEON_DATABASE_URL` (và tùy chọn `NEON_DIRECT_URL`) trong GitHub Actions — không ghi secret vào git.
 
 ---
 
@@ -142,4 +144,4 @@ Workflow CI mặc định: [`.github/workflows/ci.yml`](../.github/workflows/ci.
 
 - Xoay mật khẩu Neon nếu từng lộ URL trong chat / log công khai.
 - Sao lưu định kỳ thư mục upload trên Pi; Neon có backup theo gói dịch vụ.
-- Cập nhật code: `git pull` trên Pi → `npm ci --omit=dev` → `npm run build` → `systemctl restart …`.
+- Cập nhật code: merge `main` (workflow self-hosted trên Pi) hoặc tay: `git pull` trên Pi → `npm ci --omit=dev` → `npm run build` → `systemctl restart …`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy backend workflow now runs on a **self-hosted runner on the Raspberry Pi** instead of SSH/rsync from `ubuntu-latest`.

## Why

- No `DEPLOY_HOST` / SSH key / inbound SSH from GitHub required.
- Build runs on **ARM** on the Pi (same architecture as production `npm ci --omit=dev`).

## Requirements

- Register a self-hosted runner on the Pi with labels **`self-hosted`** and **`diecast360-pi`** (add `diecast360-pi` at config time or in runner settings).
- Optional secret: `DEPLOY_REMOTE_PATH` (default `/opt/diecast360-backend`).
- Runner user needs write access to deploy dir + passwordless `sudo systemctl restart diecast360-api` (documented).

## Docs

- New: [`docs/BACKEND_SELF_HOSTED_RUNNER.md`](docs/BACKEND_SELF_HOSTED_RUNNER.md) — step-by-step install.
- Updated: [`docs/BACKEND_PI_CLOUDFLARE.md`](docs/BACKEND_PI_CLOUDFLARE.md), [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).

## Note before merge

Until the Pi runner is online with label `diecast360-pi`, the deploy job will **wait for a runner** when triggered. Set up the runner first, or merge when ready.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66a5a6f8-f8f7-4409-a141-e3e3ae981915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66a5a6f8-f8f7-4409-a141-e3e3ae981915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

