### PR TITLE
fix(auth): đồng bộ phiên đăng nhập giữa tab, BFCache và route công khai

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   ChartNoAxesColumn,
@@ -46,12 +46,19 @@ const adminSidebarNavLinkActive =
 export const Layout = ({ children }: LayoutProps) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { user, logout } = useAuth();
+  const { user, logout, refreshUser } = useAuth();
   const { effectiveShopId, shopContextReady } = usePublicShopContext();
   const isAdmin = location.pathname.startsWith('/admin');
   const isSuperAdmin = useIsSuperAdmin();
   const [menuState, setMenuState] = useState({ open: false, pathname: location.pathname });
   const isMenuOpen = menuState.open && menuState.pathname === location.pathname;
+
+  /** SPA navigation can restore a stale in-memory user after logout + login elsewhere; re-check cookies on each public route. */
+  useEffect(() => {
+    if (!isAdmin) {
+      void refreshUser();
+    }
+  }, [isAdmin, location.pathname, refreshUser]);
 
   /** Same resolution as catalog (query / env / JWT), not only current URL — keeps nav aligned with VITE_PUBLIC_CATALOG_SHOP_ID. */
   const publicShopNavSuffix = useMemo(() => {

--- a/frontend/src/contexts/AuthContext.ts
+++ b/frontend/src/contexts/AuthContext.ts
@@ -39,6 +39,8 @@ export interface AuthContextType {
   user: User | null;
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
+  /** Re-validate session from cookies (e.g. after BFCache back or SPA return to public pages). */
+  refreshUser: () => Promise<boolean>;
   isAuthenticated: boolean;
   loading: boolean;
 }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,11 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { apiClient } from '../api/client';
 import { clearMemoryCsrfToken, ensureCsrfBootstrap } from '../api/csrf';
+import {
+  AUTH_SESSION_STORAGE_KEY,
+  bumpAuthSessionRevision,
+  readAuthSessionRevision,
+} from '../utils/authSessionSync';
 import { AuthContext } from './AuthContext';
 import type { User } from './AuthContext';
 
@@ -13,6 +18,7 @@ interface ApiResponse<T> {
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const authSessionRevRef = useRef(readAuthSessionRevision());
 
   /**
    * Fetch current user info from the server
@@ -55,6 +61,43 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     initAuth();
   }, [fetchUser]);
 
+  /** Other tabs / windows: after logout elsewhere, re-fetch /auth/me so UI matches server cookies. */
+  useEffect(() => {
+    const syncFromStorageRevision = () => {
+      const next = readAuthSessionRevision();
+      if (next !== authSessionRevRef.current) {
+        authSessionRevRef.current = next;
+        void fetchUser();
+      }
+    };
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== AUTH_SESSION_STORAGE_KEY || e.storageArea !== localStorage) {
+        return;
+      }
+      syncFromStorageRevision();
+    };
+
+    const onFocus = () => {
+      syncFromStorageRevision();
+    };
+
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        syncFromStorageRevision();
+      }
+    };
+
+    window.addEventListener('storage', onStorage);
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [fetchUser]);
+
   /**
    * Login with email and password
    * Server will set HttpOnly cookies automatically
@@ -95,6 +138,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     } catch {
       /* cross-site: cookie on API host; body of /auth/csrf fills in-memory CSRF header */
     }
+
+    bumpAuthSessionRevision();
+    authSessionRevRef.current = readAuthSessionRevision();
   };
 
   /**
@@ -102,12 +148,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
    */
   const logout = async () => {
     try {
+      await ensureCsrfBootstrap();
+    } catch {
+      /* align header with server csrf cookie (e.g. other tab rotated or cleared cookies) */
+    }
+    try {
       await apiClient.post('/auth/logout', {});
     } catch {
       // Logout API call failed, clearing local state anyway
     } finally {
       clearMemoryCsrfToken();
       setUser(null);
+      bumpAuthSessionRevision();
+      authSessionRevRef.current = readAuthSessionRevision();
     }
   };
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -88,13 +88,29 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
     };
 
