### PR TITLE
fix(auth): allow legacy super_admin on tenant APIs (reports 403)

### DIFF
--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -127,6 +127,16 @@ describe('RolesGuard', () => {
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
+  it('denies legacy super_admin when route requires shop_staff only', async () => {
+    mockReflector(undefined, [ShopRole.shop_staff]);
+    const ctx = createContext({
+      id: 'u1',
+      active_shop_id: 'shop-a',
+      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.super_admin }],
+    });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
+
   it('throws BadRequestException when active_shop_id is missing for tenant route', async () => {
     mockReflector(undefined, [ShopRole.shop_admin]);
     const ctx = createContext({

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -104,6 +104,29 @@ describe('RolesGuard', () => {
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
+  it('allows legacy super_admin shop row when route requires shop_admin', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext({
+      id: 'u1',
+      active_shop_id: 'shop-a',
+      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.super_admin }],
+    });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('allows legacy super_admin on POST when route lists shop_admin (full write)', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext(
+      {
+        id: 'u1',
+        active_shop_id: 'shop-a',
+        shop_roles: [{ shop_id: 'shop-a', role: ShopRole.super_admin }],
+      },
+      'POST',
+    );
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
   it('throws BadRequestException when active_shop_id is missing for tenant route', async () => {
     mockReflector(undefined, [ShopRole.shop_admin]);
     const ctx = createContext({

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -137,6 +137,16 @@ describe('RolesGuard', () => {
     await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
   });
 
+  it('denies legacy super_admin when membership is for a different shop than active_shop_id', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext({
+      id: 'u1',
+      active_shop_id: 'shop-b',
+      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.super_admin }],
+    });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
+
   it('throws BadRequestException when active_shop_id is missing for tenant route', async () => {
     mockReflector(undefined, [ShopRole.shop_admin]);
     const ctx = createContext({

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -45,6 +45,9 @@ const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
  * We only equate `super_admin` to **shop_admin** eligibility: if a route were ever
  * decorated with `@Roles(ShopRole.shop_staff)` alone, legacy `super_admin` would not
  * satisfy it (avoids widening access on hypothetical staff-only surfaces).
+ *
+ * Prefer a data migration (`super_admin` → `shop_admin` per shop row) so this branch
+ * can be removed once production rows are normalized.
  */
 function userRoleSatisfiesTenantRequirement(userRole: ShopRole, tenantRoles: ShopRole[]): boolean {
   if (tenantRoles.includes(userRole)) {

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -39,6 +39,22 @@ export interface JwtUserShopRole {
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
 /**
+ * Legacy shop membership role: before RBAC migration, `user_shop_roles.role` used
+ * `super_admin` for full shop access. Those rows may still exist in production DBs.
+ * Tenant routes that list only {@link ShopRole.shop_admin} / {@link ShopRole.shop_staff}
+ * must still accept `super_admin` so authenticated users are not denied with 403.
+ */
+function userRoleSatisfiesTenantRequirement(userRole: ShopRole, tenantRoles: ShopRole[]): boolean {
+  if (!tenantRoles.includes(userRole)) {
+    if (userRole === ShopRole.super_admin) {
+      return tenantRoles.some((r) => r === ShopRole.shop_admin || r === ShopRole.shop_staff);
+    }
+    return false;
+  }
+  return true;
+}
+
+/**
  * RolesGuard — dual-layer authorization guard.
  *
  * ## Platform layer (@PlatformRoles decorator)
@@ -168,7 +184,10 @@ export class RolesGuard implements CanActivate {
     }
 
     const matchingRole = shopRoles.find(
-      (ur) => ur?.role != null && (tenantRoles as ShopRole[]).includes(ur.role) && ur.shop_id === activeShopId,
+      (ur) =>
+        ur?.role != null &&
+        ur.shop_id === activeShopId &&
+        userRoleSatisfiesTenantRequirement(ur.role, tenantRoles as ShopRole[]),
     );
 
     if (!matchingRole) {

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -41,17 +41,16 @@ const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 /**
  * Legacy shop membership role: before RBAC migration, `user_shop_roles.role` used
  * `super_admin` for full shop access. Those rows may still exist in production DBs.
- * Tenant routes that list only {@link ShopRole.shop_admin} / {@link ShopRole.shop_staff}
- * must still accept `super_admin` so authenticated users are not denied with 403.
+ *
+ * We only equate `super_admin` to **shop_admin** eligibility: if a route were ever
+ * decorated with `@Roles(ShopRole.shop_staff)` alone, legacy `super_admin` would not
+ * satisfy it (avoids widening access on hypothetical staff-only surfaces).
  */
 function userRoleSatisfiesTenantRequirement(userRole: ShopRole, tenantRoles: ShopRole[]): boolean {
-  if (!tenantRoles.includes(userRole)) {
-    if (userRole === ShopRole.super_admin) {
-      return tenantRoles.some((r) => r === ShopRole.shop_admin || r === ShopRole.shop_staff);
-    }
-    return false;
+  if (tenantRoles.includes(userRole)) {
+    return true;
   }
-  return true;
+  return userRole === ShopRole.super_admin && tenantRoles.includes(ShopRole.shop_admin);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After login, `GET /api/v1/reports/summary` and `GET /api/v1/reports/trends` returned **403 Forbidden** for some users while other parts of the admin UI still worked.

## Root cause

`RolesGuard` only matched `user_shop_roles.role` against `@Roles(shop_admin, shop_staff)`. Legacy rows still have **`super_admin`**, which did not match, so the guard returned 403. `GET /auth/me` does not use the same rule, so the session looked fine while reports failed.

## Fix

Treat legacy **`ShopRole.super_admin`** as satisfying tenant routes **only when `shop_admin` is among the required `@Roles`** (equivalent to full shop admin for Option C / write paths).

## Affected API surface (same as all `@Roles(shop_admin, shop_staff)` controllers)

Legacy `super_admin` rows now pass the tenant role check the same way as `shop_admin` for these modules (previously 403 if JWT shop matched but DB role was only `super_admin`):

- `ReportsController` — `/reports/*`
- `ItemsController`, `AiDraftController` — `/items/*`, AI draft
- `PreordersController` — `/preorders/*`
- `InventoryController` — `/inventory/*`
- `MembersController` — `/members/*`
- `ImagesController` — `/images/*`
- `SpinnerController` — spinner routes
- `AiController` — AI routes

Platform-only routes (`@PlatformRoles`) are unchanged.

## Review follow-up (addressed in commits)

- Narrow mapping: `super_admin` **only** when `shop_admin` is in `@Roles` (not staff-only metadata).
- Tests: staff-only denial; **super_admin on wrong `active_shop_id`** denied; POST with `shop_admin` in metadata allowed.
- Comment in guard: prefer **data migration** `super_admin` → `shop_admin` so the shim can be removed later.

## Migration note

Run a DB migration to normalize `user_shop_roles.role` when ready; until then this guard keeps production working.

## Verification

- `backend/src/common/guards/roles.guard.spec.ts`

Note: CI not run in agent env; run `npm test` in `backend/` locally.

---

**Automation note:** Cursor “HIGH risk / changes requested” on `RolesGuard` is expected until a human **CODEOWNERS** review (`@nguyenhoangtin1404` for `/backend/`); the bot does not self-approve.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83051d72-17c8-4457-a121-7a1b0ef69ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83051d72-17c8-4457-a121-7a1b0ef69ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

