### PR TITLE
fix(deploy): health check and listen binding for Pi deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -76,6 +76,18 @@ jobs:
           npx prisma generate
           npx prisma migrate deploy
           sudo systemctl restart diecast360-api
-          sleep 3
           systemctl is-active --quiet diecast360-api
-          curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null
+          HEALTH_RETRIES="${HEALTH_RETRIES:-30}"
+          HEALTH_INTERVAL_SEC="${HEALTH_INTERVAL_SEC:-2}"
+          for i in $(seq 1 "$HEALTH_RETRIES"); do
+            if curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null; then
+              exit 0
+            fi
+            if [ "$i" -eq "$HEALTH_RETRIES" ]; then
+              echo "::error::Health check failed after ${HEALTH_RETRIES} attempts (${HEALTH_INTERVAL_SEC}s interval)" >&2
+              sudo systemctl --no-pager -l status diecast360-api || true
+              journalctl -u diecast360-api -n 80 --no-pager || true
+              exit 1
+            fi
+            sleep "${HEALTH_INTERVAL_SEC}"
+          done

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -71,17 +71,19 @@ jobs:
           set -a
           [ -f .env ] && . ./.env
           set +a
+          # Default when .env omits PORT or sets it empty.
           PORT="${PORT:-3000}"
           npm ci --omit=dev
           npx prisma generate
           npx prisma migrate deploy
           sudo systemctl restart diecast360-api
           systemctl is-active --quiet diecast360-api
+          # Post-restart probe: Pi/Node may need several seconds before accepting IPv4.
           HEALTH_RETRIES="${HEALTH_RETRIES:-30}"
           HEALTH_INTERVAL_SEC="${HEALTH_INTERVAL_SEC:-2}"
           for i in $(seq 1 "$HEALTH_RETRIES"); do
             if curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null; then
-              exit 0
+              break
             fi
             if [ "$i" -eq "$HEALTH_RETRIES" ]; then
               echo "::error::Health check failed after ${HEALTH_RETRIES} attempts (${HEALTH_INTERVAL_SEC}s interval)" >&2

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,8 @@ DIRECT_URL="postgresql://postgres:postgres@localhost:5432/diecast360"
 
 # Application Settings
 PORT=3000
+# Listen address (default in app: 0.0.0.0). Use 127.0.0.1 for localhost-only.
+# HOST=0.0.0.0
 FRONTEND_URL="http://localhost:5173"
 # Optional comma-separated extra origins (CORS + cookies). localhost/127.0.0.1 variants are auto-added from FRONTEND_URL.
 # FRONTEND_URLS="https://preview.example.com"

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -109,9 +109,13 @@ async function bootstrap() {
 
   const port = process.env.PORT || 3000;
   // Default 0.0.0.0 so IPv4 probes (curl 127.0.0.1) work; some Node/OS combos only open :: otherwise.
-  const host = (process.env.HOST || '0.0.0.0').trim();
+  const rawHost = (process.env.HOST ?? '0.0.0.0').trim();
+  const host = rawHost.length > 0 ? rawHost : '0.0.0.0';
   await app.listen(port, host);
   console.log(`Application is running on: http://${host}:${port}`);
+  if (host === '0.0.0.0') {
+    console.log(`Also reachable at: http://127.0.0.1:${port} (and other interfaces)`);
+  }
 }
 export { validateRuntimeSecurityConfig } from './common/security/runtime-security';
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -108,8 +108,10 @@ async function bootstrap() {
   });
 
   const port = process.env.PORT || 3000;
-  await app.listen(port);
-  console.log(`Application is running on: http://localhost:${port}`);
+  // Default 0.0.0.0 so IPv4 probes (curl 127.0.0.1) work; some Node/OS combos only open :: otherwise.
+  const host = (process.env.HOST || '0.0.0.0').trim();
+  await app.listen(port, host);
+  console.log(`Application is running on: http://${host}:${port}`);
 }
 export { validateRuntimeSecurityConfig } from './common/security/runtime-security';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy workflow failed with `curl: (7) Failed to connect to 127.0.0.1 port 3000` even though `systemctl is-active` reported the service as running. That pattern often means the Node process is up but nothing is accepting **IPv4** on that port (for example when the HTTP server only binds `::`), or the app needs more time than a fixed 3s sleep before the first probe.

## Changes

- **Nest listen host:** Default `HOST` to `0.0.0.0` so the server accepts IPv4 (including `curl` to `127.0.0.1`) while remaining compatible with Cloudflare Tunnel and typical Pi setups. Empty `HOST` after trim falls back to `0.0.0.0`. Override with `HOST=127.0.0.1` if localhost-only is required. Extra log line when binding all interfaces.
- **Deploy health check:** Retry `curl` to `/api/v1/health` with configurable `HEALTH_RETRIES` / `HEALTH_INTERVAL_SEC`; on final failure print `systemctl status` and recent `journalctl` for faster diagnosis. Use `break` on success (per review).
- **Docs:** Note optional `HOST` in `backend/.env.example`.

## Follow-up (PR comments)

- AI review: `exit 0` → `break` for clarity; comments for retry vars; `HOST` empty-after-trim fallback; dev-friendly log when `host === '0.0.0.0'`.

## Testing

Node/npm were not available in this agent environment; please run backend tests locally if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0048be6b-7843-49bc-b998-34553bd5b284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0048be6b-7843-49bc-b998-34553bd5b284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

