### PR TITLE
fix(frontend): CSRF token from API response body for cross-origin admin

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,11 +1,6 @@
 import axios from 'axios';
 import { API_CONFIG } from '../config/api';
-import {
-  csrfHeaderPair,
-  ensureCsrfBootstrap,
-  fetchWithCsrfRetry,
-  rememberCsrfFromResponseBody,
-} from './csrf';
+import { csrfHeaderPair, ensureCsrfBootstrap, fetchWithCsrfRetry } from './csrf';
 
 export const apiClient = axios.create({
   baseURL: API_CONFIG.BASE_URL,
@@ -39,7 +34,6 @@ apiClient.interceptors.response.use(
   (response) => {
     // Backend returns {ok: true, data: {...}, message: ''}
     // Unwrap response.data for convenience
-    rememberCsrfFromResponseBody(response.data);
     return response.data;
   },
   async (error) => {
@@ -108,7 +102,6 @@ apiClient.interceptors.response.use(
 
         // Check if refresh was successful
         if (refreshResponse.status === 200) {
-          rememberCsrfFromResponseBody(refreshResponse.data);
           await ensureCsrfBootstrap();
           // Retry the original request - new access_token cookie will be sent automatically
           return apiClient(originalRequest);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
 import { API_CONFIG } from '../config/api';
-import { csrfHeaderPair, ensureCsrfBootstrap, fetchWithCsrfRetry } from './csrf';
+import {
+  csrfHeaderPair,
+  ensureCsrfBootstrap,
+  fetchWithCsrfRetry,
+  rememberCsrfFromResponseBody,
+} from './csrf';
 
 export const apiClient = axios.create({
   baseURL: API_CONFIG.BASE_URL,
@@ -34,6 +39,7 @@ apiClient.interceptors.response.use(
   (response) => {
     // Backend returns {ok: true, data: {...}, message: ''}
     // Unwrap response.data for convenience
+    rememberCsrfFromResponseBody(response.data);
     return response.data;
   },
   async (error) => {
@@ -102,6 +108,8 @@ apiClient.interceptors.response.use(
 
         // Check if refresh was successful
         if (refreshResponse.status === 200) {
+          rememberCsrfFromResponseBody(refreshResponse.data);
+          await ensureCsrfBootstrap();
           // Retry the original request - new access_token cookie will be sent automatically
           return apiClient(originalRequest);
         }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { API_CONFIG } from '../config/api';
-import { csrfHeaderPair, ensureCsrfBootstrap, fetchWithCsrfRetry } from './csrf';
+import { csrfHeaderPair, clearMemoryCsrfToken, ensureCsrfBootstrap, fetchWithCsrfRetry } from './csrf';
 
 export const apiClient = axios.create({
   baseURL: API_CONFIG.BASE_URL,
@@ -107,6 +107,7 @@ apiClient.interceptors.response.use(
           return apiClient(originalRequest);
         }
       } catch (refreshError) {
+        clearMemoryCsrfToken();
         // Refresh failed - only redirect if user is trying to access protected page
         // Don't redirect if:
         // 1. Already on login page

--- a/frontend/src/api/csrf.ts
+++ b/frontend/src/api/csrf.ts
@@ -25,7 +25,7 @@ function shouldRetryCsrfBootstrap(err: unknown, attemptIndex: number): boolean {
   const status = err.response?.status;
   if (status === 401 || status === 403) return false;
   if (!err.response) return true;
-  return status >= 500;
+  return typeof status === 'number' && status >= 500;
 }
 
 export function clearMemoryCsrfToken(): void {

--- a/frontend/src/api/csrf.ts
+++ b/frontend/src/api/csrf.ts
@@ -34,8 +34,8 @@ export function rememberCsrfFromResponseBody(body: unknown): void {
 
 /**
  * Double-submit CSRF: readable cookie + X-CSRF-Token header (must match).
- * Prefer the cookie when document.cookie can read it (same-origin dev); otherwise use memory
- * filled from GET /auth/csrf (and login/refresh responses) for cross-site API hosts.
+ * Prefer cookie when document.cookie can read it (same-origin dev); otherwise use memory from
+ * GET /auth/csrf for cross-site API hosts (third-party cookie not visible to JS).
  */
 export function readCsrfTokenFromCookie(): string | undefined {
   if (typeof document === 'undefined') return undefined;

--- a/frontend/src/api/csrf.ts
+++ b/frontend/src/api/csrf.ts
@@ -2,7 +2,40 @@ import axios from 'axios';
 import { API_CONFIG } from '../config/api';
 
 /**
+ * In-memory CSRF value for cross-site setups (e.g. UI on www.shop.com, API on api.shop.com).
+ * The csrf_token cookie is set on the API host; browsers do not expose third-party cookies to
+ * document.cookie, so the double-submit header must be filled from the GET /auth/csrf JSON body.
+ */
+let memoryCsrfToken: string | undefined;
+
+export function clearMemoryCsrfToken(): void {
+  memoryCsrfToken = undefined;
+}
+
+/** Parse wrapped ({ ok, data }) or raw ({ csrf_token }) API bodies from auth endpoints. */
+export function extractCsrfTokenFromBody(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const o = body as Record<string, unknown>;
+  if (typeof o.csrf_token === 'string' && o.csrf_token.length > 0) {
+    return o.csrf_token;
+  }
+  const data = o.data;
+  if (data && typeof data === 'object') {
+    const t = (data as Record<string, unknown>).csrf_token;
+    if (typeof t === 'string' && t.length > 0) return t;
+  }
+  return undefined;
+}
+
+export function rememberCsrfFromResponseBody(body: unknown): void {
+  const t = extractCsrfTokenFromBody(body);
+  if (t) memoryCsrfToken = t;
+}
+
+/**
  * Double-submit CSRF: readable cookie + X-CSRF-Token header (must match).
+ * Same-origin: cookie is readable from document.cookie.
+ * Cross-site API: use memory filled from GET /auth/csrf (and login/refresh responses if present).
  */
 export function readCsrfTokenFromCookie(): string | undefined {
   if (typeof document === 'undefined') return undefined;
@@ -23,13 +56,14 @@ export function readCsrfTokenFromCookie(): string | undefined {
 }
 
 export function csrfHeaderPair(): Record<string, string> {
-  const token = readCsrfTokenFromCookie();
+  const token = memoryCsrfToken || readCsrfTokenFromCookie();
   return token ? { 'X-CSRF-Token': token } : {};
 }
 
-/** Lấy cookie csrf_token từ backend (GET an toàn). */
+/** Lấy CSRF từ backend (GET an toàn) và lưu token vào memory khi cookie là cross-site. */
 export async function ensureCsrfBootstrap(): Promise<void> {
-  await axios.get(`${API_CONFIG.BASE_URL}/auth/csrf`, { withCredentials: true });
+  const res = await axios.get(`${API_CONFIG.BASE_URL}/auth/csrf`, { withCredentials: true });
+  rememberCsrfFromResponseBody(res.data);
 }
 
 function isCsrfInvalidAxiosError(err: unknown): boolean {

--- a/frontend/src/api/csrf.ts
+++ b/frontend/src/api/csrf.ts
@@ -8,6 +8,26 @@ import { API_CONFIG } from '../config/api';
  */
 let memoryCsrfToken: string | undefined;
 
+/** Coalesce concurrent bootstraps; one GET /auth/csrf in flight at a time. */
+let csrfBootstrapInFlight: Promise<void> | null = null;
+
+const CSRF_BOOTSTRAP_ATTEMPTS = 3;
+const CSRF_BOOTSTRAP_BASE_DELAY_MS = 200;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Retry on network errors, 5xx, or missing token in body; do not spin on 401/403. */
+function shouldRetryCsrfBootstrap(err: unknown, attemptIndex: number): boolean {
+  if (attemptIndex >= CSRF_BOOTSTRAP_ATTEMPTS - 1) return false;
+  if (!axios.isAxiosError(err)) return true;
+  const status = err.response?.status;
+  if (status === 401 || status === 403) return false;
+  if (!err.response) return true;
+  return status >= 500;
+}
+
 export function clearMemoryCsrfToken(): void {
   memoryCsrfToken = undefined;
 }
@@ -62,8 +82,41 @@ export function csrfHeaderPair(): Record<string, string> {
 
 /** Lấy CSRF từ backend (GET an toàn) và lưu token vào memory khi cookie là cross-site. */
 export async function ensureCsrfBootstrap(): Promise<void> {
-  const res = await axios.get(`${API_CONFIG.BASE_URL}/auth/csrf`, { withCredentials: true });
-  rememberCsrfFromResponseBody(res.data);
+  if (csrfBootstrapInFlight) {
+    return csrfBootstrapInFlight;
+  }
+
+  csrfBootstrapInFlight = (async () => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < CSRF_BOOTSTRAP_ATTEMPTS; attempt++) {
+      try {
+        const res = await axios.get(`${API_CONFIG.BASE_URL}/auth/csrf`, {
+          withCredentials: true,
+          timeout: 15000,
+        });
+        const token = extractCsrfTokenFromBody(res.data);
+        if (token) {
+          memoryCsrfToken = token;
+          return;
+        }
+        lastError = new Error('CSRF bootstrap: missing csrf_token in response');
+        if (!shouldRetryCsrfBootstrap(lastError, attempt)) break;
+      } catch (e) {
+        lastError = e;
+        if (!shouldRetryCsrfBootstrap(e, attempt)) break;
+      }
+      await sleep(CSRF_BOOTSTRAP_BASE_DELAY_MS * (attempt + 1));
+    }
+    clearMemoryCsrfToken();
+    if (import.meta.env.DEV) {
+      console.warn('[csrf] ensureCsrfBootstrap failed after retries', lastError);
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  })().finally(() => {
+    csrfBootstrapInFlight = null;
+  });
+
+  return csrfBootstrapInFlight;
 }
 
 function isCsrfInvalidAxiosError(err: unknown): boolean {

--- a/frontend/src/api/csrf.ts
+++ b/frontend/src/api/csrf.ts
@@ -34,8 +34,8 @@ export function rememberCsrfFromResponseBody(body: unknown): void {
 
 /**
  * Double-submit CSRF: readable cookie + X-CSRF-Token header (must match).
- * Same-origin: cookie is readable from document.cookie.
- * Cross-site API: use memory filled from GET /auth/csrf (and login/refresh responses if present).
+ * Prefer the cookie when document.cookie can read it (same-origin dev); otherwise use memory
+ * filled from GET /auth/csrf (and login/refresh responses) for cross-site API hosts.
  */
 export function readCsrfTokenFromCookie(): string | undefined {
   if (typeof document === 'undefined') return undefined;
@@ -56,7 +56,7 @@ export function readCsrfTokenFromCookie(): string | undefined {
 }
 
 export function csrfHeaderPair(): Record<string, string> {
-  const token = memoryCsrfToken || readCsrfTokenFromCookie();
+  const token = readCsrfTokenFromCookie() || memoryCsrfToken;
   return token ? { 'X-CSRF-Token': token } : {};
 }
 

--- a/frontend/src/api/csrf.ts
+++ b/frontend/src/api/csrf.ts
@@ -2,9 +2,21 @@ import axios from 'axios';
 import { API_CONFIG } from '../config/api';
 
 /**
- * In-memory CSRF value for cross-site setups (e.g. UI on www.shop.com, API on api.shop.com).
- * The csrf_token cookie is set on the API host; browsers do not expose third-party cookies to
- * document.cookie, so the double-submit header must be filled from the GET /auth/csrf JSON body.
+ * Cross-site CSRF header support for cookie-based API auth.
+ *
+ * **Double-submit:** The API expects `X-CSRF-Token` to match the `csrf_token` cookie on each
+ * mutating request. When the UI and API are on different sites, the cookie is set on the API
+ * host and is not visible to `document.cookie` here, so we must copy the token from the JSON
+ * body of `GET /api/v1/auth/csrf` into {@link memoryCsrfToken}.
+ *
+ * **XSS trade-off:** Any value used to build `X-CSRF-Token` is reachable from page JS if XSS
+ * exists. Same-origin setups could already read the non-HttpOnly `csrf_token` from
+ * `document.cookie`; cross-site relies on memory instead. Mitigate XSS (CSP, sanitization) —
+ * this module does not widen impact beyond the need to send the header at all.
+ *
+ * **Per-tab state:** `memoryCsrfToken` and {@link csrfBootstrapInFlight} live in this JS realm
+ * (typically one browser tab). Other tabs have their own copy; each tab should bootstrap after
+ * auth. Concurrent calls within one tab share one in-flight bootstrap via {@link csrfBootstrapInFlight}.
  */
 let memoryCsrfToken: string | undefined;
 
@@ -76,6 +88,17 @@ export function readCsrfTokenFromCookie(): string | undefined {
 }
 
 export function csrfHeaderPair(): Record<string, string> {
+  /**
+   * Token source order (do not reverse without security review):
+   * 1. **Cookie** when readable — same-origin dev; matches the cookie the server sees.
+   * 2. **Memory** — cross-site production; cookie is not in `document.cookie`.
+   *
+   * Edge case (same-origin only): if the server rotated `csrf_token` and the browser still
+   * exposes an older first-party cookie value until the next response, cookie could briefly win
+   * over a fresher `memoryCsrfToken`. Production cross-site UI never reads the API cookie from
+   * JS, so only memory applies. Call {@link ensureCsrfBootstrap} after login / refresh / switch-shop
+   * so memory stays aligned.
+   */
   const token = readCsrfTokenFromCookie() || memoryCsrfToken;
   return token ? { 'X-CSRF-Token': token } : {};
 }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { apiClient } from '../api/client';
+import { clearMemoryCsrfToken, ensureCsrfBootstrap } from '../api/csrf';
 import { AuthContext } from './AuthContext';
 import type { User } from './AuthContext';
 
@@ -23,9 +24,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setUser(response.data?.user);
       if (response.data?.user) {
         try {
-          await apiClient.get('/auth/csrf');
+          await ensureCsrfBootstrap();
         } catch {
-          /* cookie may still be set; ignore */
+          /* ignore */
         }
       }
       return true;
@@ -88,6 +89,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     } catch {
       /* keep partial user from login if /auth/me fails */
     }
+
+    try {
+      await ensureCsrfBootstrap();
+    } catch {
+      /* cross-site: cookie on API host; body of /auth/csrf fills in-memory CSRF header */
+    }
   };
 
   /**
@@ -99,6 +106,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     } catch {
       // Logout API call failed, clearing local state anyway
     } finally {
+      clearMemoryCsrfToken();
       setUser(null);
     }
   };

--- a/frontend/src/contexts/ShopContext.tsx
+++ b/frontend/src/contexts/ShopContext.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useContext } from 'react';
 import { apiClient } from '../api/client';
+import { ensureCsrfBootstrap } from '../api/csrf';
 import { ShopContext } from './ShopContext';
 import type { Shop } from './ShopContext';
 import { AuthContext } from './AuthContext';
@@ -23,6 +24,11 @@ export const ShopProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const switchToShop = useCallback(async (shopId: string) => {
     const response = await apiClient.post('/auth/switch-shop', { shop_id: shopId });
+    try {
+      await ensureCsrfBootstrap();
+    } catch {
+      /* ignore: switch-shop already rotated server cookie; bootstrap refills header token */
+    }
     const data = response?.data || response;
     const shop: Shop = data?.active_shop;
     if (shop) {

--- a/frontend/tests/unit/csrf.crossSite.test.ts
+++ b/frontend/tests/unit/csrf.crossSite.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import axios from 'axios';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   clearMemoryCsrfToken,
   csrfHeaderPair,
+  ensureCsrfBootstrap,
   extractCsrfTokenFromBody,
   rememberCsrfFromResponseBody,
 } from '../../src/api/csrf';
@@ -9,6 +11,8 @@ import {
 afterEach(() => {
   clearMemoryCsrfToken();
   document.cookie = 'csrf_token=; path=/; max-age=0';
+  vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe('extractCsrfTokenFromBody', () => {
@@ -20,6 +24,16 @@ describe('extractCsrfTokenFromBody', () => {
     expect(
       extractCsrfTokenFromBody({ ok: true, data: { csrf_token: 'wrapped' }, message: '' }),
     ).toBe('wrapped');
+  });
+
+  it('returns undefined for null, primitives, empty token, or unrelated shapes', () => {
+    expect(extractCsrfTokenFromBody(null)).toBeUndefined();
+    expect(extractCsrfTokenFromBody(undefined)).toBeUndefined();
+    expect(extractCsrfTokenFromBody('x')).toBeUndefined();
+    expect(extractCsrfTokenFromBody({})).toBeUndefined();
+    expect(extractCsrfTokenFromBody({ csrf_token: '' })).toBeUndefined();
+    expect(extractCsrfTokenFromBody({ ok: true, data: { user: 'x' }, message: '' })).toBeUndefined();
+    expect(extractCsrfTokenFromBody({ ok: true, data: {}, message: '' })).toBeUndefined();
   });
 });
 
@@ -33,5 +47,14 @@ describe('csrfHeaderPair cross-site memory', () => {
   it('falls back to memory when cookie unreadable (cross-site)', () => {
     rememberCsrfFromResponseBody({ csrf_token: 'from-body' });
     expect(csrfHeaderPair()['X-CSRF-Token']).toBe('from-body');
+  });
+});
+
+describe('ensureCsrfBootstrap', () => {
+  it('dedupes concurrent in-flight bootstraps into one GET', async () => {
+    const spy = vi.spyOn(axios, 'get').mockResolvedValue({ data: { csrf_token: 'one-shot' } });
+    await Promise.all([ensureCsrfBootstrap(), ensureCsrfBootstrap()]);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(csrfHeaderPair()['X-CSRF-Token']).toBe('one-shot');
   });
 });

--- a/frontend/tests/unit/csrf.crossSite.test.ts
+++ b/frontend/tests/unit/csrf.crossSite.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearMemoryCsrfToken,
+  csrfHeaderPair,
+  extractCsrfTokenFromBody,
+  rememberCsrfFromResponseBody,
+} from '../../src/api/csrf';
+
+afterEach(() => {
+  clearMemoryCsrfToken();
+  document.cookie = 'csrf_token=; path=/; max-age=0';
+});
+
+describe('extractCsrfTokenFromBody', () => {
+  it('reads raw csrf_token', () => {
+    expect(extractCsrfTokenFromBody({ csrf_token: 'abc' })).toBe('abc');
+  });
+
+  it('reads wrapped ok/data envelope', () => {
+    expect(
+      extractCsrfTokenFromBody({ ok: true, data: { csrf_token: 'wrapped' }, message: '' }),
+    ).toBe('wrapped');
+  });
+});
+
+describe('csrfHeaderPair cross-site memory', () => {
+  it('uses first-party cookie when present', () => {
+    document.cookie = 'csrf_token=cookieval; path=/';
+    rememberCsrfFromResponseBody({ csrf_token: 'mem' });
+    expect(csrfHeaderPair()['X-CSRF-Token']).toBe('cookieval');
+  });
+
+  it('falls back to memory when cookie unreadable (cross-site)', () => {
+    rememberCsrfFromResponseBody({ csrf_token: 'from-body' });
+    expect(csrfHeaderPair()['X-CSRF-Token']).toBe('from-body');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Follow-up (review feedback)

- **`ensureCsrfBootstrap`**: Coalesces concurrent callers into a single in-flight GET; retries up to 3 times on network errors, missing `csrf_token` in body, or 5xx; does **not** retry on 401/403; 15s timeout; clears memory and throws after exhaustion; `console.warn` in dev only.
- **`client.ts`**: On refresh failure, calls `clearMemoryCsrfToken()` so stale in-memory CSRF is not reused.
- **Tests**: More `extractCsrfTokenFromBody` edge cases; unit test that parallel `ensureCsrfBootstrap` only issues one `axios.get`.

## Original summary

Cross-site admin (UI ≠ API host): `csrf_token` cookie is not readable from `document.cookie`; store token from `GET /auth/csrf` JSON in memory; `csrfHeaderPair` prefers cookie then memory; bootstrap after login, refresh path, switch-shop; clear on logout.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6af363a5-95ac-4cd5-ba29-1912db6fdcbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6af363a5-95ac-4cd5-ba29-1912db6fdcbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