+    /** BFCache / browser Back: React state can be restored while cookies were cleared at logout. */
+    const onPageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) {
+        void fetchUser();
+      }
+    };
+
+    /** SPA history back (e.g. Home → logout → login URL, then Back to cached Home). */
+    const onPopState = () => {
+      void fetchUser();
+    };
+
     window.addEventListener('storage', onStorage);
     window.addEventListener('focus', onFocus);
     document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('pageshow', onPageShow);
+    window.addEventListener('popstate', onPopState);
     return () => {
       window.removeEventListener('storage', onStorage);
       window.removeEventListener('focus', onFocus);
       document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('pageshow', onPageShow);
+      window.removeEventListener('popstate', onPopState);
     };
   }, [fetchUser]);
 
@@ -170,6 +186,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         user,
         login,
         logout,
+        refreshUser: fetchUser,
         isAuthenticated: !!user,
         loading,
       }}

--- a/frontend/src/utils/authSessionSync.ts
+++ b/frontend/src/utils/authSessionSync.ts
@@ -1,0 +1,18 @@
+/** Cross-tab signal: bump after logout so other tabs re-check cookies via /auth/me. */
+export const AUTH_SESSION_STORAGE_KEY = 'diecast360_auth_session_rev';
+
+export function readAuthSessionRevision(): string {
+  try {
+    return localStorage.getItem(AUTH_SESSION_STORAGE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export function bumpAuthSessionRevision(): void {
+  try {
+    localStorage.setItem(AUTH_SESSION_STORAGE_KEY, String(Date.now()));
+  } catch {
+    /* private mode / disabled storage */
+  }
+}

--- a/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
+++ b/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
@@ -19,7 +19,14 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 
 vi.mock('../../src/hooks/useAuth', () => ({
-  useAuth: () => ({ user: null, loading: false, isAuthenticated: false, login: vi.fn(), logout: vi.fn() }),
+  useAuth: () => ({
+    user: null,
+    loading: false,
+    isAuthenticated: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    refreshUser: vi.fn(),
+  }),
 }));
 
 vi.mock('../../src/components/catalog/ItemCard', () => ({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Vấn đề
1. **Tab khác:** Đăng xuất ở một tab không cập nhật tab còn lại (React state tách theo tab).
2. **BFCache / nút Back:** Sau khi đăng xuất, quay lại trang có thể khôi phục từ BFCache — UI vẫn hiển thị user cũ dù cookie đã xóa.
3. **SPA:** Điều hướng giữa các trang công khai có thể giữ state user trong bộ nhớ không khớp cookie.

## Thay đổi
- `localStorage` revision (`diecast360_auth_session_rev`) + listener `storage`, `focus`, `visibilitychange` để các tab khác gọi lại `/auth/me`.
- `pageshow` với `event.persisted`: gọi lại `fetchUser()` khi trang restore từ BFCache.
- `popstate`: gọi lại `fetchUser()` khi điều hướng lịch sử SPA.
- **`refreshUser`** trên context; **`Layout`** gọi `refreshUser()` mỗi khi vào route công khai khi `pathname` đổi.
- Trước `POST /auth/logout`: `ensureCsrfBootstrap()` để CSRF đồng bộ (kể cả cross-origin admin).

## Kiểm thử
Đã chạy trên agent: `npm run lint`, `npx tsc --noEmit`, `npm run test:unit`, `npm run build` trong thư mục `frontend/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://dev-z3g6024.slack.com/archives/C0AMW0SECN7/p1777883693939409?thread_ts=1777883693.939409&cid=C0AMW0SECN7)

<div><a href="https://cursor.com/agents/bc-eab56914-5019-5d81-8d2c-795cf088ddc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eab56914-5019-5d81-8d2c-795cf088ddc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

