### PR TITLE
fix(security): require shop scope for public API in production (#130)

### DIFF
--- a/backend/src/common/constants/error-codes.spec.ts
+++ b/backend/src/common/constants/error-codes.spec.ts
@@ -1,0 +1,8 @@
+import { ErrorCode, HTTP_STATUS_MAP } from './error-codes';
+import { HttpStatus } from '@nestjs/common';
+
+describe('error-codes', () => {
+  it('maps PUBLIC_SHOP_REQUIRED to 422', () => {
+    expect(HTTP_STATUS_MAP[ErrorCode.PUBLIC_SHOP_REQUIRED]).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+  });
+});

--- a/backend/src/common/constants/error-codes.ts
+++ b/backend/src/common/constants/error-codes.ts
@@ -4,6 +4,8 @@ export enum ErrorCode {
   AUTH_FORBIDDEN = 'AUTH_FORBIDDEN',
   VALIDATION_ERROR = 'VALIDATION_ERROR',
   NOT_FOUND = 'NOT_FOUND',
+  /** Public catalog/detail requires shop scope (e.g. ?shop_id=) when unauthenticated in production. */
+  PUBLIC_SHOP_REQUIRED = 'PUBLIC_SHOP_REQUIRED',
   UPLOAD_INVALID_TYPE = 'UPLOAD_INVALID_TYPE',
   UPLOAD_TOO_LARGE = 'UPLOAD_TOO_LARGE',
   SPIN_FRAME_INDEX_CONFLICT = 'SPIN_FRAME_INDEX_CONFLICT',
@@ -24,6 +26,7 @@ export const HTTP_STATUS_MAP: Record<ErrorCode, number> = {
   [ErrorCode.AUTH_FORBIDDEN]: 403,
   [ErrorCode.VALIDATION_ERROR]: 422,
   [ErrorCode.NOT_FOUND]: 404,
+  [ErrorCode.PUBLIC_SHOP_REQUIRED]: 422,
   [ErrorCode.UPLOAD_INVALID_TYPE]: 400,
   [ErrorCode.UPLOAD_TOO_LARGE]: 413,
   [ErrorCode.SPIN_FRAME_INDEX_CONFLICT]: 409,

--- a/backend/src/public/public.controller.spec.ts
+++ b/backend/src/public/public.controller.spec.ts
@@ -73,12 +73,15 @@ describe('PublicController', () => {
       resolver.resolveCanonicalShopId.mockResolvedValue(null);
       const req = { user: undefined } as never;
 
-      await expect(controller.findAll({} as QueryPublicItemsDto, req)).rejects.toSatisfy((e: unknown) => {
-        expect(e).toBeInstanceOf(AppException);
-        expect((e as AppException).getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
-        expect((e as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
-        return true;
-      });
+      let caught: unknown;
+      try {
+        await controller.findAll({} as QueryPublicItemsDto, req);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(AppException);
+      expect((caught as AppException).getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+      expect((caught as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
       expect(publicService.findAll).not.toHaveBeenCalled();
     });
 
@@ -109,12 +112,15 @@ describe('PublicController', () => {
       resolver.resolveCanonicalShopId.mockResolvedValue(null);
       const req = { user: undefined } as never;
 
-      await expect(controller.findOne('item-1', undefined, req)).rejects.toSatisfy((e: unknown) => {
-        expect(e).toBeInstanceOf(AppException);
-        expect((e as AppException).getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
-        expect((e as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
-        return true;
-      });
+      let caught: unknown;
+      try {
+        await controller.findOne('item-1', undefined, req);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(AppException);
+      expect((caught as AppException).getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+      expect((caught as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
       expect(publicService.findOne).not.toHaveBeenCalled();
     });
 

--- a/backend/src/public/public.controller.spec.ts
+++ b/backend/src/public/public.controller.spec.ts
@@ -2,6 +2,7 @@ import { PublicController } from './public.controller';
 import { PublicService } from './public.service';
 import { PublicShopResolverService } from './public-shop-resolver.service';
 import { QueryPublicItemsDto } from './dto/query-public-items.dto';
+import { ErrorCode } from '../common/exceptions/http-exception.filter';
 
 describe('PublicController', () => {
   const publicService = {
@@ -17,7 +18,16 @@ describe('PublicController', () => {
     resolver as unknown as PublicShopResolverService,
   );
 
-  beforeEach(() => jest.clearAllMocks());
+  const prevNodeEnv = process.env.NODE_ENV;
+
+  afterAll(() => {
+    process.env.NODE_ENV = prevNodeEnv;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+  });
 
   it('uses explicit shop_id over JWT active_shop_id for list', async () => {
     resolver.resolveCanonicalShopId.mockResolvedValue('shop-from-query');
@@ -51,5 +61,75 @@ describe('PublicController', () => {
 
     expect(resolver.resolveCanonicalShopId).toHaveBeenCalledWith('my-slug');
     expect(publicService.findOne).toHaveBeenCalledWith('item-1', 'shop-a');
+  });
+
+  describe('production public shop scope', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
+
+    it('rejects list when anonymous and no shop in JWT', async () => {
+      resolver.resolveCanonicalShopId.mockResolvedValue(null);
+      const req = { user: undefined } as never;
+
+      await expect(controller.findAll({} as QueryPublicItemsDto, req)).rejects.toMatchObject({
+        errorCode: ErrorCode.PUBLIC_SHOP_REQUIRED,
+      });
+      expect(publicService.findAll).not.toHaveBeenCalled();
+    });
+
+    it('allows list when explicit shop_id resolves', async () => {
+      resolver.resolveCanonicalShopId.mockResolvedValue('shop-x');
+      publicService.findAll.mockResolvedValue({ items: [] });
+      const req = { user: undefined } as never;
+
+      await controller.findAll({ shop_id: 'my-slug' } as QueryPublicItemsDto, req);
+
+      expect(publicService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ shop_id: 'my-slug' }),
+        'shop-x',
+      );
+    });
+
+    it('allows list when JWT supplies active_shop_id and query omits shop', async () => {
+      resolver.resolveCanonicalShopId.mockResolvedValue(null);
+      publicService.findAll.mockResolvedValue({ items: [] });
+      const req = { user: { active_shop_id: 'shop-jwt' } } as never;
+
+      await controller.findAll({} as QueryPublicItemsDto, req);
+
+      expect(publicService.findAll).toHaveBeenCalledWith({}, 'shop-jwt');
+    });
+
+    it('rejects detail when anonymous and no shop in JWT', async () => {
+      resolver.resolveCanonicalShopId.mockResolvedValue(null);
+      const req = { user: undefined } as never;
+
+      await expect(controller.findOne('item-1', undefined, req)).rejects.toMatchObject({
+        errorCode: ErrorCode.PUBLIC_SHOP_REQUIRED,
+      });
+      expect(publicService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('allows detail when explicit shop_id resolves', async () => {
+      resolver.resolveCanonicalShopId.mockResolvedValue('shop-x');
+      publicService.findOne.mockResolvedValue({ item: {} });
+      const req = { user: undefined } as never;
+
+      await controller.findOne('item-1', 'slug', req);
+
+      expect(publicService.findOne).toHaveBeenCalledWith('item-1', 'shop-x');
+    });
+  });
+
+  it('allows anonymous aggregate in non-production (no tenant)', async () => {
+    process.env.NODE_ENV = 'test';
+    resolver.resolveCanonicalShopId.mockResolvedValue(null);
+    publicService.findAll.mockResolvedValue({ items: [] });
+    const req = { user: undefined } as never;
+
+    await controller.findAll({} as QueryPublicItemsDto, req);
+
+    expect(publicService.findAll).toHaveBeenCalledWith({}, null);
   });
 });

--- a/backend/src/public/public.controller.spec.ts
+++ b/backend/src/public/public.controller.spec.ts
@@ -1,8 +1,9 @@
+import { HttpStatus } from '@nestjs/common';
 import { PublicController } from './public.controller';
 import { PublicService } from './public.service';
 import { PublicShopResolverService } from './public-shop-resolver.service';
 import { QueryPublicItemsDto } from './dto/query-public-items.dto';
-import { ErrorCode } from '../common/exceptions/http-exception.filter';
+import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
 
 describe('PublicController', () => {
   const publicService = {
@@ -68,12 +69,15 @@ describe('PublicController', () => {
       process.env.NODE_ENV = 'production';
     });
 
-    it('rejects list when anonymous and no shop in JWT', async () => {
+    it('rejects list when anonymous and no shop in JWT (422 PUBLIC_SHOP_REQUIRED)', async () => {
       resolver.resolveCanonicalShopId.mockResolvedValue(null);
       const req = { user: undefined } as never;
 
-      await expect(controller.findAll({} as QueryPublicItemsDto, req)).rejects.toMatchObject({
-        errorCode: ErrorCode.PUBLIC_SHOP_REQUIRED,
+      await expect(controller.findAll({} as QueryPublicItemsDto, req)).rejects.toSatisfy((e: unknown) => {
+        expect(e).toBeInstanceOf(AppException);
+        expect((e as AppException).getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        expect((e as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
+        return true;
       });
       expect(publicService.findAll).not.toHaveBeenCalled();
     });
@@ -101,12 +105,15 @@ describe('PublicController', () => {
       expect(publicService.findAll).toHaveBeenCalledWith({}, 'shop-jwt');
     });
 
-    it('rejects detail when anonymous and no shop in JWT', async () => {
+    it('rejects detail when anonymous and no shop in JWT (422 PUBLIC_SHOP_REQUIRED)', async () => {
       resolver.resolveCanonicalShopId.mockResolvedValue(null);
       const req = { user: undefined } as never;
 
-      await expect(controller.findOne('item-1', undefined, req)).rejects.toMatchObject({
-        errorCode: ErrorCode.PUBLIC_SHOP_REQUIRED,
+      await expect(controller.findOne('item-1', undefined, req)).rejects.toSatisfy((e: unknown) => {
+        expect(e).toBeInstanceOf(AppException);
+        expect((e as AppException).getStatus()).toBe(HttpStatus.UNPROCESSABLE_ENTITY);
+        expect((e as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
+        return true;
       });
       expect(publicService.findOne).not.toHaveBeenCalled();
     });

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -4,6 +4,11 @@ import { PublicService } from './public.service';
 import { PublicShopResolverService } from './public-shop-resolver.service';
 import { QueryPublicItemsDto } from './dto/query-public-items.dto';
 import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
+import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
+
+function isProductionEnv(): boolean {
+  return (process.env.NODE_ENV || '').trim().toLowerCase() === 'production';
+}
 
 @Controller('public')
 export class PublicController {
@@ -12,12 +17,36 @@ export class PublicController {
     private readonly publicShopResolver: PublicShopResolverService,
   ) {}
 
+  /**
+   * In production, anonymous catalog/detail must not aggregate all public items across shops.
+   * Require explicit ?shop_id= (or slug) or a JWT with active_shop_id.
+   */
+  private assertPublicShopScope(
+    tenantId: string | null | undefined,
+    user: { active_shop_id?: string | null } | undefined,
+  ): void {
+    if (!isProductionEnv()) {
+      return;
+    }
+    if (tenantId) {
+      return;
+    }
+    if (user?.active_shop_id) {
+      return;
+    }
+    throw new AppException(
+      ErrorCode.PUBLIC_SHOP_REQUIRED,
+      'Public catalog requires shop_id (UUID or shop slug) or an authenticated session with an active shop.',
+    );
+  }
+
   @Get('items')
   @UseGuards(OptionalJwtAuthGuard)
   async findAll(@Query() queryDto: QueryPublicItemsDto, @Req() req: Request) {
     const user = req.user as { active_shop_id?: string | null } | undefined;
     const explicitShopId = await this.publicShopResolver.resolveCanonicalShopId(queryDto.shop_id);
     const tenantId = explicitShopId ?? user?.active_shop_id ?? null;
+    this.assertPublicShopScope(tenantId, user);
     return this.publicService.findAll(queryDto, tenantId);
   }
 
@@ -31,6 +60,7 @@ export class PublicController {
     const user = req.user as { active_shop_id?: string | null } | undefined;
     const explicitShopId = await this.publicShopResolver.resolveCanonicalShopId(shopId);
     const tenantId = explicitShopId ?? user?.active_shop_id ?? null;
+    this.assertPublicShopScope(tenantId, user);
     return this.publicService.findOne(id, tenantId);
   }
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -47,7 +47,7 @@ export const Layout = ({ children }: LayoutProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const { user, logout } = useAuth();
-  const { effectiveShopId, shopContextReady } = usePublicShopContext();
+  const { effectiveShopId, shopContextReady, publicApiShopReady } = usePublicShopContext();
   const isAdmin = location.pathname.startsWith('/admin');
   const isSuperAdmin = useIsSuperAdmin();
   const [menuState, setMenuState] = useState({ open: false, pathname: location.pathname });
@@ -55,11 +55,11 @@ export const Layout = ({ children }: LayoutProps) => {
 
   /** Same resolution as catalog (query / env / JWT), not only current URL — keeps nav aligned with VITE_PUBLIC_CATALOG_SHOP_ID. */
   const publicShopNavSuffix = useMemo(() => {
-    if (!shopContextReady || !effectiveShopId) {
+    if (!shopContextReady || !publicApiShopReady) {
       return '';
     }
     return `?shop_id=${encodeURIComponent(effectiveShopId)}`;
-  }, [shopContextReady, effectiveShopId]);
+  }, [shopContextReady, publicApiShopReady, effectiveShopId]);
 
   const handleLogout = async () => {
     setMenuState({ open: false, pathname: location.pathname });

--- a/frontend/src/hooks/usePublicShopContext.ts
+++ b/frontend/src/hooks/usePublicShopContext.ts
@@ -9,7 +9,9 @@ import { getPublicCatalogShopIdFromEnv } from '../api/config';
  * Query wins over JWT so admin shop switch does not skew a shared public URL.
  *
  * `shopContextReady`: false while auth is loading and shop is not yet known from URL/env —
- * avoids one aggregate catalog fetch before JWT resolves (multi-tenant + logged-in).
+ * avoids picking a JWT shop before the URL is read.
+ * `publicApiShopReady`: true only when there is a concrete shop (query, env default, or JWT);
+ * public catalog/detail requests should use this so anonymous users never call `/public/items` without `shop_id`.
  */
 export function usePublicShopContext(): {
   effectiveShopId: string;
@@ -40,7 +42,18 @@ export function usePublicShopContext(): {
   );
 
   const hasDeterministicShop = Boolean(queryShopId || envShopId);
+  /** URL or build-time default fixes shop; JWT fallback only after auth settles. */
   const shopContextReady = hasDeterministicShop || !authLoading;
 
-  return { effectiveShopId, queryShopId, envShopId, authLoading, shopContextReady };
+  /** True when we can call public APIs with a concrete shop (never aggregate without scope). */
+  const publicApiShopReady = Boolean(effectiveShopId);
+
+  return {
+    effectiveShopId,
+    queryShopId,
+    envShopId,
+    authLoading,
+    shopContextReady,
+    publicApiShopReady,
+  };
 }

--- a/frontend/src/hooks/usePublicShopContext.ts
+++ b/frontend/src/hooks/usePublicShopContext.ts
@@ -20,6 +20,8 @@ export function usePublicShopContext(): {
   authLoading: boolean;
   /** When false, defer public catalog/detail API calls until auth settles or URL/env fixes shop. */
   shopContextReady: boolean;
+  /** When true, `effectiveShopId` is non-empty — safe to call scoped public APIs. */
+  publicApiShopReady: boolean;
 } {
   const [searchParams] = useSearchParams();
   const { user, loading: authLoading } = useAuth();

--- a/frontend/src/pages/PublicCatalogPage.tsx
+++ b/frontend/src/pages/PublicCatalogPage.tsx
@@ -19,7 +19,7 @@ import {
 
 export const PublicCatalogPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { effectiveShopId, shopContextReady } = usePublicShopContext();
+  const { effectiveShopId, shopContextReady, publicApiShopReady } = usePublicShopContext();
   const urlState = useMemo(() => parseCatalogUrlState(searchParams), [searchParams]);
   const [searchInput, setSearchInput] = useState(() => urlState.search);
   const debouncedSearch = useDebounce(searchInput, 300);
@@ -128,7 +128,7 @@ export const PublicCatalogPage = () => {
       return undefined;
     },
     initialPageParam: 1,
-    enabled: shopContextReady,
+    enabled: shopContextReady && publicApiShopReady,
   });
 
   const items = useMemo(() => {
@@ -146,6 +146,7 @@ export const PublicCatalogPage = () => {
   };
 
   const waitingForShopContext = !shopContextReady;
+  const missingShopScope = shopContextReady && !publicApiShopReady;
 
   if (error) {
     console.error('Error loading catalog:', error);
@@ -155,6 +156,22 @@ export const PublicCatalogPage = () => {
           <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-4 text-rose-800 shadow-corporate-card">
             <p className="font-semibold">Không tải được catalog</p>
             <p className="mt-1 text-sm text-rose-700/90">Vui lòng thử lại sau.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (missingShopScope) {
+    return (
+      <div className="relative min-h-[50vh] px-4 py-16 sm:px-6">
+        <div className="mx-auto max-w-7xl">
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-4 text-amber-900 shadow-corporate-card">
+            <p className="font-semibold">Chưa chọn cửa hàng</p>
+            <p className="mt-1 text-sm text-amber-800/90">
+              Thêm <code className="rounded bg-amber-100/80 px-1">?shop_id=</code> vào URL (UUID hoặc slug cửa hàng), hoặc cấu hình biến build{' '}
+              <code className="rounded bg-amber-100/80 px-1">VITE_PUBLIC_CATALOG_SHOP_ID</code> cho bản triển khai một-cửa-hàng.
+            </p>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/PublicItemDetailPage.tsx
+++ b/frontend/src/pages/PublicItemDetailPage.tsx
@@ -34,7 +34,7 @@ export const PublicItemDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { effectiveShopId, shopContextReady } = usePublicShopContext();
+  const { effectiveShopId, shopContextReady, publicApiShopReady } = usePublicShopContext();
   const isMobile = useIsMobile();
   const viewportWidth = useViewportWidth();
 
@@ -53,7 +53,7 @@ export const PublicItemDetailPage = () => {
       const response = await apiClient.get(path);
       return response.data;
     },
-    enabled: !!id && shopContextReady,
+    enabled: !!id && shopContextReady && publicApiShopReady,
   });
 
   // Response structure: {item, images, spinner} (already unwrapped by apiClient)
@@ -68,6 +68,18 @@ export const PublicItemDetailPage = () => {
 
   if (!shopContextReady) {
     return <div style={{ padding: '40px', textAlign: 'center' }}>Đang tải...</div>;
+  }
+
+  if (!publicApiShopReady) {
+    return (
+      <div style={{ padding: '40px', textAlign: 'center', maxWidth: 480, margin: '0 auto' }}>
+        <h2 style={{ fontSize: '18px', fontWeight: 600, marginBottom: 8 }}>Chưa chọn cửa hàng</h2>
+        <p style={{ color: '#64748b', fontSize: '14px', lineHeight: 1.6 }}>
+          Thêm <code style={{ background: '#fef3c7', padding: '2px 6px', borderRadius: 4 }}>?shop_id=</code> vào URL
+          (UUID hoặc slug), hoặc cấu hình <code style={{ background: '#fef3c7', padding: '2px 6px', borderRadius: 4 }}>VITE_PUBLIC_CATALOG_SHOP_ID</code> khi build.
+        </p>
+      </div>
+    );
   }
 
   if (isLoading) return <div style={{ padding: '40px', textAlign: 'center' }}>Đang tải...</div>;
@@ -457,6 +469,7 @@ export const PublicItemDetailPage = () => {
         effectiveShopId={effectiveShopId}
         shopSearch={shopQuery}
         shopContextReady={shopContextReady}
+        publicApiShopReady={publicApiShopReady}
       />
     </div>
   );
@@ -469,6 +482,7 @@ const RelatedItemsSection = ({
   effectiveShopId,
   shopSearch,
   shopContextReady,
+  publicApiShopReady,
 }: {
   currentItemId: string;
   carBrand?: string | null;
@@ -476,6 +490,7 @@ const RelatedItemsSection = ({
   effectiveShopId: string;
   shopSearch: string;
   shopContextReady: boolean;
+  publicApiShopReady: boolean;
 }) => {
   const isMobile = useIsMobile();
   const shouldQueryCar = Boolean(currentItemId && carBrand);
@@ -499,7 +514,7 @@ const RelatedItemsSection = ({
       const response = await apiClient.get(`/public/items?${params.toString()}`);
       return response.data;
     },
-    enabled: shopContextReady && shouldQueryCar,
+    enabled: shopContextReady && publicApiShopReady && shouldQueryCar,
   });
 
   // Query 2: Items with same Model Brand
@@ -520,7 +535,7 @@ const RelatedItemsSection = ({
       const response = await apiClient.get(`/public/items?${params.toString()}`);
       return response.data;
     },
-    enabled: shopContextReady && shouldQueryModel,
+    enabled: shopContextReady && publicApiShopReady && shouldQueryModel,
   });
 
   const uniqueSeedCount = useMemo(() => {
@@ -559,7 +574,11 @@ const RelatedItemsSection = ({
       return response.data;
     },
     enabled:
-      shopContextReady && !!currentItemId && readyForFallbackQuery && uniqueSeedCount < 5,
+      shopContextReady &&
+      publicApiShopReady &&
+      !!currentItemId &&
+      readyForFallbackQuery &&
+      uniqueSeedCount < 5,
   });
 
   const finalItems = useMemo(() => {

--- a/frontend/tests/e2e/public-catalog.spec.ts
+++ b/frontend/tests/e2e/public-catalog.spec.ts
@@ -72,8 +72,15 @@ async function routePublicItemsByShop(page: import('@playwright/test').Page) {
     if (shopId === 'shop-b') {
       return route.fulfill({ json: publicItemsEnvelope([aggregateItems[1], shopBExclusive]) });
     }
-    // No shop context: aggregate across tenants (legacy behavior)
-    return route.fulfill({ json: publicItemsEnvelope([...aggregateItems]) });
+    // Production API requires shop_id; anonymous aggregate is not served.
+    return route.fulfill({
+      status: 422,
+      json: {
+        ok: false,
+        error: { code: 'PUBLIC_SHOP_REQUIRED', details: [] },
+        message: 'Public catalog requires shop_id',
+      },
+    });
   });
 }
 
@@ -83,14 +90,14 @@ test.describe('Public catalog smoke', () => {
   });
 
   test('renders product names from public API', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?shop_id=shop-a');
 
     await expect(page.getByText('Porsche 911 GT3 1:18')).toBeVisible();
-    await expect(page.getByText('McLaren 720S 1:64')).toBeVisible();
+    await expect(page.getByText('Shop A Exclusive Tomica')).toBeVisible();
   });
 
   test('renders search input on catalog page', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?shop_id=shop-a');
 
     await expect(page.getByPlaceholder('Tìm kiếm theo tên...')).toBeVisible();
   });
@@ -111,7 +118,7 @@ test.describe('Public catalog smoke', () => {
         json: apiOk({ items: [], pagination: { total: 0, page: 1, page_size: 20, total_pages: 0 } }),
       }),
     );
-    await page.goto('/');
+    await page.goto('/?shop_id=shop-a');
 
     await expect(page.getByText('Không tìm thấy sản phẩm nào.')).toBeVisible();
   });
@@ -121,9 +128,24 @@ test.describe('Public catalog smoke', () => {
     await page.route('**/api/v1/public/items**', (route: Route) =>
       route.fulfill({ status: 500, json: { ok: false, message: 'Internal error' } }),
     );
-    await page.goto('/');
+    await page.goto('/?shop_id=shop-a');
 
     await expect(page.getByText('Không tải được catalog')).toBeVisible();
+  });
+
+  test('without shop_id shows missing shop guidance (no public/items request)', async ({ page }) => {
+    let publicItemsRequestCount = 0;
+    page.on('request', (req) => {
+      if (req.url().includes('/api/v1/public/items')) {
+        publicItemsRequestCount += 1;
+      }
+    });
+
+    await page.goto('/');
+
+    await expect(page.getByText('Chưa chọn cửa hàng')).toBeVisible();
+    await expect(page.getByText(/VITE_PUBLIC_CATALOG_SHOP_ID/)).toBeVisible();
+    expect(publicItemsRequestCount).toBe(0);
   });
 });
 
@@ -143,12 +165,6 @@ test.describe('Public catalog multi-tenant (shop_id)', () => {
     await page.goto('/?shop_id=shop-b');
     await expect(page.getByText('Shop B Exclusive Hot Wheels')).toBeVisible();
     await expect(page.getByText('Shop A Exclusive Tomica')).not.toBeVisible();
-  });
-
-  test('without shop_id shows aggregate items (smoke regression)', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.getByText('Porsche 911 GT3 1:18')).toBeVisible();
-    await expect(page.getByText('McLaren 720S 1:64')).toBeVisible();
   });
 
   test('public nav preserves shop_id on preorder link', async ({ page }) => {

--- a/frontend/tests/e2e/public-item-detail-shop.spec.ts
+++ b/frontend/tests/e2e/public-item-detail-shop.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect, apiOk, type Route } from './fixtures';
+
+const ITEM_ID = 'pub-detail-1';
+
+test.describe('Public item detail — shop scope', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(`**/api/v1/public/items/${ITEM_ID}**`, (route: Route) => {
+      const url = new URL(route.request().url());
+      if (!url.searchParams.get('shop_id')) {
+        return route.fulfill({
+          status: 422,
+          json: {
+            ok: false,
+            error: { code: 'PUBLIC_SHOP_REQUIRED', details: [] },
+            message: 'Public catalog requires shop_id',
+          },
+        });
+      }
+      return route.fulfill({
+        json: apiOk({
+          item: {
+            id: ITEM_ID,
+            name: 'E2E Public Detail',
+            description: 'd',
+            scale: '1:64',
+            brand: 'HW',
+            car_brand: null,
+            model_brand: null,
+            condition: 'new',
+            price: 100000,
+            original_price: null,
+            status: 'con_hang',
+            is_public: true,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+          images: [],
+          spinner: null,
+        }),
+      });
+    });
+  });
+
+  test('without shop_id shows guidance and does not request detail API', async ({ page }) => {
+    let detailRequestCount = 0;
+    page.on('request', (req) => {
+      if (req.url().includes(`/api/v1/public/items/${ITEM_ID}`)) {
+        detailRequestCount += 1;
+      }
+    });
+
+    await page.goto(`/items/${ITEM_ID}`);
+    await expect(page.getByRole('heading', { name: 'Chưa chọn cửa hàng' })).toBeVisible();
+    expect(detailRequestCount).toBe(0);
+  });
+
+  test('with shop_id loads item from public API', async ({ page }) => {
+    await page.goto(`/items/${ITEM_ID}?shop_id=shop-a`);
+    await expect(page.getByText('E2E Public Detail')).toBeVisible();
+  });
+});

--- a/frontend/tests/unit/PublicCatalogPage.missing-shop.test.tsx
+++ b/frontend/tests/unit/PublicCatalogPage.missing-shop.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PublicCatalogPage } from '../../src/pages/PublicCatalogPage';
+
+const setSearchParamsMock = vi.fn();
+let currentSearchParams = new URLSearchParams();
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [currentSearchParams, setSearchParamsMock],
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useInfiniteQuery: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  })),
+}));
+
+vi.mock('../../src/hooks/usePublicShopContext', () => ({
+  usePublicShopContext: () => ({
+    effectiveShopId: '',
+    queryShopId: '',
+    envShopId: '',
+    authLoading: false,
+    shopContextReady: true,
+    publicApiShopReady: false,
+  }),
+}));
+
+vi.mock('../../src/components/catalog/ItemCard', () => ({
+  ItemCard: () => null,
+}));
+vi.mock('../../src/components/catalog/InfiniteScrollTrigger', () => ({
+  InfiniteScrollTrigger: () => null,
+}));
+vi.mock('../../src/components/catalog/CatalogSort', () => ({
+  CatalogSort: () => null,
+}));
+vi.mock('../../src/components/catalog/CatalogFilters', () => ({
+  CatalogFilters: () => null,
+}));
+vi.mock('../../src/components/catalog/CatalogSearchInput', () => ({
+  CatalogSearchInput: () => null,
+}));
+
+describe('PublicCatalogPage missing shop scope', () => {
+  beforeEach(() => {
+    currentSearchParams = new URLSearchParams();
+    setSearchParamsMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows guidance when publicApiShopReady is false', () => {
+    render(<PublicCatalogPage />);
+    expect(screen.getByText('Chưa chọn cửa hàng')).toBeVisible();
+    expect(screen.getByText(/VITE_PUBLIC_CATALOG_SHOP_ID/)).toBeVisible();
+  });
+});

--- a/frontend/tests/unit/PublicCatalogPage.missing-shop.test.tsx
+++ b/frontend/tests/unit/PublicCatalogPage.missing-shop.test.tsx
@@ -62,7 +62,7 @@ describe('PublicCatalogPage missing shop scope', () => {
 
   it('shows guidance when publicApiShopReady is false', () => {
     render(<PublicCatalogPage />);
-    expect(screen.getByText('Chưa chọn cửa hàng')).toBeVisible();
-    expect(screen.getByText(/VITE_PUBLIC_CATALOG_SHOP_ID/)).toBeVisible();
+    expect(screen.getByText('Chưa chọn cửa hàng')).toBeTruthy();
+    expect(screen.getByText(/VITE_PUBLIC_CATALOG_SHOP_ID/)).toBeTruthy();
   });
 });

--- a/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
+++ b/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
@@ -28,6 +28,17 @@ vi.mock('../../src/hooks/useAuth', () => ({
   }),
 }));
 
+vi.mock('../../src/hooks/usePublicShopContext', () => ({
+  usePublicShopContext: () => ({
+    effectiveShopId: 'test-shop',
+    queryShopId: '',
+    envShopId: 'test-shop',
+    authLoading: false,
+    shopContextReady: true,
+    publicApiShopReady: true,
+  }),
+}));
+
 vi.mock('../../src/components/catalog/ItemCard', () => ({
   ItemCard: () => <div>item-card</div>,
 }));
@@ -93,7 +104,7 @@ describe('PublicCatalogPage URL sync', () => {
     const firstCallArgs = useInfiniteQueryMock.mock.calls[0][0] as { queryKey: unknown[] };
     expect(firstCallArgs.queryKey).toEqual([
       'public-items',
-      '',
+      'test-shop',
       'civic',
       'Toyota',
       null,

--- a/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
+++ b/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
@@ -31,8 +31,9 @@ vi.mock('../../src/hooks/useAuth', () => ({
 vi.mock('../../src/hooks/usePublicShopContext', () => ({
   usePublicShopContext: () => ({
     effectiveShopId: 'test-shop',
-    queryShopId: '',
-    envShopId: 'test-shop',
+    /** Match URL when tests use ?shop_id= — avoids replace effect overwriting filter params. */
+    queryShopId: 'test-shop',
+    envShopId: '',
     authLoading: false,
     shopContextReady: true,
     publicApiShopReady: true,
@@ -92,7 +93,7 @@ describe('PublicCatalogPage URL sync', () => {
 
   it('should derive state from URL params on mount', () => {
     currentSearchParams = new URLSearchParams(
-      'q=%20civic%20&car_brand=Toyota&condition=old&sort_by=name&sort_order=asc',
+      'shop_id=test-shop&q=%20civic%20&car_brand=Toyota&condition=old&sort_by=name&sort_order=asc',
     );
 
     render(<PublicCatalogPage />);
@@ -115,7 +116,7 @@ describe('PublicCatalogPage URL sync', () => {
   });
 
   it('should update URL when filters, sort, and search input change', () => {
-    currentSearchParams = new URLSearchParams('q=civic');
+    currentSearchParams = new URLSearchParams('shop_id=test-shop&q=civic');
 
     render(<PublicCatalogPage />);
 
@@ -129,21 +130,23 @@ describe('PublicCatalogPage URL sync', () => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(appliedSearchParams).toContain('q=civic&car_brand=Honda');
-    expect(appliedSearchParams).toContain('q=civic&car_brand=Honda&sort_by=price&sort_order=asc');
-    expect(appliedSearchParams).toContain('q=mx5&car_brand=Honda&sort_by=price&sort_order=asc');
-    expect(appliedSearchParams.at(-1)).toBe('q=mx5&car_brand=Honda&sort_by=price&sort_order=asc');
+    expect(appliedSearchParams).toContain('shop_id=test-shop&q=civic&car_brand=Honda');
+    expect(appliedSearchParams).toContain('shop_id=test-shop&q=civic&car_brand=Honda&sort_by=price&sort_order=asc');
+    expect(appliedSearchParams).toContain('shop_id=test-shop&q=mx5&car_brand=Honda&sort_by=price&sort_order=asc');
+    expect(appliedSearchParams.at(-1)).toBe(
+      'shop_id=test-shop&q=mx5&car_brand=Honda&sort_by=price&sort_order=asc',
+    );
   });
 
   it('should not reset search input when URL q changes from external navigation', () => {
-    currentSearchParams = new URLSearchParams('q=civic');
+    currentSearchParams = new URLSearchParams('shop_id=test-shop&q=civic');
 
     const { rerender } = render(<PublicCatalogPage />);
     fireEvent.change(screen.getByPlaceholderText('Tìm kiếm theo tên...'), {
       target: { value: 'supra ' },
     });
 
-    currentSearchParams = new URLSearchParams('q=skyline');
+    currentSearchParams = new URLSearchParams('shop_id=test-shop&q=skyline');
     rerender(<PublicCatalogPage />);
 
     expect(

--- a/frontend/tests/unit/usePublicShopContext.test.tsx
+++ b/frontend/tests/unit/usePublicShopContext.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { usePublicShopContext } from '../../src/hooks/usePublicShopContext';
+
+const useAuthMock = vi.fn();
+const getPublicCatalogShopIdFromEnvMock = vi.fn();
+
+vi.mock('../../src/hooks/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('../../src/api/config', () => ({
+  getPublicCatalogShopIdFromEnv: () => getPublicCatalogShopIdFromEnvMock(),
+}));
+
+function wrapper(initialPath: string) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="*" element={<>{children}</>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+}
+
+describe('usePublicShopContext', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses shop_id from URL and sets shopContextReady and publicApiShopReady', () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    getPublicCatalogShopIdFromEnvMock.mockReturnValue('');
+
+    const { result } = renderHook(() => usePublicShopContext(), {
+      wrapper: wrapper('/?shop_id=shop-a'),
+    });
+
+    expect(result.current.queryShopId).toBe('shop-a');
+    expect(result.current.envShopId).toBe('');
+    expect(result.current.effectiveShopId).toBe('shop-a');
+    expect(result.current.shopContextReady).toBe(true);
+    expect(result.current.publicApiShopReady).toBe(true);
+  });
+
+  it('prefers URL shop_id over env default', () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    getPublicCatalogShopIdFromEnvMock.mockReturnValue('from-env');
+
+    const { result } = renderHook(() => usePublicShopContext(), {
+      wrapper: wrapper('/?shop_id=url-shop'),
+    });
+
+    expect(result.current.effectiveShopId).toBe('url-shop');
+    expect(result.current.publicApiShopReady).toBe(true);
+  });
+
+  it('uses env default when URL has no shop_id', () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    getPublicCatalogShopIdFromEnvMock.mockReturnValue('env-default-shop');
+
+    const { result } = renderHook(() => usePublicShopContext(), {
+      wrapper: wrapper('/'),
+    });
+
+    expect(result.current.queryShopId).toBe('');
+    expect(result.current.effectiveShopId).toBe('env-default-shop');
+    expect(result.current.shopContextReady).toBe(true);
+    expect(result.current.publicApiShopReady).toBe(true);
+  });
+
+  it('defers shopContextReady while auth loads and no URL/env shop', async () => {
+    useAuthMock.mockReturnValue({ user: null, loading: true });
+    getPublicCatalogShopIdFromEnvMock.mockReturnValue('');
+
+    const { result, rerender } = renderHook(() => usePublicShopContext(), {
+      wrapper: wrapper('/'),
+    });
+
+    expect(result.current.shopContextReady).toBe(false);
+    expect(result.current.publicApiShopReady).toBe(false);
+
+    useAuthMock.mockReturnValue({
+      user: { active_shop_id: 'jwt-shop' },
+      loading: false,
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.shopContextReady).toBe(true);
+    });
+    expect(result.current.effectiveShopId).toBe('jwt-shop');
+    expect(result.current.publicApiShopReady).toBe(true);
+  });
+
+  it('when auth settled with no shop anywhere, shopContextReady true and publicApiShopReady false', async () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    getPublicCatalogShopIdFromEnvMock.mockReturnValue('');
+
+    const { result } = renderHook(() => usePublicShopContext(), {
+      wrapper: wrapper('/'),
+    });
+
+    expect(result.current.shopContextReady).toBe(true);
+    expect(result.current.effectiveShopId).toBe('');
+    expect(result.current.publicApiShopReady).toBe(false);
+  });
+
+  it('uses JWT active_shop_id when no URL or env shop after auth loads', async () => {
+    useAuthMock.mockReturnValue({ user: { active_shop_id: 'jwt-only' }, loading: false });
+    getPublicCatalogShopIdFromEnvMock.mockReturnValue('');
+
+    const { result } = renderHook(() => usePublicShopContext(), {
+      wrapper: wrapper('/'),
+    });
+
+    expect(result.current.effectiveShopId).toBe('jwt-only');
+    expect(result.current.publicApiShopReady).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements the **code** portion of [issue #130](https://github.com/nguyenhoangtin1404/Diecast360/issues/130) (production public catalog scope). **Environment variables** (NODE_ENV, secrets, CORS, cookies, HTTPS) are left for operators as requested.

## Backend
- When `NODE_ENV === 'production'`, `GET /api/v1/public/items` and `GET /api/v1/public/items/:id` require a resolved tenant: explicit `shop_id` (UUID or slug) **or** JWT `active_shop_id`. Anonymous requests without either return **422** with `PUBLIC_SHOP_REQUIRED`.
- New `ErrorCode.PUBLIC_SHOP_REQUIRED` in `error-codes.ts`.
- Unit tests: `public.controller.spec.ts`, `error-codes.spec.ts`.

## Frontend
- `usePublicShopContext` exposes `publicApiShopReady` (true only when `effectiveShopId` is non-empty). Catalog, item detail, related-items queries, and layout public nav suffix use it.
- User-facing message when shop is missing.
- **Unit tests:** `usePublicShopContext.test.tsx`, `PublicCatalogPage.missing-shop.test.tsx`, updated `PublicCatalogPage.url-sync.test.tsx`.
- **Playwright:** `public-catalog.spec.ts` updated; new `public-item-detail-shop.spec.ts`.

## How to verify
```bash
pnpm --filter ./backend test
pnpm --filter ./frontend test:unit
pnpm --filter ./frontend test:e2e
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-727a4fc3-b543-4ce7-91c9-5d614514018e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-727a4fc3-b543-4ce7-91c9-5d614514018e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

