### PR TITLE
fix(api): CORS before CSRF so 403 responses are not opaque to browsers

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -22,6 +22,8 @@ function buildCorsAllowedOrigins(): string[] {
     out.add(raw);
     try {
       const u = new URL(raw);
+      // Normalize so trailing slash in env (e.g. https://app.com/) still matches browser Origin.
+      out.add(u.origin);
       if (u.hostname === 'localhost') {
         u.hostname = '127.0.0.1';
         out.add(u.origin);
@@ -68,7 +70,6 @@ async function bootstrap() {
     throw new Error('COOKIE_SECRET must be set and at least 32 characters long');
   }
   app.use(cookieParser(cookieSecret));
-  app.use(createCsrfMiddleware());
 
   app.setGlobalPrefix('api/v1');
   
@@ -106,6 +107,9 @@ async function bootstrap() {
     },
     credentials: true,
   });
+
+  // Run after CORS so error responses (e.g. CSRF 403) still get Access-Control-Allow-Origin.
+  app.use(createCsrfMiddleware());
 
   const port = process.env.PORT || 3000;
   // Default 0.0.0.0 so IPv4 probes (curl 127.0.0.1) work; some Node/OS combos only open :: otherwise.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Mutating requests (`DELETE`, `POST` to `/api/v1/items`) returned **403** (often `CSRF_INVALID`) while the browser also reported **CORS: No Access-Control-Allow-Origin** and Axios **Network Error**. That masked the real failure: CSRF middleware ran **before** CORS was applied, so short-circuited 403 responses never received CORS headers and the client could not read the JSON body.

## Changes

1. Call `app.enableCors(...)` **before** `app.use(createCsrfMiddleware())` so CORS headers are applied even when CSRF rejects the request.
2. In `buildCorsAllowedOrigins`, also add `u.origin` for every configured URL so `FRONTEND_URL=https://www.dhtoys.store/` (trailing slash) still matches the browser `Origin` header.

## Deploy

Merge and redeploy the API container/process on the Pi, then retry delete/create from `https://www.dhtoys.store`. If 403 persists after CORS is fixed, the response body should now be visible in DevTools as `CSRF_INVALID` — fix by ensuring `GET /api/v1/auth/csrf` runs after login (existing frontend flow) and that `csrf_token` cookie is set for the API domain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6af363a5-95ac-4cd5-ba29-1912db6fdcbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6af363a5-95ac-4cd5-ba29-1912db6fdcbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

