### PR TITLE
Document BACKEND_URL for production media URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,8 @@ PORT=3000
 # Used for CORS in backend and generation of links
 FRONTEND_URL=http://localhost:5173
 PUBLIC_BASE_URL=http://localhost:5173
+# API origin for signed media URLs (/api/v1/media). Backend defaults to http://localhost:3000 if unset.
+# BACKEND_URL=https://your-api-host.example.com
 
 # Frontend Configuration
 # Used during build time for frontend

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,9 @@ FRONTEND_URL="http://localhost:5173"
 # Vite --host (LAN): set true in dev, keep false in production unless you need it.
 # CORS_ALLOW_LAN=true
 UPLOAD_DIR="./uploads"
+# Public base URL of this API (no trailing slash). Used to sign GET /api/v1/media links.
+# In production set to your HTTPS API origin (e.g. https://nhtin.name.vn). If unset, defaults to http://localhost:3000 (breaks images from a public HTTPS frontend).
+# BACKEND_URL="https://nhtin.name.vn"
 
 # Auth Settings
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production consoles showed mixed content and loopback blocks when image URLs pointed at `http://localhost:3000/api/v1/media`. The backend builds those URLs in `LocalStorageService.getFileUrl()` using `BACKEND_URL`, defaulting to `http://localhost:3000` when unset.

## Changes

- Document `BACKEND_URL` in `backend/.env.example` with a short note that production must set the public HTTPS API origin.
- Add the same hint to the root `.env.example` next to `PUBLIC_BASE_URL` / `FRONTEND_URL`.

No runtime code changes; operators deploying API + separate frontend should set `BACKEND_URL` on the API host and ensure `FRONTEND_URL` / `FRONTEND_URLS` include the live frontend origin for CORS and cookies per `docs/COOKIE_AUTH.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6af363a5-95ac-4cd5-ba29-1912db6fdcbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6af363a5-95ac-4cd5-ba29-1912db6fdcbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

