### PR TITLE
Configurable shop contact page (#134)

### DIFF
--- a/backend/prisma/migrations/20260505000000_add_shop_contact_json/migration.sql
+++ b/backend/prisma/migrations/20260505000000_add_shop_contact_json/migration.sql
@@ -1,0 +1,2 @@
+-- Shop-configurable public contact page content
+ALTER TABLE "shops" ADD COLUMN "contact_json" JSONB NOT NULL DEFAULT '{}';

--- a/backend/prisma/migrations/20260505120000_add_shop_appearance_json/migration.sql
+++ b/backend/prisma/migrations/20260505120000_add_shop_appearance_json/migration.sql
@@ -1,0 +1,2 @@
+-- Reserved for future storefront branding (logo, favicon, colors, fonts)
+ALTER TABLE "shops" ADD COLUMN "appearance_json" JSONB NOT NULL DEFAULT '{}';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -69,6 +69,8 @@ model Shop {
   is_active  Boolean        @default(true)
   // Public contact page: phone, socials, hours (JSON; edited in admin / platform shop settings)
   contact_json Json          @default("{}")
+  // Storefront branding (logo URL, favicon, colors, fonts) — shop admin; apply on public UI later
+  appearance_json Json       @default("{}")
   created_at DateTime       @default(now())
   updated_at DateTime       @updatedAt
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -67,6 +67,8 @@ model Shop {
   name       String
   slug       String         @unique
   is_active  Boolean        @default(true)
+  // Public contact page: phone, socials, hours (JSON; edited in admin / platform shop settings)
+  contact_json Json          @default("{}")
   created_at DateTime       @default(now())
   updated_at DateTime       @updatedAt
 

--- a/backend/src/public/public.controller.spec.ts
+++ b/backend/src/public/public.controller.spec.ts
@@ -9,6 +9,7 @@ describe('PublicController', () => {
   const publicService = {
     findAll: jest.fn(),
     findOne: jest.fn(),
+    getShopContact: jest.fn(),
   };
   const resolver = {
     resolveCanonicalShopId: jest.fn(),
@@ -144,5 +145,35 @@ describe('PublicController', () => {
     await controller.findAll({} as QueryPublicItemsDto, req);
 
     expect(publicService.findAll).toHaveBeenCalledWith({}, null);
+  });
+
+  describe('getShopContact', () => {
+    it('prefers explicit shop param over JWT', async () => {
+      resolver.resolveCanonicalShopId.mockResolvedValue('shop-from-path');
+      publicService.getShopContact.mockResolvedValue({ shop: {}, contact: {} });
+      const req = { user: { active_shop_id: 'shop-jwt' } } as never;
+
+      const out = await controller.getShopContact('my-slug', req);
+
+      expect(resolver.resolveCanonicalShopId).toHaveBeenCalledWith('my-slug');
+      expect(publicService.getShopContact).toHaveBeenCalledWith('shop-from-path');
+      expect(out).toEqual({ shop: {}, contact: {} });
+    });
+
+    it('rejects in production when anonymous and no shop (422)', async () => {
+      process.env.NODE_ENV = 'production';
+      resolver.resolveCanonicalShopId.mockResolvedValue(null);
+      const req = { user: undefined } as never;
+
+      let caught: unknown;
+      try {
+        await controller.getShopContact('slug', req);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(AppException);
+      expect((caught as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
+      expect(publicService.getShopContact).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/public/public.controller.spec.ts
+++ b/backend/src/public/public.controller.spec.ts
@@ -161,19 +161,24 @@ describe('PublicController', () => {
     });
 
     it('rejects in production when anonymous and no shop (422)', async () => {
-      process.env.NODE_ENV = 'production';
-      resolver.resolveCanonicalShopId.mockResolvedValue(null);
-      const req = { user: undefined } as never;
-
-      let caught: unknown;
+      const prevEnv = process.env.NODE_ENV;
       try {
-        await controller.getShopContact('slug', req);
-      } catch (e) {
-        caught = e;
+        process.env.NODE_ENV = 'production';
+        resolver.resolveCanonicalShopId.mockResolvedValue(null);
+        const req = { user: undefined } as never;
+
+        let caught: unknown;
+        try {
+          await controller.getShopContact('slug', req);
+        } catch (e) {
+          caught = e;
+        }
+        expect(caught).toBeInstanceOf(AppException);
+        expect((caught as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
+        expect(publicService.getShopContact).not.toHaveBeenCalled();
+      } finally {
+        process.env.NODE_ENV = prevEnv;
       }
-      expect(caught).toBeInstanceOf(AppException);
-      expect((caught as AppException).errorCode).toBe(ErrorCode.PUBLIC_SHOP_REQUIRED);
-      expect(publicService.getShopContact).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -40,6 +40,19 @@ export class PublicController {
     );
   }
 
+  @Get('shops/:shopId/contact')
+  @UseGuards(OptionalJwtAuthGuard)
+  async getShopContact(@Param('shopId') shopId: string, @Req() req: Request) {
+    const user = req.user as { active_shop_id?: string | null } | undefined;
+    const explicitShopId = await this.publicShopResolver.resolveCanonicalShopId(shopId);
+    const tenantId = explicitShopId ?? user?.active_shop_id ?? null;
+    this.assertPublicShopScope(tenantId, user);
+    if (!tenantId) {
+      throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
+    }
+    return this.publicService.getShopContact(tenantId);
+  }
+
   @Get('items')
   @UseGuards(OptionalJwtAuthGuard)
   async findAll(@Query() queryDto: QueryPublicItemsDto, @Req() req: Request) {

--- a/backend/src/public/public.controller.ts
+++ b/backend/src/public/public.controller.ts
@@ -46,7 +46,9 @@ export class PublicController {
     const user = req.user as { active_shop_id?: string | null } | undefined;
     const explicitShopId = await this.publicShopResolver.resolveCanonicalShopId(shopId);
     const tenantId = explicitShopId ?? user?.active_shop_id ?? null;
+    // Production: same rule as catalog — need ?shop_id / path shop or JWT active shop (422 otherwise).
     this.assertPublicShopScope(tenantId, user);
+    // Non-production: assertPublicShopScope is a no-op, but contact is always shop-scoped (no "all shops" view).
     if (!tenantId) {
       throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
     }

--- a/backend/src/public/public.service.spec.ts
+++ b/backend/src/public/public.service.spec.ts
@@ -71,6 +71,7 @@ describe('PublicService', () => {
         name: 'My Shop',
         slug: 'my-shop',
         contact_json: {},
+        appearance_json: {},
       });
 
       const out = await service.getShopContact('shop-1');
@@ -79,6 +80,7 @@ describe('PublicService', () => {
       expect(out.contact.page_title).toBe('Liên hệ với chúng tôi');
       expect(out.contact.phone?.hint).toBe('Gọi ngay để được tư vấn');
       expect(String(out.contact.hours?.schedule_line)).toContain('My Shop');
+      expect(out.appearance).toEqual({});
     });
 
     it('throws NOT_FOUND when shop is missing or inactive', async () => {

--- a/backend/src/public/public.service.spec.ts
+++ b/backend/src/public/public.service.spec.ts
@@ -7,6 +7,7 @@ describe('PublicService', () => {
   let service: PublicService;
   let prisma: {
     item: Record<string, jest.Mock>;
+    shop: Record<string, jest.Mock>;
   };
   let storage: Record<string, jest.Mock>;
 
@@ -37,6 +38,9 @@ describe('PublicService', () => {
         findFirst: jest.fn(),
         count: jest.fn(),
       },
+      shop: {
+        findFirst: jest.fn(),
+      },
     };
 
     storage = {
@@ -58,6 +62,30 @@ describe('PublicService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getShopContact', () => {
+    it('returns shop identity and merged contact defaults', async () => {
+      prisma.shop.findFirst.mockResolvedValue({
+        id: 'shop-1',
+        name: 'My Shop',
+        slug: 'my-shop',
+        contact_json: {},
+      });
+
+      const out = await service.getShopContact('shop-1');
+
+      expect(out.shop).toEqual({ id: 'shop-1', name: 'My Shop', slug: 'my-shop' });
+      expect(out.contact.page_title).toBe('Liên hệ với chúng tôi');
+      expect(out.contact.phone?.hint).toBe('Gọi ngay để được tư vấn');
+      expect(String(out.contact.hours?.schedule_line)).toContain('My Shop');
+    });
+
+    it('throws NOT_FOUND when shop is missing or inactive', async () => {
+      prisma.shop.findFirst.mockResolvedValue(null);
+
+      await expect(service.getShopContact('nope')).rejects.toBeInstanceOf(AppException);
+    });
   });
 
   // ============================================================

--- a/backend/src/public/public.service.ts
+++ b/backend/src/public/public.service.ts
@@ -6,6 +6,7 @@ import { QueryPublicItemsDto } from './dto/query-public-items.dto';
 import { Prisma } from '../generated/prisma/client';
 import { toNumber } from '../common/utils/decimal.utils';
 import { totalPagesFromCount } from '../common/utils/pagination.utils';
+import { parseShopContactJson, ShopContactSettings } from '../shops/types/shop-contact.types';
 
 @Injectable()
 export class PublicService {
@@ -19,6 +20,69 @@ export class PublicService {
     private prisma: PrismaService,
     @Inject('IStorageService') private storage: IStorageService,
   ) {}
+
+  private defaultContact(shopName: string): ShopContactSettings {
+    return {
+      page_title: 'Liên hệ với chúng tôi',
+      page_subtitle: 'Chúng tôi luôn sẵn sàng hỗ trợ và giải đáp mọi thắc mắc của bạn',
+      phone: {
+        title: 'Điện thoại',
+        label: '',
+        tel: '',
+        hint: 'Gọi ngay để được tư vấn',
+      },
+      facebook: {
+        title: 'Facebook',
+        url: '',
+        label: '',
+        hint: 'Theo dõi chúng tôi trên Facebook',
+      },
+      zalo: {
+        title: 'Zalo',
+        url: '',
+        label: '',
+        hint: 'Chat với chúng tôi trên Zalo',
+      },
+      hours: {
+        title: 'Thời gian làm việc',
+        schedule_line: `**${shopName}** — cập nhật giờ mở cửa tại trang quản trị shop.`,
+        footer_note: 'Chúng tôi luôn sẵn sàng phục vụ bạn!',
+      },
+    };
+  }
+
+  private mergeWithDefaults(shopName: string, stored: ShopContactSettings): ShopContactSettings {
+    const d = this.defaultContact(shopName);
+    return {
+      page_title: stored.page_title ?? d.page_title,
+      page_subtitle: stored.page_subtitle ?? d.page_subtitle,
+      phone: { ...d.phone, ...stored.phone },
+      facebook: { ...d.facebook, ...stored.facebook },
+      zalo: { ...d.zalo, ...stored.zalo },
+      hours: { ...d.hours, ...stored.hours },
+    };
+  }
+
+  async getShopContact(canonicalShopId: string) {
+    const shop = await this.prisma.shop.findFirst({
+      where: { id: canonicalShopId, is_active: true },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        contact_json: true,
+      },
+    });
+    if (!shop) {
+      throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
+    }
+    const stored = parseShopContactJson(shop.contact_json);
+    const contact = this.mergeWithDefaults(shop.name, stored);
+    return {
+      shop: { id: shop.id, name: shop.name, slug: shop.slug },
+      contact,
+    };
+  }
 
   private buildCountCacheKey(where: Prisma.ItemWhereInput): string {
     return JSON.stringify(where);

--- a/backend/src/public/public.service.ts
+++ b/backend/src/public/public.service.ts
@@ -7,7 +7,7 @@ import { Prisma } from '../generated/prisma/client';
 import { toNumber } from '../common/utils/decimal.utils';
 import { totalPagesFromCount } from '../common/utils/pagination.utils';
 import { parseShopContactJson, ShopContactSettings } from '../shops/types/shop-contact.types';
-import { parseShopAppearanceJson, ShopAppearanceSettings } from '../shops/types/shop-appearance.types';
+import { parseShopAppearanceJson } from '../shops/types/shop-appearance.types';
 
 @Injectable()
 export class PublicService {

--- a/backend/src/public/public.service.ts
+++ b/backend/src/public/public.service.ts
@@ -7,6 +7,7 @@ import { Prisma } from '../generated/prisma/client';
 import { toNumber } from '../common/utils/decimal.utils';
 import { totalPagesFromCount } from '../common/utils/pagination.utils';
 import { parseShopContactJson, ShopContactSettings } from '../shops/types/shop-contact.types';
+import { parseShopAppearanceJson, ShopAppearanceSettings } from '../shops/types/shop-appearance.types';
 
 @Injectable()
 export class PublicService {
@@ -71,6 +72,7 @@ export class PublicService {
         name: true,
         slug: true,
         contact_json: true,
+        appearance_json: true,
       },
     });
     if (!shop) {
@@ -78,9 +80,11 @@ export class PublicService {
     }
     const stored = parseShopContactJson(shop.contact_json);
     const contact = this.mergeWithDefaults(shop.name, stored);
+    const appearance = parseShopAppearanceJson(shop.appearance_json);
     return {
       shop: { id: shop.id, name: shop.name, slug: shop.slug },
       contact,
+      appearance,
     };
   }
 

--- a/backend/src/shops/dto/update-shop-appearance.dto.ts
+++ b/backend/src/shops/dto/update-shop-appearance.dto.ts
@@ -3,8 +3,8 @@ import { Type } from 'class-transformer';
 import { ShopContactPatchDto } from './update-shop.dto';
 
 /** Safe subset for values that may later be applied to inline CSS */
-const CSS_TOKEN_COLOR = /^#[0-9A-Fa-f]{3,8}$|^[a-zA-Z][a-zA-Z0-9\-]*$/;
-const CSS_FONT_FAMILY = /^[a-zA-Z0-9\s\-'",.]+$/;
+const CSS_TOKEN_COLOR = /^#[0-9A-Fa-f]{3,8}$|^[a-zA-Z][a-zA-Z0-9-]*$/;
+const CSS_FONT_FAMILY = /^[a-zA-Z0-9\s'",.-]+$/;
 
 /** Branding / storefront — stored in Shop.appearance_json; public UI can read later */
 export class ShopAppearancePatchDto {

--- a/backend/src/shops/dto/update-shop-appearance.dto.ts
+++ b/backend/src/shops/dto/update-shop-appearance.dto.ts
@@ -1,0 +1,40 @@
+import { IsOptional, IsString, IsUrl, ValidateIf, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ShopContactPatchDto } from './update-shop.dto';
+
+/** Branding / storefront — stored in Shop.appearance_json; public UI can read later */
+export class ShopAppearancePatchDto {
+  @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
+  @IsUrl({ require_protocol: true, protocols: ['http', 'https'] })
+  logo_url?: string;
+
+  @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
+  @IsUrl({ require_protocol: true, protocols: ['http', 'https'] })
+  favicon_url?: string;
+
+  @IsOptional()
+  @IsString()
+  primary_color?: string;
+
+  @IsOptional()
+  @IsString()
+  accent_color?: string;
+
+  @IsOptional()
+  @IsString()
+  font_family?: string;
+}
+
+export class UpdateShopSettingsDto {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShopContactPatchDto)
+  contact?: ShopContactPatchDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShopAppearancePatchDto)
+  appearance?: ShopAppearancePatchDto;
+}

--- a/backend/src/shops/dto/update-shop-appearance.dto.ts
+++ b/backend/src/shops/dto/update-shop-appearance.dto.ts
@@ -1,29 +1,48 @@
-import { IsOptional, IsString, IsUrl, ValidateIf, ValidateNested } from 'class-validator';
+import { IsOptional, IsString, IsUrl, Matches, MaxLength, ValidateIf, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ShopContactPatchDto } from './update-shop.dto';
+
+/** Safe subset for values that may later be applied to inline CSS */
+const CSS_TOKEN_COLOR = /^#[0-9A-Fa-f]{3,8}$|^[a-zA-Z][a-zA-Z0-9\-]*$/;
+const CSS_FONT_FAMILY = /^[a-zA-Z0-9\s\-'",.]+$/;
 
 /** Branding / storefront — stored in Shop.appearance_json; public UI can read later */
 export class ShopAppearancePatchDto {
   @IsOptional()
   @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsUrl({ require_protocol: true, protocols: ['http', 'https'] })
+  @MaxLength(2000)
   logo_url?: string;
 
   @IsOptional()
   @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsUrl({ require_protocol: true, protocols: ['http', 'https'] })
+  @MaxLength(2000)
   favicon_url?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(64)
+  @Matches(CSS_TOKEN_COLOR, {
+    message: 'primary_color must be a hex color (#RGB) or a simple CSS color keyword',
+  })
   primary_color?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(64)
+  @Matches(CSS_TOKEN_COLOR, {
+    message: 'accent_color must be a hex color (#RGB) or a simple CSS color keyword',
+  })
   accent_color?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(200)
+  @Matches(CSS_FONT_FAMILY, { message: 'font_family contains invalid characters' })
   font_family?: string;
 }
 

--- a/backend/src/shops/dto/update-shop.dto.ts
+++ b/backend/src/shops/dto/update-shop.dto.ts
@@ -3,6 +3,8 @@ import {
   IsOptional,
   IsString,
   IsUrl,
+  Matches,
+  MaxLength,
   MinLength,
   ValidateIf,
   ValidateNested,
@@ -11,82 +13,115 @@ import { Type } from 'class-transformer';
 
 class ShopContactPhoneDto {
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(80)
   title?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(120)
   label?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(25)
+  @Matches(/^[+\d\s\-().]{6,25}$/, { message: 'tel must look like a phone number' })
   tel?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(200)
   hint?: string;
 }
 
 class ShopContactFacebookDto {
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(80)
   title?: string;
 
   @IsOptional()
   @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsUrl({ require_protocol: true, protocols: ['http', 'https'] })
+  @MaxLength(2000)
   url?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(200)
   label?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(200)
   hint?: string;
 }
 
 class ShopContactZaloDto {
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(80)
   title?: string;
 
   @IsOptional()
   @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsUrl({ require_protocol: true, protocols: ['http', 'https'] })
+  @MaxLength(2000)
   url?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(200)
   label?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(200)
   hint?: string;
 }
 
 class ShopContactHoursDto {
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(120)
   title?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(2000)
   schedule_line?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(500)
   footer_note?: string;
 }
 
 /** Nested contact sections for PATCH /admin/shops/:id — replaces corresponding slice when provided */
 export class ShopContactPatchDto {
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(200)
   page_title?: string;
 
   @IsOptional()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
   @IsString()
+  @MaxLength(500)
   page_subtitle?: string;
 
   @IsOptional()

--- a/backend/src/shops/dto/update-shop.dto.ts
+++ b/backend/src/shops/dto/update-shop.dto.ts
@@ -2,7 +2,9 @@ import {
   IsBoolean,
   IsOptional,
   IsString,
+  IsUrl,
   MinLength,
+  ValidateIf,
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -31,7 +33,8 @@ class ShopContactFacebookDto {
   title?: string;
 
   @IsOptional()
-  @IsString()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
+  @IsUrl({ require_protocol: true, protocols: ['http', 'https'] })
   url?: string;
 
   @IsOptional()
@@ -49,7 +52,8 @@ class ShopContactZaloDto {
   title?: string;
 
   @IsOptional()
-  @IsString()
+  @ValidateIf((_, v) => v !== undefined && v !== null && String(v).trim().length > 0)
+  @IsUrl({ require_protocol: true, protocols: ['http', 'https'] })
   url?: string;
 
   @IsOptional()

--- a/backend/src/shops/dto/update-shop.dto.ts
+++ b/backend/src/shops/dto/update-shop.dto.ts
@@ -1,4 +1,110 @@
-import { IsBoolean, IsOptional, IsString, MinLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+class ShopContactPhoneDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @IsOptional()
+  @IsString()
+  tel?: string;
+
+  @IsOptional()
+  @IsString()
+  hint?: string;
+}
+
+class ShopContactFacebookDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  url?: string;
+
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @IsOptional()
+  @IsString()
+  hint?: string;
+}
+
+class ShopContactZaloDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  url?: string;
+
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @IsOptional()
+  @IsString()
+  hint?: string;
+}
+
+class ShopContactHoursDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  schedule_line?: string;
+
+  @IsOptional()
+  @IsString()
+  footer_note?: string;
+}
+
+/** Nested contact sections for PATCH /admin/shops/:id — replaces corresponding slice when provided */
+export class ShopContactPatchDto {
+  @IsOptional()
+  @IsString()
+  page_title?: string;
+
+  @IsOptional()
+  @IsString()
+  page_subtitle?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShopContactPhoneDto)
+  phone?: ShopContactPhoneDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShopContactFacebookDto)
+  facebook?: ShopContactFacebookDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShopContactZaloDto)
+  zalo?: ShopContactZaloDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShopContactHoursDto)
+  hours?: ShopContactHoursDto;
+}
 
 export class UpdateShopDto {
   @IsOptional()
@@ -9,4 +115,9 @@ export class UpdateShopDto {
   @IsOptional()
   @IsBoolean()
   is_active?: boolean;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ShopContactPatchDto)
+  contact?: ShopContactPatchDto;
 }

--- a/backend/src/shops/json-stable-stringify.spec.ts
+++ b/backend/src/shops/json-stable-stringify.spec.ts
@@ -1,0 +1,15 @@
+import { jsonStableStringify } from './json-stable-stringify';
+
+describe('jsonStableStringify', () => {
+  it('treats same object with different key order as equal', () => {
+    const a = { z: 1, a: { y: 2, b: 3 } };
+    const b = { a: { b: 3, y: 2 }, z: 1 };
+    expect(jsonStableStringify(a)).toBe(jsonStableStringify(b));
+  });
+
+  it('normalizes nested key order recursively', () => {
+    const x = { outer: { z: 1, a: { m: 2, n: 3 } } };
+    const y = { outer: { a: { n: 3, m: 2 }, z: 1 } };
+    expect(jsonStableStringify(x)).toBe(jsonStableStringify(y));
+  });
+});

--- a/backend/src/shops/json-stable-stringify.ts
+++ b/backend/src/shops/json-stable-stringify.ts
@@ -1,0 +1,21 @@
+/**
+ * Deterministic JSON string for comparing Prisma Json values (key order independent at every depth).
+ */
+export function jsonStableStringify(value: unknown): string {
+  const normalize = (v: unknown): unknown => {
+    if (v === null || typeof v !== 'object') {
+      return v;
+    }
+    if (Array.isArray(v)) {
+      return v.map((item) => normalize(item));
+    }
+    const obj = v as Record<string, unknown>;
+    return Object.keys(obj)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = normalize(obj[key]);
+        return acc;
+      }, {});
+  };
+  return JSON.stringify(normalize(value));
+}

--- a/backend/src/shops/shop-settings.controller.ts
+++ b/backend/src/shops/shop-settings.controller.ts
@@ -1,0 +1,40 @@
+import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TenantGuard } from '../common/guards/tenant.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { CurrentTenantId } from '../common/decorators/tenant.decorator';
+import { CurrentUserId } from '../common/decorators/current-user-id.decorator';
+import { ShopRole } from '../generated/prisma/client';
+import { ShopsService } from './shops.service';
+import { UpdateShopSettingsDto } from './dto/update-shop-appearance.dto';
+
+/**
+ * Tenant-scoped shop branding + public contact copy.
+ * Routes: /shop-settings (active shop from JWT / TenantGuard).
+ */
+@Controller('shop-settings')
+@UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
+export class ShopSettingsController {
+  constructor(private readonly shopsService: ShopsService) {}
+
+  @Get()
+  getSettings(@CurrentTenantId() tenantId: string) {
+    return this.shopsService.getTenantShopSettings(tenantId);
+  }
+
+  @Patch()
+  updateSettings(
+    @CurrentTenantId() tenantId: string,
+    @Body() dto: UpdateShopSettingsDto,
+    @CurrentUserId() actorUserId: string | null,
+  ) {
+    return this.shopsService.updateContactAndAppearanceForTenant(
+      tenantId,
+      dto.contact,
+      dto.appearance,
+      actorUserId,
+    );
+  }
+}

--- a/backend/src/shops/shop-settings.controller.ts
+++ b/backend/src/shops/shop-settings.controller.ts
@@ -12,19 +12,23 @@ import { UpdateShopSettingsDto } from './dto/update-shop-appearance.dto';
 /**
  * Tenant-scoped shop branding + public contact copy.
  * Routes: /shop-settings (active shop from JWT / TenantGuard).
+ *
+ * GET: shop_admin or shop_staff (read-only for staff via RolesGuard).
+ * PATCH: shop_admin only — staff cannot change public contact / branding.
  */
 @Controller('shop-settings')
 @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
-@Roles(ShopRole.shop_admin, ShopRole.shop_staff)
 export class ShopSettingsController {
   constructor(private readonly shopsService: ShopsService) {}
 
   @Get()
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   getSettings(@CurrentTenantId() tenantId: string) {
     return this.shopsService.getTenantShopSettings(tenantId);
   }
 
   @Patch()
+  @Roles(ShopRole.shop_admin)
   updateSettings(
     @CurrentTenantId() tenantId: string,
     @Body() dto: UpdateShopSettingsDto,

--- a/backend/src/shops/shops.module.ts
+++ b/backend/src/shops/shops.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ShopsService } from './shops.service';
 import { ShopsController } from './shops.controller';
+import { ShopSettingsController } from './shop-settings.controller';
 import { StorageModule } from '../storage/storage.module';
 
 @Module({
   imports: [StorageModule],
-  controllers: [ShopsController],
+  controllers: [ShopsController, ShopSettingsController],
   providers: [ShopsService],
   exports: [ShopsService],
 })

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -548,6 +548,7 @@ describe('ShopsService', () => {
         name: 'Shop A',
         slug: 'shop-a',
         is_active: true,
+        contact_json: {},
         _count: { items: 0, user_roles: 1 },
       });
       prisma.shop.update.mockResolvedValue({
@@ -555,11 +556,46 @@ describe('ShopsService', () => {
         name: 'Shop A',
         slug: 'shop-a',
         is_active: true,
+        contact_json: {},
       });
 
       await service.update(shopId, {}, 'actor-1');
 
       expect(prisma.shopAuditLog.create).not.toHaveBeenCalled();
+    });
+
+    it('logs update_shop when contact_json changes', async () => {
+      prisma.shop.findUnique.mockResolvedValue({
+        id: shopId,
+        name: 'Shop A',
+        slug: 'shop-a',
+        is_active: true,
+        contact_json: {},
+        _count: { items: 0, user_roles: 1 },
+      });
+      prisma.shop.update.mockResolvedValue({
+        id: shopId,
+        name: 'Shop A',
+        slug: 'shop-a',
+        is_active: true,
+        contact_json: { phone: { tel: '+84' } },
+      });
+      prisma.shopAuditLog.create.mockResolvedValue({ id: 'log-c' });
+
+      await service.update(
+        shopId,
+        { contact: { phone: { tel: '+84' } } },
+        'actor-1',
+      );
+
+      expect(prisma.shopAuditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'update_shop',
+            metadata_json: expect.stringContaining('contact_json'),
+          }),
+        }),
+      );
     });
   });
 });

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -26,6 +26,7 @@ describe('ShopsService', () => {
     prisma = {
       shop: {
         findUnique: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
       },
       item: {
@@ -593,6 +594,61 @@ describe('ShopsService', () => {
           data: expect.objectContaining({
             action: 'update_shop',
             metadata_json: expect.stringContaining('contact_json'),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('tenant shop settings', () => {
+    const tenantId = 'shop-tenant-1';
+
+    it('getTenantShopSettings returns slim shop row', async () => {
+      prisma.shop.findFirst.mockResolvedValue({
+        id: tenantId,
+        name: 'T',
+        slug: 't',
+        contact_json: {},
+        appearance_json: {},
+      });
+
+      const out = await service.getTenantShopSettings(tenantId);
+
+      expect(out.id).toBe(tenantId);
+      expect(prisma.shop.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: tenantId, is_active: true } }),
+      );
+    });
+
+    it('updateContactAndAppearanceForTenant merges appearance', async () => {
+      prisma.shop.findFirst.mockResolvedValue({
+        id: tenantId,
+        name: 'T',
+        slug: 't',
+        contact_json: {},
+        appearance_json: {},
+      });
+      prisma.shop.update.mockResolvedValue({
+        id: tenantId,
+        name: 'T',
+        slug: 't',
+        contact_json: {},
+        appearance_json: { logo_url: 'https://cdn.example/logo.png' },
+      });
+      prisma.shopAuditLog.create.mockResolvedValue({});
+
+      await service.updateContactAndAppearanceForTenant(
+        tenantId,
+        undefined,
+        { logo_url: 'https://cdn.example/logo.png' },
+        'u1',
+      );
+
+      expect(prisma.shop.update).toHaveBeenCalled();
+      expect(prisma.shopAuditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            metadata_json: expect.stringContaining('appearance_json'),
           }),
         }),
       );

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -16,6 +16,7 @@ import { IStorageService } from '../storage/storage.interface';
 import { toNumber } from '../common/utils/decimal.utils';
 import { totalPagesFromCount } from '../common/utils/pagination.utils';
 import { RolesGuard } from '../common/guards/roles.guard';
+import { jsonStableStringify } from './json-stable-stringify';
 
 const MAX_SLUG_ALLOCATION_ATTEMPTS = 32;
 
@@ -224,7 +225,7 @@ export class ShopsService {
     const nameChanged = dto.name !== undefined && oldShop.name !== updated.name;
     const contactChanged =
       dto.contact !== undefined &&
-      JSON.stringify(oldShop.contact_json) !== JSON.stringify(updated.contact_json);
+      jsonStableStringify(oldShop.contact_json) !== jsonStableStringify(updated.contact_json);
 
     if (activationChanged) {
       await this.logAudit(
@@ -267,7 +268,7 @@ export class ShopsService {
 
   /**
    * Shop-scoped settings (contact + appearance) for the active tenant.
-   * Used by shop_admin / shop_staff via GET/PATCH /shop-settings.
+   * GET: shop_admin or shop_staff. PATCH: shop_admin only (RolesGuard).
    */
   async getTenantShopSettings(tenantId: string) {
     const shop = await this.prisma.shop.findFirst({
@@ -295,39 +296,55 @@ export class ShopsService {
     if (contact === undefined && appearance === undefined) {
       return this.getTenantShopSettings(tenantId);
     }
-    const oldShop = await this.getTenantShopSettings(tenantId);
-    const data: Prisma.ShopUpdateInput = {};
-    if (contact !== undefined) {
-      data.contact_json = this.mergeContactJson(oldShop.contact_json, contact);
-    }
-    if (appearance !== undefined) {
-      data.appearance_json = this.mergeAppearanceJson(oldShop.appearance_json, appearance);
-    }
 
-    const updated = await this.prisma.shop.update({
-      where: { id: tenantId },
-      data,
+    return this.prisma.$transaction(async (tx) => {
+      const oldShop = await tx.shop.findFirst({
+        where: { id: tenantId, is_active: true },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          contact_json: true,
+          appearance_json: true,
+        },
+      });
+      if (!oldShop) {
+        throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
+      }
+
+      const data: Prisma.ShopUpdateInput = {};
+      if (contact !== undefined) {
+        data.contact_json = this.mergeContactJson(oldShop.contact_json, contact);
+      }
+      if (appearance !== undefined) {
+        data.appearance_json = this.mergeAppearanceJson(oldShop.appearance_json, appearance);
+      }
+
+      const updated = await tx.shop.update({
+        where: { id: tenantId },
+        data,
+      });
+
+      const contactChanged =
+        contact !== undefined &&
+        jsonStableStringify(oldShop.contact_json) !== jsonStableStringify(updated.contact_json);
+      const appearanceChanged =
+        appearance !== undefined &&
+        jsonStableStringify(oldShop.appearance_json) !== jsonStableStringify(updated.appearance_json);
+
+      if (contactChanged) {
+        await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
+          field: 'contact_json',
+        });
+      }
+      if (appearanceChanged) {
+        await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
+          field: 'appearance_json',
+        });
+      }
+
+      return updated;
     });
-
-    const contactChanged =
-      contact !== undefined &&
-      JSON.stringify(oldShop.contact_json) !== JSON.stringify(updated.contact_json);
-    const appearanceChanged =
-      appearance !== undefined &&
-      JSON.stringify(oldShop.appearance_json) !== JSON.stringify(updated.appearance_json);
-
-    if (contactChanged) {
-      await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
-        field: 'contact_json',
-      });
-    }
-    if (appearanceChanged) {
-      await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
-        field: 'appearance_json',
-      });
-    }
-
-    return updated;
   }
 
   /**

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -6,9 +6,9 @@ import { CreateShopDto } from './dto/create-shop.dto';
 import { QueryShopMembersDto } from './dto/query-shop-members.dto';
 import { QueryShopItemsDto } from './dto/query-shop-items.dto';
 import { QueryShopAuditLogsDto } from './dto/query-shop-audit-logs.dto';
-import { UpdateShopDto } from './dto/update-shop.dto';
+import { UpdateShopDto, ShopContactPatchDto } from './dto/update-shop.dto';
 import { AddShopAdminDto } from './dto/add-shop-admin.dto';
-import { ShopAuditAction, ShopRole } from '../generated/prisma/client';
+import { Prisma, ShopAuditAction, ShopRole } from '../generated/prisma/client';
 import * as bcrypt from 'bcrypt';
 import { isUUID } from 'class-validator';
 import { IStorageService } from '../storage/storage.interface';
@@ -41,6 +41,55 @@ export class ShopsService {
   /** Slug candidate: `base`, then `base-1`, `base-2`, ... (matches prior allocateUniqueSlug numbering). */
   private shopSlugCandidate(base: string, attemptIndex: number): string {
     return attemptIndex === 0 ? base : `${base}-${attemptIndex}`;
+  }
+
+  private mergeContactJson(
+    existing: Prisma.JsonValue,
+    patch: ShopContactPatchDto,
+  ): Prisma.InputJsonValue {
+    const baseObj =
+      typeof existing === 'object' && existing !== null && !Array.isArray(existing)
+        ? { ...(existing as Record<string, unknown>) }
+        : {};
+    const next: Record<string, unknown> = { ...baseObj };
+
+    const mergeStringRecord = (
+      prevRaw: unknown,
+      patchRecord: Record<string, unknown> | undefined,
+    ): Record<string, unknown> => {
+      const prev =
+        typeof prevRaw === 'object' && prevRaw !== null && !Array.isArray(prevRaw)
+          ? { ...(prevRaw as Record<string, unknown>) }
+          : {};
+      if (!patchRecord) return prev;
+      for (const [k, v] of Object.entries(patchRecord)) {
+        if (v === undefined) continue;
+        if (typeof v === 'string' && v.trim() === '') {
+          delete prev[k];
+        } else {
+          prev[k] = v;
+        }
+      }
+      return prev;
+    };
+
+    if (patch.page_title !== undefined) {
+      if (patch.page_title.trim() === '') delete next.page_title;
+      else next.page_title = patch.page_title;
+    }
+    if (patch.page_subtitle !== undefined) {
+      if (patch.page_subtitle.trim() === '') delete next.page_subtitle;
+      else next.page_subtitle = patch.page_subtitle;
+    }
+
+    const nested = ['phone', 'facebook', 'zalo', 'hours'] as const;
+    for (const key of nested) {
+      if (patch[key] !== undefined) {
+        next[key] = mergeStringRecord(next[key], patch[key] as Record<string, unknown>);
+      }
+    }
+
+    return next as Prisma.InputJsonValue;
   }
 
   private async logAudit(
@@ -131,13 +180,23 @@ export class ShopsService {
 
   async update(id: string, dto: UpdateShopDto, actorUserId?: string | null) {
     const oldShop = await this.findOne(id); // throws 404 if not found
+    const data: Prisma.ShopUpdateInput = {};
+    if (dto.name !== undefined) data.name = dto.name;
+    if (dto.is_active !== undefined) data.is_active = dto.is_active;
+    if (dto.contact !== undefined) {
+      data.contact_json = this.mergeContactJson(oldShop.contact_json, dto.contact);
+    }
+
     const updated = await this.prisma.shop.update({
       where: { id },
-      data: dto,
+      data,
     });
     const activationChanged =
       dto.is_active !== undefined && oldShop.is_active !== updated.is_active;
     const nameChanged = dto.name !== undefined && oldShop.name !== updated.name;
+    const contactChanged =
+      dto.contact !== undefined &&
+      JSON.stringify(oldShop.contact_json) !== JSON.stringify(updated.contact_json);
 
     if (activationChanged) {
       await this.logAudit(
@@ -167,6 +226,12 @@ export class ShopsService {
           after: { name: updated.name },
         },
       );
+    }
+
+    if (contactChanged) {
+      await this.logAudit(id, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', id, {
+        field: 'contact_json',
+      });
     }
 
     return updated;

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -297,54 +297,54 @@ export class ShopsService {
       return this.getTenantShopSettings(tenantId);
     }
 
-    return this.prisma.$transaction(async (tx) => {
-      const oldShop = await tx.shop.findFirst({
-        where: { id: tenantId, is_active: true },
-        select: {
-          id: true,
-          name: true,
-          slug: true,
-          contact_json: true,
-          appearance_json: true,
-        },
-      });
-      if (!oldShop) {
-        throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
-      }
+    const oldShop = await this.prisma.shop.findFirst({
+      where: { id: tenantId, is_active: true },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        contact_json: true,
+        appearance_json: true,
+      },
+    });
+    if (!oldShop) {
+      throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
+    }
 
-      const data: Prisma.ShopUpdateInput = {};
-      if (contact !== undefined) {
-        data.contact_json = this.mergeContactJson(oldShop.contact_json, contact);
-      }
-      if (appearance !== undefined) {
-        data.appearance_json = this.mergeAppearanceJson(oldShop.appearance_json, appearance);
-      }
+    const data: Prisma.ShopUpdateInput = {};
+    if (contact !== undefined) {
+      data.contact_json = this.mergeContactJson(oldShop.contact_json, contact);
+    }
+    if (appearance !== undefined) {
+      data.appearance_json = this.mergeAppearanceJson(oldShop.appearance_json, appearance);
+    }
 
-      const updated = await tx.shop.update({
+    const contactChanged =
+      contact !== undefined &&
+      jsonStableStringify(oldShop.contact_json) !== jsonStableStringify(data.contact_json);
+    const appearanceChanged =
+      appearance !== undefined &&
+      jsonStableStringify(oldShop.appearance_json) !== jsonStableStringify(data.appearance_json);
+
+    const updated = await this.prisma.$transaction(async (tx) => {
+      return tx.shop.update({
         where: { id: tenantId },
         data,
       });
-
-      const contactChanged =
-        contact !== undefined &&
-        jsonStableStringify(oldShop.contact_json) !== jsonStableStringify(updated.contact_json);
-      const appearanceChanged =
-        appearance !== undefined &&
-        jsonStableStringify(oldShop.appearance_json) !== jsonStableStringify(updated.appearance_json);
-
-      if (contactChanged) {
-        await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
-          field: 'contact_json',
-        });
-      }
-      if (appearanceChanged) {
-        await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
-          field: 'appearance_json',
-        });
-      }
-
-      return updated;
     });
+
+    if (contactChanged) {
+      await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
+        field: 'contact_json',
+      });
+    }
+    if (appearanceChanged) {
+      await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
+        field: 'appearance_json',
+      });
+    }
+
+    return updated;
   }
 
   /**

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -7,6 +7,7 @@ import { QueryShopMembersDto } from './dto/query-shop-members.dto';
 import { QueryShopItemsDto } from './dto/query-shop-items.dto';
 import { QueryShopAuditLogsDto } from './dto/query-shop-audit-logs.dto';
 import { UpdateShopDto, ShopContactPatchDto } from './dto/update-shop.dto';
+import { ShopAppearancePatchDto } from './dto/update-shop-appearance.dto';
 import { AddShopAdminDto } from './dto/add-shop-admin.dto';
 import { Prisma, ShopAuditAction, ShopRole } from '../generated/prisma/client';
 import * as bcrypt from 'bcrypt';
@@ -89,6 +90,33 @@ export class ShopsService {
       }
     }
 
+    return next as Prisma.InputJsonValue;
+  }
+
+  private mergeAppearanceJson(
+    existing: Prisma.JsonValue,
+    patch: ShopAppearancePatchDto,
+  ): Prisma.InputJsonValue {
+    const baseObj =
+      typeof existing === 'object' && existing !== null && !Array.isArray(existing)
+        ? { ...(existing as Record<string, unknown>) }
+        : {};
+    const next: Record<string, unknown> = { ...baseObj };
+    const entries: [keyof typeof patch, unknown][] = [
+      ['logo_url', patch.logo_url],
+      ['favicon_url', patch.favicon_url],
+      ['primary_color', patch.primary_color],
+      ['accent_color', patch.accent_color],
+      ['font_family', patch.font_family],
+    ];
+    for (const [key, val] of entries) {
+      if (val === undefined) continue;
+      if (typeof val === 'string' && val.trim() === '') {
+        delete next[key as string];
+      } else {
+        next[key as string] = val;
+      }
+    }
     return next as Prisma.InputJsonValue;
   }
 
@@ -231,6 +259,71 @@ export class ShopsService {
     if (contactChanged) {
       await this.logAudit(id, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', id, {
         field: 'contact_json',
+      });
+    }
+
+    return updated;
+  }
+
+  /**
+   * Shop-scoped settings (contact + appearance) for the active tenant.
+   * Used by shop_admin / shop_staff via GET/PATCH /shop-settings.
+   */
+  async getTenantShopSettings(tenantId: string) {
+    const shop = await this.prisma.shop.findFirst({
+      where: { id: tenantId, is_active: true },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        contact_json: true,
+        appearance_json: true,
+      },
+    });
+    if (!shop) {
+      throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
+    }
+    return shop;
+  }
+
+  async updateContactAndAppearanceForTenant(
+    tenantId: string,
+    contact?: ShopContactPatchDto,
+    appearance?: ShopAppearancePatchDto,
+    actorUserId?: string | null,
+  ) {
+    if (contact === undefined && appearance === undefined) {
+      return this.getTenantShopSettings(tenantId);
+    }
+    const oldShop = await this.getTenantShopSettings(tenantId);
+    const data: Prisma.ShopUpdateInput = {};
+    if (contact !== undefined) {
+      data.contact_json = this.mergeContactJson(oldShop.contact_json, contact);
+    }
+    if (appearance !== undefined) {
+      data.appearance_json = this.mergeAppearanceJson(oldShop.appearance_json, appearance);
+    }
+
+    const updated = await this.prisma.shop.update({
+      where: { id: tenantId },
+      data,
+    });
+
+    const contactChanged =
+      contact !== undefined &&
+      JSON.stringify(oldShop.contact_json) !== JSON.stringify(updated.contact_json);
+    const appearanceChanged =
+      appearance !== undefined &&
+      JSON.stringify(oldShop.appearance_json) !== JSON.stringify(updated.appearance_json);
+
+    if (contactChanged) {
+      await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
+        field: 'contact_json',
+      });
+    }
+    if (appearanceChanged) {
+      await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
+        field: 'appearance_json',
       });
     }
 

--- a/backend/src/shops/types/shop-appearance.types.ts
+++ b/backend/src/shops/types/shop-appearance.types.ts
@@ -1,0 +1,19 @@
+import { Prisma } from '../../generated/prisma/client';
+
+export type ShopAppearanceSettings = {
+  logo_url?: string;
+  favicon_url?: string;
+  primary_color?: string;
+  accent_color?: string;
+  font_family?: string;
+};
+
+export function parseShopAppearanceJson(raw: Prisma.JsonValue | null | undefined): ShopAppearanceSettings {
+  if (raw === null || raw === undefined) {
+    return {};
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+  return raw as ShopAppearanceSettings;
+}

--- a/backend/src/shops/types/shop-appearance.types.ts
+++ b/backend/src/shops/types/shop-appearance.types.ts
@@ -8,6 +8,14 @@ export type ShopAppearanceSettings = {
   font_family?: string;
 };
 
+const KEYS: (keyof ShopAppearanceSettings)[] = [
+  'logo_url',
+  'favicon_url',
+  'primary_color',
+  'accent_color',
+  'font_family',
+];
+
 export function parseShopAppearanceJson(raw: Prisma.JsonValue | null | undefined): ShopAppearanceSettings {
   if (raw === null || raw === undefined) {
     return {};
@@ -15,5 +23,13 @@ export function parseShopAppearanceJson(raw: Prisma.JsonValue | null | undefined
   if (typeof raw !== 'object' || Array.isArray(raw)) {
     return {};
   }
-  return raw as ShopAppearanceSettings;
+  const root = raw as Record<string, unknown>;
+  const out: ShopAppearanceSettings = {};
+  for (const k of KEYS) {
+    const v = root[k as string];
+    if (typeof v === 'string') {
+      out[k] = v;
+    }
+  }
+  return out;
 }

--- a/backend/src/shops/types/shop-contact.types.spec.ts
+++ b/backend/src/shops/types/shop-contact.types.spec.ts
@@ -1,0 +1,14 @@
+import { parseShopContactJson } from './shop-contact.types';
+
+describe('parseShopContactJson', () => {
+  it('ignores non-string nested values', () => {
+    const raw = {
+      page_title: 123,
+      phone: { tel: 999, label: 'ok' },
+    };
+    const out = parseShopContactJson(raw);
+    expect(out.page_title).toBeUndefined();
+    expect(out.phone?.tel).toBeUndefined();
+    expect(out.phone?.label).toBe('ok');
+  });
+});

--- a/backend/src/shops/types/shop-contact.types.ts
+++ b/backend/src/shops/types/shop-contact.types.ts
@@ -1,0 +1,49 @@
+import { Prisma } from '../../generated/prisma/client';
+
+/**
+ * Shape stored in Shop.contact_json and returned by GET /public/shops/:id/contact.
+ */
+export type ShopContactSettings = {
+  page_title?: string;
+  page_subtitle?: string;
+  phone?: {
+    /** Display label e.g. "Điện thoại" */
+    title?: string;
+    /** Shown to users (e.g. 0856694766) */
+    label?: string;
+    /** tel: href without scheme, e.g. +84856694766 */
+    tel?: string;
+    hint?: string;
+  };
+  facebook?: {
+    title?: string;
+    /** Full URL */
+    url?: string;
+    /** Short label for link text */
+    label?: string;
+    hint?: string;
+  };
+  zalo?: {
+    title?: string;
+    /** Full URL e.g. https://zalo.me/0856694766 */
+    url?: string;
+    label?: string;
+    hint?: string;
+  };
+  hours?: {
+    title?: string;
+    /** Main line e.g. "Thứ 2 - Chủ nhật: 9:00 - 21:00" */
+    schedule_line?: string;
+    footer_note?: string;
+  };
+};
+
+export function parseShopContactJson(raw: Prisma.JsonValue | null | undefined): ShopContactSettings {
+  if (raw === null || raw === undefined) {
+    return {};
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+  return raw as ShopContactSettings;
+}

--- a/backend/src/shops/types/shop-contact.types.ts
+++ b/backend/src/shops/types/shop-contact.types.ts
@@ -38,6 +38,39 @@ export type ShopContactSettings = {
   };
 };
 
+function strField(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+function readNestedStrings(
+  raw: Record<string, unknown>,
+  key: string,
+): Record<string, string | undefined> {
+  const v = raw[key];
+  if (!v || typeof v !== 'object' || Array.isArray(v)) {
+    return {};
+  }
+  const o = v as Record<string, unknown>;
+  const out: Record<string, string | undefined> = {};
+  for (const k of Object.keys(o)) {
+    out[k] = strField(o[k]);
+  }
+  return out;
+}
+
+function compactNested(
+  fields: Record<string, string | undefined>,
+): Record<string, string> | undefined {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    if (v !== undefined && v !== '') {
+      out[k] = v;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Coerce DB JSON to typed strings only — avoids runtime errors on corrupt types. */
 export function parseShopContactJson(raw: Prisma.JsonValue | null | undefined): ShopContactSettings {
   if (raw === null || raw === undefined) {
     return {};
@@ -45,5 +78,26 @@ export function parseShopContactJson(raw: Prisma.JsonValue | null | undefined): 
   if (typeof raw !== 'object' || Array.isArray(raw)) {
     return {};
   }
-  return raw as ShopContactSettings;
+  const root = raw as Record<string, unknown>;
+  const phone = readNestedStrings(root, 'phone');
+  const facebook = readNestedStrings(root, 'facebook');
+  const zalo = readNestedStrings(root, 'zalo');
+  const hours = readNestedStrings(root, 'hours');
+
+  const out: ShopContactSettings = {};
+  const pt = strField(root.page_title);
+  const ps = strField(root.page_subtitle);
+  if (pt !== undefined) out.page_title = pt;
+  if (ps !== undefined) out.page_subtitle = ps;
+
+  const phoneC = compactNested(phone as Record<string, string | undefined>);
+  if (phoneC) out.phone = phoneC as ShopContactSettings['phone'];
+  const fbC = compactNested(facebook as Record<string, string | undefined>);
+  if (fbC) out.facebook = fbC as ShopContactSettings['facebook'];
+  const zaloC = compactNested(zalo as Record<string, string | undefined>);
+  if (zaloC) out.zalo = zaloC as ShopContactSettings['zalo'];
+  const hoursC = compactNested(hours as Record<string, string | undefined>);
+  if (hoursC) out.hours = hoursC as ShopContactSettings['hours'];
+
+  return out;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { FacebookPostsPage } from './pages/admin/FacebookPostsPage';
 import { ReportsPage } from './pages/admin/ReportsPage';
 import { MembersPage } from './pages/admin/MembersPage';
 import ShopsPage from './pages/admin/ShopsPage';
+import { ShopSettingsPage } from './pages/admin/ShopSettingsPage';
 import { PublicCatalogPage } from './pages/PublicCatalogPage';
 import { PublicItemDetailPage } from './pages/PublicItemDetailPage';
 import { ContactPage } from './pages/ContactPage';
@@ -151,6 +152,16 @@ function App() {
                   <ProtectedRoute>
                     <Layout>
                       <ShopsPage />
+                    </Layout>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path={ROUTES.admin.shopSettings}
+                element={
+                  <ProtectedRoute>
+                    <Layout>
+                      <ShopSettingsPage />
                     </Layout>
                   </ProtectedRoute>
                 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import {
   Home,
   LogOut,
   Menu,
+  Palette,
   Phone,
   ShoppingBag,
   Sparkles,
@@ -20,6 +21,7 @@ import {
   isAdminMembersActive,
   isAdminItemsSectionActive,
   isAdminPreordersHubActive,
+  isAdminShopSettingsActive,
 } from '../config/routes';
 import { cn } from '../lib/utils';
 import { usePublicShopContext } from '../hooks/usePublicShopContext';
@@ -184,6 +186,17 @@ export const Layout = ({ children }: LayoutProps) => {
           📘
         </span>
         <span>Bài đăng FB</span>
+      </Link>
+      <Link
+        to={ROUTES.admin.shopSettings}
+        className={cn(
+          adminSidebarNavLinkBase,
+          isAdminShopSettingsActive(pathname) && adminSidebarNavLinkActive,
+        )}
+        onClick={closeMobileMenu}
+      >
+        <Palette size={18} strokeWidth={2} />
+        <span>Cấu hình shop</span>
       </Link>
       {isSuperAdmin && (
         <Link

--- a/frontend/src/config/routes.ts
+++ b/frontend/src/config/routes.ts
@@ -18,8 +18,14 @@ export const ROUTES = {
     preordersManage: '/admin/preorders/manage',
     facebookPosts: '/admin/facebook-posts',
     shops: '/admin/shops',
+    /** Contact + branding (tenant); shop_admin / shop_staff */
+    shopSettings: '/admin/shop-settings',
   },
 } as const;
+
+export function isAdminShopSettingsActive(pathname: string): boolean {
+  return pathname.startsWith(ROUTES.admin.shopSettings);
+}
 
 /** Danh sách / chi tiết / mới — không gồm trang import AI */
 export function isAdminItemsSectionActive(pathname: string): boolean {

--- a/frontend/src/contexts/ShopContext.tsx
+++ b/frontend/src/contexts/ShopContext.tsx
@@ -122,12 +122,9 @@ export const ShopProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, [authCtx?.isAuthenticated, authCtx?.loading, switchToShop]);
 
-  /* Hydrate allowed/active shops from /auth/me when auth state settles */
-  /* eslint-disable react-hooks/set-state-in-effect -- async loads shops then updates context state */
   useEffect(() => {
     void loadUserShops();
   }, [loadUserShops]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const switchShop = async (shopId: string) => {
     setLoading(true);

--- a/frontend/src/contexts/ShopContext.tsx
+++ b/frontend/src/contexts/ShopContext.tsx
@@ -122,9 +122,12 @@ export const ShopProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   }, [authCtx?.isAuthenticated, authCtx?.loading, switchToShop]);
 
+  /* Hydrate allowed/active shops from /auth/me when auth state settles */
+  /* eslint-disable react-hooks/set-state-in-effect -- async loads shops then updates context state */
   useEffect(() => {
     void loadUserShops();
   }, [loadUserShops]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const switchShop = async (shopId: string) => {
     setLoading(true);

--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -22,14 +22,15 @@ function renderInlineBold(text: string): ReactNode {
   const parts = text.split(/(\*\*[^*]+\*\*)/g);
   return parts.map((part, i) => {
     const m = part.match(/^\*\*([^*]+)\*\*$/);
+    const key = `p${i}:${part.length}:${part.slice(0, 24)}`;
     if (m) {
       return (
-        <strong key={i} style={{ fontWeight: 600, color: '#1a1a1a' }}>
+        <strong key={key} style={{ fontWeight: 600, color: '#1a1a1a' }}>
           {m[1]}
         </strong>
       );
     }
-    return <span key={i}>{part}</span>;
+    return <span key={key}>{part}</span>;
   });
 }
 

--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -5,6 +5,19 @@ import { apiClient } from '../api/client';
 import { usePublicShopContext } from '../hooks/usePublicShopContext';
 import type { PublicShopContactResponse } from '../types/shopContactPublic';
 
+/** Only allow http(s) links in href / window.open to avoid javascript: and other schemes. */
+function safeHttpUrl(url: string | undefined): string {
+  if (!url) return '';
+  const t = url.trim();
+  if (!t) return '';
+  try {
+    const p = new URL(t);
+    return p.protocol === 'http:' || p.protocol === 'https:' ? t : '';
+  } catch {
+    return '';
+  }
+}
+
 function renderInlineBold(text: string): ReactNode {
   const parts = text.split(/(\*\*[^*]+\*\*)/g);
   return parts.map((part, i) => {
@@ -35,6 +48,9 @@ export const ContactPage = () => {
   });
 
   const contact = data?.contact;
+
+  const facebookUrl = safeHttpUrl(contact?.facebook?.url);
+  const zaloUrl = safeHttpUrl(contact?.zalo?.url);
 
   const phoneTelHref = useMemo(() => {
     const raw = contact?.phone?.tel?.trim() ?? '';
@@ -99,8 +115,8 @@ export const ContactPage = () => {
   };
 
   const showPhone = Boolean(contact.phone?.tel?.trim() || contact.phone?.label?.trim());
-  const showFacebook = Boolean(contact.facebook?.url?.trim());
-  const showZalo = Boolean(contact.zalo?.url?.trim());
+  const showFacebook = Boolean(facebookUrl);
+  const showZalo = Boolean(zaloUrl);
 
   return (
     <div style={{ minHeight: 'calc(100vh - 200px)', padding: '40px 20px' }}>
@@ -236,9 +252,9 @@ export const ContactPage = () => {
               }}
               onMouseEnter={cardHoverEnter}
               onMouseLeave={cardHoverLeave}
-              onClick={() =>
-                window.open(contact.facebook?.url?.trim() ?? '', '_blank')
-              }
+              onClick={() => {
+                if (facebookUrl) window.open(facebookUrl, '_blank');
+              }}
             >
               <div
                 style={{
@@ -266,7 +282,7 @@ export const ContactPage = () => {
                 {contact.facebook?.title || 'Facebook'}
               </h3>
               <a
-                href={contact.facebook?.url?.trim()}
+                href={facebookUrl || undefined}
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{
@@ -311,7 +327,9 @@ export const ContactPage = () => {
               }}
               onMouseEnter={cardHoverEnter}
               onMouseLeave={cardHoverLeave}
-              onClick={() => window.open(contact.zalo?.url?.trim() ?? '', '_blank')}
+              onClick={() => {
+                if (zaloUrl) window.open(zaloUrl, '_blank');
+              }}
             >
               <div
                 style={{
@@ -339,7 +357,7 @@ export const ContactPage = () => {
                 {contact.zalo?.title || 'Zalo'}
               </h3>
               <a
-                href={contact.zalo?.url?.trim()}
+                href={zaloUrl || undefined}
                 target="_blank"
                 rel="noopener noreferrer"
                 style={{

--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -1,271 +1,429 @@
-import { Phone, Facebook, MessageCircle} from 'lucide-react';
+import { useMemo, type ReactNode, type MouseEvent } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Phone, Facebook, MessageCircle } from 'lucide-react';
+import { apiClient } from '../api/client';
+import { usePublicShopContext } from '../hooks/usePublicShopContext';
+import type { PublicShopContactResponse } from '../types/shopContactPublic';
+
+function renderInlineBold(text: string): ReactNode {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  return parts.map((part, i) => {
+    const m = part.match(/^\*\*([^*]+)\*\*$/);
+    if (m) {
+      return (
+        <strong key={i} style={{ fontWeight: 600, color: '#1a1a1a' }}>
+          {m[1]}
+        </strong>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
 
 export const ContactPage = () => {
+  const { effectiveShopId, shopContextReady, publicApiShopReady } = usePublicShopContext();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['public-shop-contact', effectiveShopId],
+    queryFn: async () => {
+      const res = await apiClient.get(
+        `/public/shops/${encodeURIComponent(effectiveShopId)}/contact`,
+      );
+      return res.data as PublicShopContactResponse;
+    },
+    enabled: shopContextReady && publicApiShopReady,
+  });
+
+  const contact = data?.contact;
+
+  const phoneTelHref = useMemo(() => {
+    const raw = contact?.phone?.tel?.trim() ?? '';
+    if (!raw) return '';
+    const withScheme = raw.startsWith('tel:') ? raw : `tel:${raw}`;
+    return withScheme;
+  }, [contact?.phone?.tel]);
+
+  if (!shopContextReady) {
+    return (
+      <div style={{ padding: '40px', textAlign: 'center' }}>Đang tải...</div>
+    );
+  }
+
+  if (!publicApiShopReady) {
+    return (
+      <div style={{ padding: '40px', textAlign: 'center', maxWidth: 480, margin: '0 auto' }}>
+        <h2 style={{ fontSize: '18px', fontWeight: 600, marginBottom: 8 }}>Chưa chọn cửa hàng</h2>
+        <p style={{ color: '#64748b', fontSize: '14px', lineHeight: 1.6 }}>
+          Thêm{' '}
+          <code style={{ background: '#fef3c7', padding: '2px 6px', borderRadius: 4 }}>
+            ?shop_id=
+          </code>{' '}
+          vào URL (UUID hoặc slug), hoặc cấu hình{' '}
+          <code style={{ background: '#fef3c7', padding: '2px 6px', borderRadius: 4 }}>
+            VITE_PUBLIC_CATALOG_SHOP_ID
+          </code>{' '}
+          khi build.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div style={{ padding: '40px', textAlign: 'center' }}>Đang tải liên hệ...</div>
+    );
+  }
+
+  if (error || !contact) {
+    return (
+      <div style={{ padding: '40px', textAlign: 'center', color: '#b91c1c' }}>
+        Không tải được thông tin liên hệ. Thử lại sau.
+      </div>
+    );
+  }
+
+  const cardHoverEnter = (e: MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.transform = 'translateY(-4px)';
+    e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.15)';
+  };
+  const cardHoverLeave = (e: MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.transform = 'translateY(0)';
+    e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.1)';
+  };
+
+  const linkHoverEnter = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.currentTarget.style.textDecoration = 'underline';
+  };
+  const linkHoverLeave = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.currentTarget.style.textDecoration = 'none';
+  };
+
+  const showPhone = Boolean(contact.phone?.tel?.trim() || contact.phone?.label?.trim());
+  const showFacebook = Boolean(contact.facebook?.url?.trim());
+  const showZalo = Boolean(contact.zalo?.url?.trim());
+
   return (
     <div style={{ minHeight: 'calc(100vh - 200px)', padding: '40px 20px' }}>
       <div style={{ maxWidth: '800px', margin: '0 auto' }}>
         <div style={{ textAlign: 'center', marginBottom: '48px' }}>
-          <h1 style={{
-            fontSize: '36px',
-            fontWeight: '700',
-            color: '#1a1a1a',
-            margin: '0 0 12px 0',
-            letterSpacing: '-0.5px',
-          }}>
-            Liên hệ với chúng tôi
+          <h1
+            style={{
+              fontSize: '36px',
+              fontWeight: '700',
+              color: '#1a1a1a',
+              margin: '0 0 12px 0',
+              letterSpacing: '-0.5px',
+            }}
+          >
+            {contact.page_title || 'Liên hệ'}
           </h1>
-          <p style={{
-            fontSize: '18px',
-            color: '#666',
-            margin: 0,
-            lineHeight: '1.6',
-          }}>
-            Chúng tôi luôn sẵn sàng hỗ trợ và giải đáp mọi thắc mắc của bạn
+          {contact.page_subtitle ? (
+            <p
+              style={{
+                fontSize: '18px',
+                color: '#666',
+                margin: 0,
+                lineHeight: '1.6',
+              }}
+            >
+              {contact.page_subtitle}
+            </p>
+          ) : null}
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+            gap: '24px',
+            marginBottom: '48px',
+          }}
+        >
+          {showPhone ? (
+            <div
+              style={{
+                backgroundColor: '#fff',
+                padding: '32px',
+                borderRadius: '16px',
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+                textAlign: 'center',
+                transition: 'transform 0.2s, box-shadow 0.2s',
+                cursor: phoneTelHref ? 'pointer' : 'default',
+              }}
+              onMouseEnter={cardHoverEnter}
+              onMouseLeave={cardHoverLeave}
+              onClick={() => {
+                if (phoneTelHref) window.location.href = phoneTelHref;
+              }}
+            >
+              <div
+                style={{
+                  width: '64px',
+                  height: '64px',
+                  backgroundColor: '#007bff',
+                  borderRadius: '50%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  margin: '0 auto 20px',
+                  boxShadow: '0 4px 12px rgba(0, 123, 255, 0.3)',
+                }}
+              >
+                <Phone size={32} color="white" />
+              </div>
+              <h3
+                style={{
+                  fontSize: '20px',
+                  fontWeight: '600',
+                  color: '#1a1a1a',
+                  margin: '0 0 8px 0',
+                }}
+              >
+                {contact.phone?.title || 'Điện thoại'}
+              </h3>
+              {phoneTelHref ? (
+                <a
+                  href={phoneTelHref}
+                  style={{
+                    fontSize: '18px',
+                    color: '#007bff',
+                    textDecoration: 'none',
+                    fontWeight: '500',
+                    display: 'block',
+                  }}
+                  onMouseEnter={linkHoverEnter}
+                  onMouseLeave={linkHoverLeave}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {contact.phone?.label?.trim() || contact.phone?.tel?.trim()}
+                </a>
+              ) : (
+                <span
+                  style={{
+                    fontSize: '18px',
+                    color: '#007bff',
+                    fontWeight: '500',
+                    display: 'block',
+                  }}
+                >
+                  {contact.phone?.label?.trim()}
+                </span>
+              )}
+              {contact.phone?.hint ? (
+                <p
+                  style={{
+                    fontSize: '14px',
+                    color: '#666',
+                    margin: '8px 0 0 0',
+                  }}
+                >
+                  {contact.phone.hint}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {showFacebook ? (
+            <div
+              style={{
+                backgroundColor: '#fff',
+                padding: '32px',
+                borderRadius: '16px',
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+                textAlign: 'center',
+                transition: 'transform 0.2s, box-shadow 0.2s',
+                cursor: 'pointer',
+              }}
+              onMouseEnter={cardHoverEnter}
+              onMouseLeave={cardHoverLeave}
+              onClick={() =>
+                window.open(contact.facebook?.url?.trim() ?? '', '_blank')
+              }
+            >
+              <div
+                style={{
+                  width: '64px',
+                  height: '64px',
+                  backgroundColor: '#1877f2',
+                  borderRadius: '50%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  margin: '0 auto 20px',
+                  boxShadow: '0 4px 12px rgba(24, 119, 242, 0.3)',
+                }}
+              >
+                <Facebook size={32} color="white" />
+              </div>
+              <h3
+                style={{
+                  fontSize: '20px',
+                  fontWeight: '600',
+                  color: '#1a1a1a',
+                  margin: '0 0 8px 0',
+                }}
+              >
+                {contact.facebook?.title || 'Facebook'}
+              </h3>
+              <a
+                href={contact.facebook?.url?.trim()}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  fontSize: '18px',
+                  color: '#1877f2',
+                  textDecoration: 'none',
+                  fontWeight: '500',
+                  display: 'block',
+                  wordBreak: 'break-word',
+                }}
+                onMouseEnter={linkHoverEnter}
+                onMouseLeave={linkHoverLeave}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {contact.facebook?.label?.trim() ||
+                  contact.facebook?.url?.replace(/^https?:\/\//, '')}
+              </a>
+              {contact.facebook?.hint ? (
+                <p
+                  style={{
+                    fontSize: '14px',
+                    color: '#666',
+                    margin: '8px 0 0 0',
+                  }}
+                >
+                  {contact.facebook.hint}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {showZalo ? (
+            <div
+              style={{
+                backgroundColor: '#fff',
+                padding: '32px',
+                borderRadius: '16px',
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+                textAlign: 'center',
+                transition: 'transform 0.2s, box-shadow 0.2s',
+                cursor: 'pointer',
+              }}
+              onMouseEnter={cardHoverEnter}
+              onMouseLeave={cardHoverLeave}
+              onClick={() => window.open(contact.zalo?.url?.trim() ?? '', '_blank')}
+            >
+              <div
+                style={{
+                  width: '64px',
+                  height: '64px',
+                  backgroundColor: '#0068ff',
+                  borderRadius: '50%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  margin: '0 auto 20px',
+                  boxShadow: '0 4px 12px rgba(0, 104, 255, 0.3)',
+                }}
+              >
+                <MessageCircle size={32} color="white" />
+              </div>
+              <h3
+                style={{
+                  fontSize: '20px',
+                  fontWeight: '600',
+                  color: '#1a1a1a',
+                  margin: '0 0 8px 0',
+                }}
+              >
+                {contact.zalo?.title || 'Zalo'}
+              </h3>
+              <a
+                href={contact.zalo?.url?.trim()}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  fontSize: '18px',
+                  color: '#0068ff',
+                  textDecoration: 'none',
+                  fontWeight: '500',
+                  display: 'block',
+                }}
+                onMouseEnter={linkHoverEnter}
+                onMouseLeave={linkHoverLeave}
+                onClick={(e) => e.stopPropagation()}
+              >
+                {contact.zalo?.label?.trim() || contact.zalo?.url?.trim()}
+              </a>
+              {contact.zalo?.hint ? (
+                <p
+                  style={{
+                    fontSize: '14px',
+                    color: '#666',
+                    margin: '8px 0 0 0',
+                  }}
+                >
+                  {contact.zalo.hint}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        {!showPhone && !showFacebook && !showZalo ? (
+          <p
+            style={{
+              textAlign: 'center',
+              color: '#64748b',
+              marginBottom: '32px',
+              fontSize: '15px',
+            }}
+          >
+            Cửa hàng chưa cập nhật kênh liên hệ. Vui lòng quay lại sau hoặc xem danh mục sản phẩm.
           </p>
-        </div>
+        ) : null}
 
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
-          gap: '24px',
-          marginBottom: '48px',
-        }}>
-          {/* Phone */}
-          <div style={{
-            backgroundColor: '#fff',
+        <div
+          style={{
+            backgroundColor: '#f9f9f9',
             padding: '32px',
             borderRadius: '16px',
-            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
             textAlign: 'center',
-            transition: 'transform 0.2s, box-shadow 0.2s',
-            cursor: 'pointer',
           }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-4px)';
-            e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.15)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.1)';
-          }}
-          onClick={() => window.location.href = 'tel:+84856694766'}>
-            <div style={{
-              width: '64px',
-              height: '64px',
-              backgroundColor: '#007bff',
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              margin: '0 auto 20px',
-              boxShadow: '0 4px 12px rgba(0, 123, 255, 0.3)',
-            }}>
-              <Phone size={32} color="white" />
-            </div>
-            <h3 style={{
-              fontSize: '20px',
+        >
+          <h2
+            style={{
+              fontSize: '24px',
               fontWeight: '600',
               color: '#1a1a1a',
-              margin: '0 0 8px 0',
-            }}>
-              Điện thoại
-            </h3>
-            <a
-              href="tel:+84856694766"
-              style={{
-                fontSize: '18px',
-                color: '#007bff',
-                textDecoration: 'none',
-                fontWeight: '500',
-                display: 'block',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.textDecoration = 'underline';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.textDecoration = 'none';
-              }}
-            >
-              0856694766
-            </a>
-            <p style={{
-              fontSize: '14px',
-              color: '#666',
-              margin: '8px 0 0 0',
-            }}>
-              Gọi ngay để được tư vấn
-            </p>
-          </div>
-
-          {/* Facebook */}
-          <div style={{
-            backgroundColor: '#fff',
-            padding: '32px',
-            borderRadius: '16px',
-            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-            textAlign: 'center',
-            transition: 'transform 0.2s, box-shadow 0.2s',
-            cursor: 'pointer',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-4px)';
-            e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.15)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.1)';
-          }}
-          onClick={() => window.open('https://www.facebook.com/tinnh.pyn/', '_blank')}>
-            <div style={{
-              width: '64px',
-              height: '64px',
-              backgroundColor: '#1877f2',
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              margin: '0 auto 20px',
-              boxShadow: '0 4px 12px rgba(24, 119, 242, 0.3)',
-            }}>
-              <Facebook size={32} color="white" />
-            </div>
-            <h3 style={{
-              fontSize: '20px',
-              fontWeight: '600',
-              color: '#1a1a1a',
-              margin: '0 0 8px 0',
-            }}>
-              Facebook
-            </h3>
-            <a
-              href="https://www.facebook.com/tinnh.pyn/"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                fontSize: '18px',
-                color: '#1877f2',
-                textDecoration: 'none',
-                fontWeight: '500',
-                display: 'block',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.textDecoration = 'underline';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.textDecoration = 'none';
-              }}
-            >
-              facebook.com/tinnh.pyn/
-            </a>
-            <p style={{
-              fontSize: '14px',
-              color: '#666',
-              margin: '8px 0 0 0',
-            }}>
-              Theo dõi chúng tôi trên Facebook
-            </p>
-          </div>
-
-          {/* Zalo */}
-          <div style={{
-            backgroundColor: '#fff',
-            padding: '32px',
-            borderRadius: '16px',
-            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-            textAlign: 'center',
-            transition: 'transform 0.2s, box-shadow 0.2s',
-            cursor: 'pointer',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-4px)';
-            e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.15)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.1)';
-          }}
-          onClick={() => window.open('https://zalo.me/0856694766', '_blank')}>
-            <div style={{
-              width: '64px',
-              height: '64px',
-              backgroundColor: '#0068ff',
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              margin: '0 auto 20px',
-              boxShadow: '0 4px 12px rgba(0, 104, 255, 0.3)',
-            }}>
-              <MessageCircle size={32} color="white" />
-            </div>
-            <h3 style={{
-              fontSize: '20px',
-              fontWeight: '600',
-              color: '#1a1a1a',
-              margin: '0 0 8px 0',
-            }}>
-              Zalo
-            </h3>
-            <a
-              href="https://zalo.me/0856694766"
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                fontSize: '18px',
-                color: '#0068ff',
-                textDecoration: 'none',
-                fontWeight: '500',
-                display: 'block',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.textDecoration = 'underline';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.textDecoration = 'none';
-              }}
-            >
-              0856694766
-            </a>
-            <p style={{
-              fontSize: '14px',
-              color: '#666',
-              margin: '8px 0 0 0',
-            }}>
-              Chat với chúng tôi trên Zalo
-            </p>
-          </div>
-        </div>
-
-        {/* Additional Info */}
-        <div style={{
-          backgroundColor: '#f9f9f9',
-          padding: '32px',
-          borderRadius: '16px',
-          textAlign: 'center',
-        }}>
-          <h2 style={{
-            fontSize: '24px',
-            fontWeight: '600',
-            color: '#1a1a1a',
-            margin: '0 0 16px 0',
-          }}>
-            Thời gian làm việc
+              margin: '0 0 16px 0',
+            }}
+          >
+            {contact.hours?.title || 'Thời gian làm việc'}
           </h2>
-          <p style={{
-            fontSize: '16px',
-            color: '#666',
-            margin: '0 0 8px 0',
-            lineHeight: '1.6',
-          }}>
-            <strong>Thứ 2 - Chủ nhật:</strong> 9:00 - 21:00
-          </p>
-          <p style={{
-            fontSize: '14px',
-            color: '#999',
-            margin: '16px 0 0 0',
-          }}>
-            Chúng tôi luôn sẵn sàng phục vụ bạn!
-          </p>
+          {contact.hours?.schedule_line ? (
+            <p
+              style={{
+                fontSize: '16px',
+                color: '#666',
+                margin: '0 0 8px 0',
+                lineHeight: '1.6',
+              }}
+            >
+              {renderInlineBold(contact.hours.schedule_line)}
+            </p>
+          ) : null}
+          {contact.hours?.footer_note ? (
+            <p
+              style={{
+                fontSize: '14px',
+                color: '#999',
+                margin: '16px 0 0 0',
+              }}
+            >
+              {contact.hours.footer_note}
+            </p>
+          ) : null}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -269,6 +269,7 @@ export const ItemDetailPage = () => {
   );
 
   // Load data into form when data changes
+  /* eslint-disable react-hooks/set-state-in-effect -- server item response hydrates local form state */
   useEffect(() => {
     // data structure: {item: {...}, images: [...], spin_sets: [...]}
     if (data?.item) {
@@ -306,6 +307,7 @@ export const ItemDetailPage = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Cleanup preview URLs on unmount
   useEffect(() => {
@@ -331,6 +333,7 @@ export const ItemDetailPage = () => {
     }
   }, [searchParams, data]);
 
+  /* eslint-disable react-hooks/set-state-in-effect -- URL ?step= syncs wizard step */
   useEffect(() => {
     const stepFromQuery = searchParams.get('step');
     if (!stepFromQuery) return;
@@ -339,6 +342,7 @@ export const ItemDetailPage = () => {
       setCurrentStep(parsed as ProductStep);
     }
   }, [searchParams]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const extractItemIdFromResponse = (response: unknown): string | null => {
     const isApiResponse = (r: unknown): r is ApiResponse<ItemResponse> => {
@@ -350,6 +354,7 @@ export const ItemDetailPage = () => {
     return extractedId || null;
   };
 
+  /* eslint-disable react-hooks/set-state-in-effect -- reset defaults when creating new item */
   useEffect(() => {
     if (id === 'new') {
       setCondition('new');
@@ -357,6 +362,7 @@ export const ItemDetailPage = () => {
       setAttributeRows([{ id: newAttributeRowId(), key: '', value: '' }]);
     }
   }, [id]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const saveMutation = useMutation({
     mutationFn: async ({ itemData }: SavePayload) => {

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -269,7 +269,6 @@ export const ItemDetailPage = () => {
   );
 
   // Load data into form when data changes
-  /* eslint-disable react-hooks/set-state-in-effect -- server item response hydrates local form state */
   useEffect(() => {
     // data structure: {item: {...}, images: [...], spin_sets: [...]}
     if (data?.item) {
@@ -307,7 +306,6 @@ export const ItemDetailPage = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Cleanup preview URLs on unmount
   useEffect(() => {
@@ -333,7 +331,6 @@ export const ItemDetailPage = () => {
     }
   }, [searchParams, data]);
 
-  /* eslint-disable react-hooks/set-state-in-effect -- URL ?step= syncs wizard step */
   useEffect(() => {
     const stepFromQuery = searchParams.get('step');
     if (!stepFromQuery) return;
@@ -342,7 +339,6 @@ export const ItemDetailPage = () => {
       setCurrentStep(parsed as ProductStep);
     }
   }, [searchParams]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const extractItemIdFromResponse = (response: unknown): string | null => {
     const isApiResponse = (r: unknown): r is ApiResponse<ItemResponse> => {
@@ -354,7 +350,6 @@ export const ItemDetailPage = () => {
     return extractedId || null;
   };
 
-  /* eslint-disable react-hooks/set-state-in-effect -- reset defaults when creating new item */
   useEffect(() => {
     if (id === 'new') {
       setCondition('new');
@@ -362,7 +357,6 @@ export const ItemDetailPage = () => {
       setAttributeRows([{ id: newAttributeRowId(), key: '', value: '' }]);
     }
   }, [id]);
-  /* eslint-enable react-hooks/set-state-in-effect */
 
   const saveMutation = useMutation({
     mutationFn: async ({ itemData }: SavePayload) => {

--- a/frontend/src/pages/admin/ShopSettingsPage.tsx
+++ b/frontend/src/pages/admin/ShopSettingsPage.tsx
@@ -4,6 +4,7 @@ import { Palette } from 'lucide-react';
 import { apiClient } from '../../api/client';
 import { useAuth } from '../../hooks/useAuth';
 import { useShop } from '../../hooks/useShop';
+import { jsonStableStringify } from '../../utils/jsonStableStringify';
 import { buildShopContactPatch, parseShopContactFormDefaults } from './shops/shopContactForm';
 import { buildAppearancePatch, parseAppearanceFormDefaults } from './shops/shopSettingsForm';
 import type { ShopContactFormState } from './shops/types/shopContact';
@@ -69,7 +70,7 @@ export const ShopSettingsPage = () => {
       ? user.shop_roles.find((r) => r.shop_id === activeShop.id)?.role ?? null
       : null;
 
-  /** PATCH /shop-settings is shop_admin only (RolesGuard); legacy tenant super_admin counts as admin. */
+  /** PATCH /shop-settings: RolesGuard allows shop_admin; legacy tenant super_admin is treated as admin. */
   const canEditSettings =
     roleForActiveShop === 'shop_admin' || roleForActiveShop === 'super_admin';
 
@@ -99,15 +100,31 @@ export const ShopSettingsPage = () => {
 
   const saveMutation = useMutation({
     mutationFn: async () => {
-      const contactPatch = buildShopContactPatch(contact).contact;
-      const appearancePatch = buildAppearancePatch(appearance);
-      return apiClient.patch('/shop-settings', {
-        contact: contactPatch,
-        appearance: appearancePatch,
-      });
+      if (!settingsQuery.data) {
+        throw new Error('Chưa tải xong cấu hình.');
+      }
+      const serverContact = parseShopContactFormDefaults(settingsQuery.data.contact_json);
+      const serverAppearance = parseAppearanceFormDefaults(settingsQuery.data.appearance_json);
+      const nextContact = buildShopContactPatch(contact).contact;
+      const nextAppearance = buildAppearancePatch(appearance);
+      const patch: { contact?: typeof nextContact; appearance?: typeof nextAppearance } = {};
+      if (jsonStableStringify(nextContact) !== jsonStableStringify(buildShopContactPatch(serverContact).contact)) {
+        patch.contact = nextContact;
+      }
+      if (jsonStableStringify(nextAppearance) !== jsonStableStringify(buildAppearancePatch(serverAppearance))) {
+        patch.appearance = nextAppearance;
+      }
+      if (Object.keys(patch).length === 0) {
+        return { skipped: true as const };
+      }
+      return apiClient.patch('/shop-settings', patch);
     },
-    onSuccess: async () => {
+    onSuccess: async (res) => {
       setSaveError(null);
+      if (res && typeof res === 'object' && 'skipped' in res && (res as { skipped?: boolean }).skipped) {
+        setSaveOk('Không có thay đổi cần lưu.');
+        return;
+      }
       setSaveOk('Đã lưu cấu hình shop.');
       await queryClient.invalidateQueries({ queryKey: shopSettingsQueryKey });
     },
@@ -168,8 +185,8 @@ export const ShopSettingsPage = () => {
             color: '#713f12',
           }}
         >
-          Bạn không có quyền chỉnh sửa cấu hình shop này (chỉ <strong>quản trị shop</strong> được lưu thay đổi tại
-          đây).
+          Bạn không có quyền chỉnh sửa cấu hình shop này (chỉ <strong>quản trị shop</strong> được lưu; tài khoản nhân
+          viên chỉ xem).
         </p>
       ) : null}
 

--- a/frontend/src/pages/admin/ShopSettingsPage.tsx
+++ b/frontend/src/pages/admin/ShopSettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type CSSProperties, type FormEvent } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Palette } from 'lucide-react';
 import { apiClient } from '../../api/client';
+import { useAuth } from '../../hooks/useAuth';
 import { useShop } from '../../hooks/useShop';
 import { buildShopContactPatch, parseShopContactFormDefaults } from './shops/shopContactForm';
 import { buildAppearancePatch, parseAppearanceFormDefaults } from './shops/shopSettingsForm';
@@ -54,14 +55,26 @@ const hint: CSSProperties = { fontSize: '12px', color: '#6b7280', margin: 0, lin
 
 export const ShopSettingsPage = () => {
   const { activeShop } = useShop();
+  const { user } = useAuth();
   const queryClient = useQueryClient();
   const [contact, setContact] = useState<ShopContactFormState>(() => parseShopContactFormDefaults(undefined));
   const [appearance, setAppearance] = useState<ShopAppearanceFormState>(() => parseAppearanceFormDefaults(undefined));
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveOk, setSaveOk] = useState<string | null>(null);
 
+  const shopSettingsQueryKey = ['shop-settings', activeShop?.id ?? null] as const;
+
+  const roleForActiveShop =
+    activeShop?.id && user?.shop_roles?.length
+      ? user.shop_roles.find((r) => r.shop_id === activeShop.id)?.role ?? null
+      : null;
+
+  /** PATCH /shop-settings is shop_admin only (RolesGuard); legacy tenant super_admin counts as admin. */
+  const canEditSettings =
+    roleForActiveShop === 'shop_admin' || roleForActiveShop === 'super_admin';
+
   const settingsQuery = useQuery({
-    queryKey: ['shop-settings'],
+    queryKey: shopSettingsQueryKey,
     queryFn: async () => {
       const res = (await apiClient.get('/shop-settings')) as unknown;
       const wrapped = res as { data?: ShopSettingsApiRow };
@@ -71,6 +84,7 @@ export const ShopSettingsPage = () => {
       }
       throw new Error('Invalid shop settings response');
     },
+    enabled: Boolean(activeShop?.id),
   });
 
   /* Sync form from server when GET /shop-settings resolves (or refetches) */
@@ -95,7 +109,7 @@ export const ShopSettingsPage = () => {
     onSuccess: async () => {
       setSaveError(null);
       setSaveOk('Đã lưu cấu hình shop.');
-      await queryClient.invalidateQueries({ queryKey: ['shop-settings'] });
+      await queryClient.invalidateQueries({ queryKey: shopSettingsQueryKey });
     },
     onError: (err: unknown) => {
       const msg =
@@ -142,6 +156,23 @@ export const ShopSettingsPage = () => {
         <span style={{ color: '#94a3b8' }}> · slug {activeShop?.slug ?? settingsQuery.data?.slug}</span>
       </p>
 
+      {!canEditSettings && activeShop?.id ? (
+        <p
+          style={{
+            ...hint,
+            marginBottom: '16px',
+            padding: '12px 14px',
+            background: '#fef9c3',
+            border: '1px solid #fde047',
+            borderRadius: '8px',
+            color: '#713f12',
+          }}
+        >
+          Bạn không có quyền chỉnh sửa cấu hình shop này (chỉ <strong>quản trị shop</strong> được lưu thay đổi tại
+          đây).
+        </p>
+      ) : null}
+
       {saveOk && <p style={{ color: '#15803d', marginBottom: '12px' }}>{saveOk}</p>}
       {saveError && <p style={{ color: '#b91c1c', marginBottom: '12px' }}>{saveError}</p>}
 
@@ -159,6 +190,7 @@ export const ShopSettingsPage = () => {
             idPrefix="shop-settings"
             value={contact}
             onChange={setContact}
+            disabled={!canEditSettings}
             styles={{
               formRow,
               modalLabel: label,
@@ -188,6 +220,7 @@ export const ShopSettingsPage = () => {
               value={appearance.logo_url}
               onChange={(e) => setAppearance((a) => ({ ...a, logo_url: e.target.value }))}
               placeholder="https://..."
+              disabled={!canEditSettings}
             />
           </div>
           <div style={formRow}>
@@ -200,17 +233,19 @@ export const ShopSettingsPage = () => {
               value={appearance.favicon_url}
               onChange={(e) => setAppearance((a) => ({ ...a, favicon_url: e.target.value }))}
               placeholder="https://..."
+              disabled={!canEditSettings}
             />
           </div>
           <div style={formRow}>
             <label style={label} htmlFor="appearance-primary">
-              Màu chủ (CSS, ví dụ #4f46e5)
+              Màu chủ (hex #RRGGBB hoặc tên màu đơn giản, ví dụ #4f46e5 hoặc indigo)
             </label>
             <input
               id="appearance-primary"
               style={input}
               value={appearance.primary_color}
               onChange={(e) => setAppearance((a) => ({ ...a, primary_color: e.target.value }))}
+              disabled={!canEditSettings}
             />
           </div>
           <div style={formRow}>
@@ -222,6 +257,7 @@ export const ShopSettingsPage = () => {
               style={input}
               value={appearance.accent_color}
               onChange={(e) => setAppearance((a) => ({ ...a, accent_color: e.target.value }))}
+              disabled={!canEditSettings}
             />
           </div>
           <div style={formRow}>
@@ -234,6 +270,7 @@ export const ShopSettingsPage = () => {
               value={appearance.font_family}
               onChange={(e) => setAppearance((a) => ({ ...a, font_family: e.target.value }))}
               placeholder="Inter, system-ui, sans-serif"
+              disabled={!canEditSettings}
             />
           </div>
         </div>
@@ -241,7 +278,7 @@ export const ShopSettingsPage = () => {
         <div style={{ display: 'flex', gap: '12px', justifyContent: 'flex-end' }}>
           <button
             type="submit"
-            disabled={saveMutation.isPending}
+            disabled={saveMutation.isPending || !canEditSettings}
             style={{
               padding: '10px 20px',
               background: '#4f46e5',
@@ -249,8 +286,8 @@ export const ShopSettingsPage = () => {
               border: 'none',
               borderRadius: '8px',
               fontWeight: 600,
-              cursor: saveMutation.isPending ? 'not-allowed' : 'pointer',
-              opacity: saveMutation.isPending ? 0.7 : 1,
+              cursor: saveMutation.isPending || !canEditSettings ? 'not-allowed' : 'pointer',
+              opacity: saveMutation.isPending || !canEditSettings ? 0.55 : 1,
             }}
           >
             {saveMutation.isPending ? 'Đang lưu...' : 'Lưu cấu hình'}

--- a/frontend/src/pages/admin/ShopSettingsPage.tsx
+++ b/frontend/src/pages/admin/ShopSettingsPage.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useState, type CSSProperties, type FormEvent } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Palette } from 'lucide-react';
+import { apiClient } from '../../api/client';
+import { useShop } from '../../hooks/useShop';
+import { buildShopContactPatch, parseShopContactFormDefaults } from './shops/shopContactForm';
+import { buildAppearancePatch, parseAppearanceFormDefaults } from './shops/shopSettingsForm';
+import type { ShopContactFormState } from './shops/types/shopContact';
+import type { ShopAppearanceFormState } from './shops/types/shopSettings';
+import { ShopContactFields } from './shops/ShopContactFields';
+
+type ShopSettingsApiRow = {
+  id: string;
+  name: string;
+  slug: string;
+  contact_json?: unknown;
+  appearance_json?: unknown;
+};
+
+const card: CSSProperties = {
+  background: '#fff',
+  border: '1px solid #e2e8f0',
+  borderRadius: '12px',
+  padding: '24px',
+  marginBottom: '20px',
+  boxShadow: '0 4px 14px rgba(15,23,42,0.06)',
+};
+
+const label: CSSProperties = {
+  fontSize: '13px',
+  fontWeight: 500,
+  color: '#374151',
+};
+
+const input: CSSProperties = {
+  padding: '8px 12px',
+  border: '1px solid #d1d5db',
+  borderRadius: '8px',
+  fontSize: '14px',
+  color: '#111827',
+  width: '100%',
+  boxSizing: 'border-box',
+};
+
+const formRow: CSSProperties = { display: 'flex', flexDirection: 'column', gap: '6px' };
+const sectionTitle: CSSProperties = {
+  fontSize: '14px',
+  fontWeight: 600,
+  color: '#111827',
+  marginTop: '8px',
+  marginBottom: '4px',
+};
+const hint: CSSProperties = { fontSize: '12px', color: '#6b7280', margin: 0, lineHeight: 1.45 };
+
+export const ShopSettingsPage = () => {
+  const { activeShop } = useShop();
+  const queryClient = useQueryClient();
+  const [contact, setContact] = useState<ShopContactFormState>(() => parseShopContactFormDefaults(undefined));
+  const [appearance, setAppearance] = useState<ShopAppearanceFormState>(() => parseAppearanceFormDefaults(undefined));
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveOk, setSaveOk] = useState<string | null>(null);
+
+  const settingsQuery = useQuery({
+    queryKey: ['shop-settings'],
+    queryFn: async () => {
+      const res = await apiClient.get('/shop-settings');
+      const row = (res as { data?: ShopSettingsApiRow })?.data ?? (res as ShopSettingsApiRow);
+      return row;
+    },
+  });
+
+  /* Sync form from server when GET /shop-settings resolves (or refetches) */
+  /* eslint-disable react-hooks/set-state-in-effect -- hydrate local form from query result */
+  useEffect(() => {
+    const row = settingsQuery.data;
+    if (!row) return;
+    setContact(parseShopContactFormDefaults(row.contact_json));
+    setAppearance(parseAppearanceFormDefaults(row.appearance_json));
+  }, [settingsQuery.data]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const contactPatch = buildShopContactPatch(contact).contact;
+      const appearancePatch = buildAppearancePatch(appearance);
+      return apiClient.patch('/shop-settings', {
+        contact: contactPatch,
+        appearance: appearancePatch,
+      });
+    },
+    onSuccess: async () => {
+      setSaveError(null);
+      setSaveOk('Đã lưu cấu hình shop.');
+      await queryClient.invalidateQueries({ queryKey: ['shop-settings'] });
+    },
+    onError: (err: unknown) => {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+        (err as { message?: string })?.message ||
+        'Lưu thất bại.';
+      setSaveError(msg);
+      setSaveOk(null);
+    },
+  });
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    setSaveOk(null);
+    setSaveError(null);
+    saveMutation.mutate();
+  };
+
+  if (settingsQuery.isLoading) {
+    return (
+      <div style={{ padding: '32px', maxWidth: '720px', margin: '0 auto' }}>
+        <p style={{ color: '#64748b' }}>Đang tải cấu hình...</p>
+      </div>
+    );
+  }
+
+  if (settingsQuery.isError) {
+    return (
+      <div style={{ padding: '32px', maxWidth: '720px', margin: '0 auto' }}>
+        <p style={{ color: '#b91c1c' }}>Không tải được cấu hình. Kiểm tra đã chọn shop và đăng nhập.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '24px 16px 48px', maxWidth: '720px', margin: '0 auto' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '8px' }}>
+        <Palette size={28} style={{ color: '#4f46e5' }} />
+        <h1 style={{ fontSize: '24px', fontWeight: 800, margin: 0, color: '#0f172a' }}>Cấu hình shop</h1>
+      </div>
+      <p style={{ fontSize: '14px', color: '#64748b', marginBottom: '24px', lineHeight: 1.5 }}>
+        Chỉnh nội dung trang liên hệ công khai và giao diện (mở rộng) cho shop:{' '}
+        <strong>{activeShop?.name ?? settingsQuery.data?.name}</strong>
+        <span style={{ color: '#94a3b8' }}> · slug {activeShop?.slug ?? settingsQuery.data?.slug}</span>
+      </p>
+
+      {saveOk && <p style={{ color: '#15803d', marginBottom: '12px' }}>{saveOk}</p>}
+      {saveError && <p style={{ color: '#b91c1c', marginBottom: '12px' }}>{saveError}</p>}
+
+      <form onSubmit={onSubmit}>
+        <div style={card}>
+          <h2 style={{ fontSize: '16px', fontWeight: 700, margin: '0 0 12px', color: '#111827' }}>
+            Trang liên hệ (công khai)
+          </h2>
+          <p style={{ ...hint, marginBottom: '16px' }}>
+            Hiển thị tại <code style={{ background: '#f1f5f9', padding: '2px 6px', borderRadius: 4 }}>/contact</code>{' '}
+            với <code style={{ background: '#f1f5f9', padding: '2px 6px', borderRadius: 4 }}>?shop_id=</code> (slug
+            hoặc UUID). Để trống rồi lưu để xóa giá trị.
+          </p>
+          <ShopContactFields
+            idPrefix="shop-settings"
+            value={contact}
+            onChange={setContact}
+            styles={{
+              formRow,
+              modalLabel: label,
+              modalInput: input,
+              modalHint: hint,
+              sectionTitle: { ...sectionTitle, marginTop: '12px' },
+            }}
+          />
+        </div>
+
+        <div style={card}>
+          <h2 style={{ fontSize: '16px', fontWeight: 700, margin: '0 0 8px', color: '#111827' }}>
+            Giao diện (chuẩn bị mở rộng)
+          </h2>
+          <p style={{ ...hint, marginBottom: '16px' }}>
+            Dữ liệu lưu trong <code style={{ background: '#f1f5f9', padding: '2px 6px', borderRadius: 4 }}>appearance_json</code>
+            . Áp dụng lên catalog công khai có thể làm ở bước sau.
+          </p>
+
+          <div style={formRow}>
+            <label style={label} htmlFor="appearance-logo">
+              URL logo (https)
+            </label>
+            <input
+              id="appearance-logo"
+              style={input}
+              value={appearance.logo_url}
+              onChange={(e) => setAppearance((a) => ({ ...a, logo_url: e.target.value }))}
+              placeholder="https://..."
+            />
+          </div>
+          <div style={formRow}>
+            <label style={label} htmlFor="appearance-favicon">
+              URL favicon (https)
+            </label>
+            <input
+              id="appearance-favicon"
+              style={input}
+              value={appearance.favicon_url}
+              onChange={(e) => setAppearance((a) => ({ ...a, favicon_url: e.target.value }))}
+              placeholder="https://..."
+            />
+          </div>
+          <div style={formRow}>
+            <label style={label} htmlFor="appearance-primary">
+              Màu chủ (CSS, ví dụ #4f46e5)
+            </label>
+            <input
+              id="appearance-primary"
+              style={input}
+              value={appearance.primary_color}
+              onChange={(e) => setAppearance((a) => ({ ...a, primary_color: e.target.value }))}
+            />
+          </div>
+          <div style={formRow}>
+            <label style={label} htmlFor="appearance-accent">
+              Màu nhấn
+            </label>
+            <input
+              id="appearance-accent"
+              style={input}
+              value={appearance.accent_color}
+              onChange={(e) => setAppearance((a) => ({ ...a, accent_color: e.target.value }))}
+            />
+          </div>
+          <div style={formRow}>
+            <label style={label} htmlFor="appearance-font">
+              Font (CSS font-family)
+            </label>
+            <input
+              id="appearance-font"
+              style={input}
+              value={appearance.font_family}
+              onChange={(e) => setAppearance((a) => ({ ...a, font_family: e.target.value }))}
+              placeholder="Inter, system-ui, sans-serif"
+            />
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: '12px', justifyContent: 'flex-end' }}>
+          <button
+            type="submit"
+            disabled={saveMutation.isPending}
+            style={{
+              padding: '10px 20px',
+              background: '#4f46e5',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '8px',
+              fontWeight: 600,
+              cursor: saveMutation.isPending ? 'not-allowed' : 'pointer',
+              opacity: saveMutation.isPending ? 0.7 : 1,
+            }}
+          >
+            {saveMutation.isPending ? 'Đang lưu...' : 'Lưu cấu hình'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/pages/admin/ShopSettingsPage.tsx
+++ b/frontend/src/pages/admin/ShopSettingsPage.tsx
@@ -63,9 +63,13 @@ export const ShopSettingsPage = () => {
   const settingsQuery = useQuery({
     queryKey: ['shop-settings'],
     queryFn: async () => {
-      const res = await apiClient.get('/shop-settings');
-      const row = (res as { data?: ShopSettingsApiRow })?.data ?? (res as ShopSettingsApiRow);
-      return row;
+      const res = (await apiClient.get('/shop-settings')) as unknown;
+      const wrapped = res as { data?: ShopSettingsApiRow };
+      const row = wrapped?.data;
+      if (row && typeof row === 'object' && typeof row.id === 'string') {
+        return row;
+      }
+      throw new Error('Invalid shop settings response');
     },
   });
 

--- a/frontend/src/pages/admin/ShopsPage.tsx
+++ b/frontend/src/pages/admin/ShopsPage.tsx
@@ -6,6 +6,7 @@ import { styles } from './ShopsPage.styles';
 import { useShopItems } from './shops/useShopItems';
 import { useAuditLogs } from './shops/useAuditLogs';
 import type { Shop, ShopAuditLogRow, ShopMemberRow } from './shops/types';
+import { buildShopContactPatch, parseShopContactFormDefaults } from './shops/shopContactForm';
 import ShopCard from './shops/ShopCard';
 import ShopItemsModal from './shops/modals/ShopItemsModal';
 import ShopAuditModal from './shops/modals/ShopAuditModal';
@@ -210,6 +211,7 @@ const ShopsPage: React.FC = () => {
 
   const [editShopModalId, setEditShopModalId] = useState<string | null>(null);
   const [editShopName, setEditShopName] = useState('');
+  const [editShopContact, setEditShopContact] = useState(() => parseShopContactFormDefaults(undefined));
   const [editShopSaving, setEditShopSaving] = useState(false);
   const [editShopError, setEditShopError] = useState<string | null>(null);
 
@@ -667,6 +669,7 @@ const ShopsPage: React.FC = () => {
   const openEditShopModal = (shop: Shop) => {
     setEditShopError(null);
     setEditShopName(shop.name);
+    setEditShopContact(parseShopContactFormDefaults(shop.contact_json));
     setEditShopModalId(shop.id);
   };
 
@@ -686,7 +689,10 @@ const ShopsPage: React.FC = () => {
     setEditShopError(null);
     setEditShopSaving(true);
     try {
-      await apiClient.patch(`/admin/shops/${editShopModalId}`, { name });
+      await apiClient.patch(`/admin/shops/${editShopModalId}`, {
+        name,
+        ...buildShopContactPatch(editShopContact),
+      });
       setEditShopModalId(null);
       setShopActionError(null);
       setShopActionSuccess('Đã cập nhật thông tin shop.');
@@ -792,7 +798,15 @@ const ShopsPage: React.FC = () => {
         if (!editTargetShop) return null;
         return (
           <div style={styles.modalOverlay} onClick={closeEditShopModal}>
-            <div style={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div
+              style={{
+                ...styles.modal,
+                maxWidth: '640px',
+                maxHeight: '90vh',
+                overflowY: 'auto',
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
               <div style={styles.modalTitle}>Sửa thông tin shop</div>
               {editShopError && <p style={styles.modalError}>{editShopError}</p>}
               <form onSubmit={handleEditShopSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
@@ -816,6 +830,219 @@ const ShopsPage: React.FC = () => {
                 <p style={styles.modalHint}>
                   Shop URL <code style={styles.modalCode}>{editTargetShop.slug}</code> — slug không sửa trên form này.
                 </p>
+
+                <div
+                  style={{
+                    borderTop: '1px solid #e5e7eb',
+                    marginTop: '4px',
+                    paddingTop: '12px',
+                  }}
+                >
+                  <div style={{ fontSize: '15px', fontWeight: 600, color: '#111827', marginBottom: '8px' }}>
+                    Trang liên hệ (công khai)
+                  </div>
+                  <p style={{ ...styles.modalHint, marginBottom: '10px' }}>
+                    Nội dung hiển thị tại <code style={styles.modalCode}>/contact?shop_id=</code> (UUID hoặc slug). Để
+                    trống một ô rồi lưu sẽ xóa giá trị đó.
+                  </p>
+                </div>
+
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-contact-title-${editTargetShop.id}`}>
+                    Tiêu đề trang
+                  </label>
+                  <input
+                    id={`edit-contact-title-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.page_title}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({ ...c, page_title: e.target.value }))
+                    }
+                    autoComplete="off"
+                    placeholder="Ví dụ: Liên hệ với chúng tôi"
+                  />
+                </div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-contact-sub-${editTargetShop.id}`}>
+                    Mô tả dưới tiêu đề
+                  </label>
+                  <input
+                    id={`edit-contact-sub-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.page_subtitle}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({ ...c, page_subtitle: e.target.value }))
+                    }
+                    autoComplete="off"
+                  />
+                </div>
+
+                <div style={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '4px' }}>Điện thoại</div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-phone-tel-${editTargetShop.id}`}>
+                    Số gọi (tel, có thể gồm +)
+                  </label>
+                  <input
+                    id={`edit-phone-tel-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.phone.tel}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        phone: { ...c.phone, tel: e.target.value },
+                      }))
+                    }
+                    autoComplete="off"
+                    placeholder="+84856694766"
+                  />
+                </div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-phone-label-${editTargetShop.id}`}>
+                    Dòng hiển thị (nếu trống sẽ dùng số gọi)
+                  </label>
+                  <input
+                    id={`edit-phone-label-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.phone.label}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        phone: { ...c.phone, label: e.target.value },
+                      }))
+                    }
+                    autoComplete="off"
+                    placeholder="0856694766"
+                  />
+                </div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-phone-hint-${editTargetShop.id}`}>
+                    Gợi ý phụ
+                  </label>
+                  <input
+                    id={`edit-phone-hint-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.phone.hint}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        phone: { ...c.phone, hint: e.target.value },
+                      }))
+                    }
+                    autoComplete="off"
+                    placeholder="Gọi ngay để được tư vấn"
+                  />
+                </div>
+
+                <div style={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '8px' }}>Facebook</div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-fb-url-${editTargetShop.id}`}>
+                    URL
+                  </label>
+                  <input
+                    id={`edit-fb-url-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.facebook.url}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        facebook: { ...c.facebook, url: e.target.value },
+                      }))
+                    }
+                    autoComplete="off"
+                    placeholder="https://www.facebook.com/..."
+                  />
+                </div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-fb-label-${editTargetShop.id}`}>
+                    Text link (tùy chọn)
+                  </label>
+                  <input
+                    id={`edit-fb-label-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.facebook.label}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        facebook: { ...c.facebook, label: e.target.value },
+                      }))
+                    }
+                    autoComplete="off"
+                  />
+                </div>
+
+                <div style={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '8px' }}>Zalo</div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-zalo-url-${editTargetShop.id}`}>
+                    URL (zalo.me/...)
+                  </label>
+                  <input
+                    id={`edit-zalo-url-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.zalo.url}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        zalo: { ...c.zalo, url: e.target.value },
+                      }))
+                    }
+                    autoComplete="off"
+                    placeholder="https://zalo.me/..."
+                  />
+                </div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-zalo-label-${editTargetShop.id}`}>
+                    Dòng hiển thị
+                  </label>
+                  <input
+                    id={`edit-zalo-label-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.zalo.label}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        zalo: { ...c.zalo, label: e.target.value },
+                      }))
+                    }
+                    autoComplete="off"
+                  />
+                </div>
+
+                <div style={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '8px' }}>Giờ làm việc</div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-hours-line-${editTargetShop.id}`}>
+                    Dòng lịch (có thể dùng **in đậm**)
+                  </label>
+                  <textarea
+                    id={`edit-hours-line-${editTargetShop.id}`}
+                    style={{ ...styles.modalInput, minHeight: '72px', resize: 'vertical' as const }}
+                    value={editShopContact.hours.schedule_line}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        hours: { ...c.hours, schedule_line: e.target.value },
+                      }))
+                    }
+                    placeholder="**Thứ 2 - Chủ nhật:** 9:00 - 21:00"
+                  />
+                </div>
+                <div style={styles.formRow}>
+                  <label style={styles.modalLabel} htmlFor={`edit-hours-foot-${editTargetShop.id}`}>
+                    Dòng chú thích dưới
+                  </label>
+                  <input
+                    id={`edit-hours-foot-${editTargetShop.id}`}
+                    style={styles.modalInput}
+                    value={editShopContact.hours.footer_note}
+                    onChange={(e) =>
+                      setEditShopContact((c) => ({
+                        ...c,
+                        hours: { ...c.hours, footer_note: e.target.value },
+                      }))
+                    }
+                    autoComplete="off"
+                  />
+                </div>
+
                 <div style={styles.modalActions}>
                   <button type="button" style={styles.modalCancelBtn} onClick={closeEditShopModal} disabled={editShopSaving}>
                     Hủy

--- a/frontend/src/pages/admin/ShopsPage.tsx
+++ b/frontend/src/pages/admin/ShopsPage.tsx
@@ -7,6 +7,7 @@ import { useShopItems } from './shops/useShopItems';
 import { useAuditLogs } from './shops/useAuditLogs';
 import type { Shop, ShopAuditLogRow, ShopMemberRow } from './shops/types';
 import { buildShopContactPatch, parseShopContactFormDefaults } from './shops/shopContactForm';
+import { ShopContactFields } from './shops/ShopContactFields';
 import ShopCard from './shops/ShopCard';
 import ShopItemsModal from './shops/modals/ShopItemsModal';
 import ShopAuditModal from './shops/modals/ShopAuditModal';
@@ -847,201 +848,18 @@ const ShopsPage: React.FC = () => {
                   </p>
                 </div>
 
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-contact-title-${editTargetShop.id}`}>
-                    Tiêu đề trang
-                  </label>
-                  <input
-                    id={`edit-contact-title-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.page_title}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({ ...c, page_title: e.target.value }))
-                    }
-                    autoComplete="off"
-                    placeholder="Ví dụ: Liên hệ với chúng tôi"
-                  />
-                </div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-contact-sub-${editTargetShop.id}`}>
-                    Mô tả dưới tiêu đề
-                  </label>
-                  <input
-                    id={`edit-contact-sub-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.page_subtitle}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({ ...c, page_subtitle: e.target.value }))
-                    }
-                    autoComplete="off"
-                  />
-                </div>
-
-                <div style={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '4px' }}>Điện thoại</div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-phone-tel-${editTargetShop.id}`}>
-                    Số gọi (tel, có thể gồm +)
-                  </label>
-                  <input
-                    id={`edit-phone-tel-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.phone.tel}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        phone: { ...c.phone, tel: e.target.value },
-                      }))
-                    }
-                    autoComplete="off"
-                    placeholder="+84856694766"
-                  />
-                </div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-phone-label-${editTargetShop.id}`}>
-                    Dòng hiển thị (nếu trống sẽ dùng số gọi)
-                  </label>
-                  <input
-                    id={`edit-phone-label-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.phone.label}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        phone: { ...c.phone, label: e.target.value },
-                      }))
-                    }
-                    autoComplete="off"
-                    placeholder="0856694766"
-                  />
-                </div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-phone-hint-${editTargetShop.id}`}>
-                    Gợi ý phụ
-                  </label>
-                  <input
-                    id={`edit-phone-hint-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.phone.hint}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        phone: { ...c.phone, hint: e.target.value },
-                      }))
-                    }
-                    autoComplete="off"
-                    placeholder="Gọi ngay để được tư vấn"
-                  />
-                </div>
-
-                <div style={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '8px' }}>Facebook</div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-fb-url-${editTargetShop.id}`}>
-                    URL
-                  </label>
-                  <input
-                    id={`edit-fb-url-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.facebook.url}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        facebook: { ...c.facebook, url: e.target.value },
-                      }))
-                    }
-                    autoComplete="off"
-                    placeholder="https://www.facebook.com/..."
-                  />
-                </div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-fb-label-${editTargetShop.id}`}>
-                    Text link (tùy chọn)
-                  </label>
-                  <input
-                    id={`edit-fb-label-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.facebook.label}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        facebook: { ...c.facebook, label: e.target.value },
-                      }))
-                    }
-                    autoComplete="off"
-                  />
-                </div>
-
-                <div style={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '8px' }}>Zalo</div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-zalo-url-${editTargetShop.id}`}>
-                    URL (zalo.me/...)
-                  </label>
-                  <input
-                    id={`edit-zalo-url-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.zalo.url}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        zalo: { ...c.zalo, url: e.target.value },
-                      }))
-                    }
-                    autoComplete="off"
-                    placeholder="https://zalo.me/..."
-                  />
-                </div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-zalo-label-${editTargetShop.id}`}>
-                    Dòng hiển thị
-                  </label>
-                  <input
-                    id={`edit-zalo-label-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.zalo.label}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        zalo: { ...c.zalo, label: e.target.value },
-                      }))
-                    }
-                    autoComplete="off"
-                  />
-                </div>
-
-                <div style={{ fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '8px' }}>Giờ làm việc</div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-hours-line-${editTargetShop.id}`}>
-                    Dòng lịch (có thể dùng **in đậm**)
-                  </label>
-                  <textarea
-                    id={`edit-hours-line-${editTargetShop.id}`}
-                    style={{ ...styles.modalInput, minHeight: '72px', resize: 'vertical' as const }}
-                    value={editShopContact.hours.schedule_line}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        hours: { ...c.hours, schedule_line: e.target.value },
-                      }))
-                    }
-                    placeholder="**Thứ 2 - Chủ nhật:** 9:00 - 21:00"
-                  />
-                </div>
-                <div style={styles.formRow}>
-                  <label style={styles.modalLabel} htmlFor={`edit-hours-foot-${editTargetShop.id}`}>
-                    Dòng chú thích dưới
-                  </label>
-                  <input
-                    id={`edit-hours-foot-${editTargetShop.id}`}
-                    style={styles.modalInput}
-                    value={editShopContact.hours.footer_note}
-                    onChange={(e) =>
-                      setEditShopContact((c) => ({
-                        ...c,
-                        hours: { ...c.hours, footer_note: e.target.value },
-                      }))
-                    }
-                    autoComplete="off"
-                  />
-                </div>
+                <ShopContactFields
+                  idPrefix={`edit-shop-${editTargetShop.id}`}
+                  value={editShopContact}
+                  onChange={setEditShopContact}
+                  styles={{
+                    formRow: styles.formRow,
+                    modalLabel: styles.modalLabel,
+                    modalInput: styles.modalInput,
+                    modalHint: styles.modalHint,
+                    sectionTitle: { fontSize: '13px', fontWeight: 600, color: '#374151', marginTop: '8px' },
+                  }}
+                />
 
                 <div style={styles.modalActions}>
                   <button type="button" style={styles.modalCancelBtn} onClick={closeEditShopModal} disabled={editShopSaving}>

--- a/frontend/src/pages/admin/shops/ShopContactFields.tsx
+++ b/frontend/src/pages/admin/shops/ShopContactFields.tsx
@@ -15,9 +15,10 @@ type Props = {
   onChange: (next: ShopContactFormState) => void;
   styles: FieldStyles;
   intro?: ReactNode;
+  disabled?: boolean;
 };
 
-export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: Props) {
+export function ShopContactFields({ idPrefix, value, onChange, styles, intro, disabled }: Props) {
   const set = (patch: Partial<ShopContactFormState>) => onChange({ ...value, ...patch });
   const setPhone = (patch: Partial<ShopContactFormState['phone']>) =>
     onChange({ ...value, phone: { ...value.phone, ...patch } });
@@ -42,6 +43,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           onChange={(e) => set({ page_title: e.target.value })}
           autoComplete="off"
           placeholder="Ví dụ: Liên hệ với chúng tôi"
+          disabled={disabled}
         />
       </div>
       <div style={styles.formRow}>
@@ -54,6 +56,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           value={value.page_subtitle}
           onChange={(e) => set({ page_subtitle: e.target.value })}
           autoComplete="off"
+          disabled={disabled}
         />
       </div>
 
@@ -69,6 +72,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           onChange={(e) => setPhone({ tel: e.target.value })}
           autoComplete="off"
           placeholder="+84856694766"
+          disabled={disabled}
         />
       </div>
       <div style={styles.formRow}>
@@ -82,6 +86,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           onChange={(e) => setPhone({ label: e.target.value })}
           autoComplete="off"
           placeholder="0856694766"
+          disabled={disabled}
         />
       </div>
       <div style={styles.formRow}>
@@ -95,6 +100,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           onChange={(e) => setPhone({ hint: e.target.value })}
           autoComplete="off"
           placeholder="Gọi ngay để được tư vấn"
+          disabled={disabled}
         />
       </div>
 
@@ -110,6 +116,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           onChange={(e) => setFacebook({ url: e.target.value })}
           autoComplete="off"
           placeholder="https://www.facebook.com/..."
+          disabled={disabled}
         />
       </div>
       <div style={styles.formRow}>
@@ -122,6 +129,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           value={value.facebook.label}
           onChange={(e) => setFacebook({ label: e.target.value })}
           autoComplete="off"
+          disabled={disabled}
         />
       </div>
 
@@ -137,6 +145,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           onChange={(e) => setZalo({ url: e.target.value })}
           autoComplete="off"
           placeholder="https://zalo.me/..."
+          disabled={disabled}
         />
       </div>
       <div style={styles.formRow}>
@@ -149,6 +158,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           value={value.zalo.label}
           onChange={(e) => setZalo({ label: e.target.value })}
           autoComplete="off"
+          disabled={disabled}
         />
       </div>
 
@@ -163,6 +173,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           value={value.hours.schedule_line}
           onChange={(e) => setHours({ schedule_line: e.target.value })}
           placeholder="**Thứ 2 - Chủ nhật:** 9:00 - 21:00"
+          disabled={disabled}
         />
       </div>
       <div style={styles.formRow}>
@@ -175,6 +186,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: 
           value={value.hours.footer_note}
           onChange={(e) => setHours({ footer_note: e.target.value })}
           autoComplete="off"
+          disabled={disabled}
         />
       </div>
     </>

--- a/frontend/src/pages/admin/shops/ShopContactFields.tsx
+++ b/frontend/src/pages/admin/shops/ShopContactFields.tsx
@@ -1,0 +1,182 @@
+import type { CSSProperties, ReactNode } from 'react';
+import type { ShopContactFormState } from './types/shopContact';
+
+type FieldStyles = {
+  formRow: CSSProperties;
+  modalLabel: CSSProperties;
+  modalInput: CSSProperties;
+  modalHint: CSSProperties;
+  sectionTitle: CSSProperties;
+};
+
+type Props = {
+  idPrefix: string;
+  value: ShopContactFormState;
+  onChange: (next: ShopContactFormState) => void;
+  styles: FieldStyles;
+  intro?: ReactNode;
+};
+
+export function ShopContactFields({ idPrefix, value, onChange, styles, intro }: Props) {
+  const set = (patch: Partial<ShopContactFormState>) => onChange({ ...value, ...patch });
+  const setPhone = (patch: Partial<ShopContactFormState['phone']>) =>
+    onChange({ ...value, phone: { ...value.phone, ...patch } });
+  const setFacebook = (patch: Partial<ShopContactFormState['facebook']>) =>
+    onChange({ ...value, facebook: { ...value.facebook, ...patch } });
+  const setZalo = (patch: Partial<ShopContactFormState['zalo']>) =>
+    onChange({ ...value, zalo: { ...value.zalo, ...patch } });
+  const setHours = (patch: Partial<ShopContactFormState['hours']>) =>
+    onChange({ ...value, hours: { ...value.hours, ...patch } });
+
+  return (
+    <>
+      {intro}
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-contact-title`}>
+          Tiêu đề trang
+        </label>
+        <input
+          id={`${idPrefix}-contact-title`}
+          style={styles.modalInput}
+          value={value.page_title}
+          onChange={(e) => set({ page_title: e.target.value })}
+          autoComplete="off"
+          placeholder="Ví dụ: Liên hệ với chúng tôi"
+        />
+      </div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-contact-sub`}>
+          Mô tả dưới tiêu đề
+        </label>
+        <input
+          id={`${idPrefix}-contact-sub`}
+          style={styles.modalInput}
+          value={value.page_subtitle}
+          onChange={(e) => set({ page_subtitle: e.target.value })}
+          autoComplete="off"
+        />
+      </div>
+
+      <div style={styles.sectionTitle}>Điện thoại</div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-phone-tel`}>
+          Số gọi (tel, có thể gồm +)
+        </label>
+        <input
+          id={`${idPrefix}-phone-tel`}
+          style={styles.modalInput}
+          value={value.phone.tel}
+          onChange={(e) => setPhone({ tel: e.target.value })}
+          autoComplete="off"
+          placeholder="+84856694766"
+        />
+      </div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-phone-label`}>
+          Dòng hiển thị (nếu trống sẽ dùng số gọi)
+        </label>
+        <input
+          id={`${idPrefix}-phone-label`}
+          style={styles.modalInput}
+          value={value.phone.label}
+          onChange={(e) => setPhone({ label: e.target.value })}
+          autoComplete="off"
+          placeholder="0856694766"
+        />
+      </div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-phone-hint`}>
+          Gợi ý phụ
+        </label>
+        <input
+          id={`${idPrefix}-phone-hint`}
+          style={styles.modalInput}
+          value={value.phone.hint}
+          onChange={(e) => setPhone({ hint: e.target.value })}
+          autoComplete="off"
+          placeholder="Gọi ngay để được tư vấn"
+        />
+      </div>
+
+      <div style={styles.sectionTitle}>Facebook</div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-fb-url`}>
+          URL (https)
+        </label>
+        <input
+          id={`${idPrefix}-fb-url`}
+          style={styles.modalInput}
+          value={value.facebook.url}
+          onChange={(e) => setFacebook({ url: e.target.value })}
+          autoComplete="off"
+          placeholder="https://www.facebook.com/..."
+        />
+      </div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-fb-label`}>
+          Text link (tùy chọn)
+        </label>
+        <input
+          id={`${idPrefix}-fb-label`}
+          style={styles.modalInput}
+          value={value.facebook.label}
+          onChange={(e) => setFacebook({ label: e.target.value })}
+          autoComplete="off"
+        />
+      </div>
+
+      <div style={styles.sectionTitle}>Zalo</div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-zalo-url`}>
+          URL (https)
+        </label>
+        <input
+          id={`${idPrefix}-zalo-url`}
+          style={styles.modalInput}
+          value={value.zalo.url}
+          onChange={(e) => setZalo({ url: e.target.value })}
+          autoComplete="off"
+          placeholder="https://zalo.me/..."
+        />
+      </div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-zalo-label`}>
+          Dòng hiển thị
+        </label>
+        <input
+          id={`${idPrefix}-zalo-label`}
+          style={styles.modalInput}
+          value={value.zalo.label}
+          onChange={(e) => setZalo({ label: e.target.value })}
+          autoComplete="off"
+        />
+      </div>
+
+      <div style={styles.sectionTitle}>Giờ làm việc</div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-hours-line`}>
+          Dòng lịch (có thể dùng **in đậm**)
+        </label>
+        <textarea
+          id={`${idPrefix}-hours-line`}
+          style={{ ...styles.modalInput, minHeight: '72px', resize: 'vertical' as const }}
+          value={value.hours.schedule_line}
+          onChange={(e) => setHours({ schedule_line: e.target.value })}
+          placeholder="**Thứ 2 - Chủ nhật:** 9:00 - 21:00"
+        />
+      </div>
+      <div style={styles.formRow}>
+        <label style={styles.modalLabel} htmlFor={`${idPrefix}-hours-foot`}>
+          Dòng chú thích dưới
+        </label>
+        <input
+          id={`${idPrefix}-hours-foot`}
+          style={styles.modalInput}
+          value={value.hours.footer_note}
+          onChange={(e) => setHours({ footer_note: e.target.value })}
+          autoComplete="off"
+        />
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/admin/shops/shopContactForm.ts
+++ b/frontend/src/pages/admin/shops/shopContactForm.ts
@@ -1,5 +1,5 @@
 import type { Shop } from './types';
-import type { ShopContactPayload } from './types/shopContact';
+import type { ShopContactFormState, ShopContactPayload } from './types/shopContact';
 
 function readNested(obj: Record<string, unknown>, key: string): Record<string, unknown> {
   const v = obj[key];
@@ -14,10 +14,7 @@ function str(v: unknown): string {
 }
 
 /** Hydrate edit-modal state from GET /admin/shops list row (`contact_json`). */
-export function parseShopContactFormDefaults(contactJson: Shop['contact_json']): ShopContactPayload & {
-  page_title: string;
-  page_subtitle: string;
-} {
+export function parseShopContactFormDefaults(contactJson: Shop['contact_json']): ShopContactFormState {
   const root =
     contactJson && typeof contactJson === 'object' && !Array.isArray(contactJson)
       ? (contactJson as Record<string, unknown>)
@@ -56,7 +53,7 @@ export function parseShopContactFormDefaults(contactJson: Shop['contact_json']):
   };
 }
 
-export function buildShopContactPatch(form: ReturnType<typeof parseShopContactFormDefaults>): {
+export function buildShopContactPatch(form: ShopContactFormState): {
   contact: ShopContactPayload;
 } {
   return {

--- a/frontend/src/pages/admin/shops/shopContactForm.ts
+++ b/frontend/src/pages/admin/shops/shopContactForm.ts
@@ -13,8 +13,8 @@ function str(v: unknown): string {
   return typeof v === 'string' ? v : '';
 }
 
-/** Hydrate edit-modal state from GET /admin/shops list row (`contact_json`). */
-export function parseShopContactFormDefaults(contactJson: Shop['contact_json']): ShopContactFormState {
+/** Hydrate form state from `contact_json` (API / admin list). */
+export function parseShopContactFormDefaults(contactJson: Shop['contact_json'] | unknown): ShopContactFormState {
   const root =
     contactJson && typeof contactJson === 'object' && !Array.isArray(contactJson)
       ? (contactJson as Record<string, unknown>)

--- a/frontend/src/pages/admin/shops/shopContactForm.ts
+++ b/frontend/src/pages/admin/shops/shopContactForm.ts
@@ -1,0 +1,91 @@
+import type { Shop } from './types';
+import type { ShopContactPayload } from './types/shopContact';
+
+function readNested(obj: Record<string, unknown>, key: string): Record<string, unknown> {
+  const v = obj[key];
+  if (v && typeof v === 'object' && !Array.isArray(v)) {
+    return v as Record<string, unknown>;
+  }
+  return {};
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/** Hydrate edit-modal state from GET /admin/shops list row (`contact_json`). */
+export function parseShopContactFormDefaults(contactJson: Shop['contact_json']): ShopContactPayload & {
+  page_title: string;
+  page_subtitle: string;
+} {
+  const root =
+    contactJson && typeof contactJson === 'object' && !Array.isArray(contactJson)
+      ? (contactJson as Record<string, unknown>)
+      : {};
+  const phone = readNested(root, 'phone');
+  const facebook = readNested(root, 'facebook');
+  const zalo = readNested(root, 'zalo');
+  const hours = readNested(root, 'hours');
+
+  return {
+    page_title: str(root.page_title),
+    page_subtitle: str(root.page_subtitle),
+    phone: {
+      title: str(phone.title),
+      label: str(phone.label),
+      tel: str(phone.tel),
+      hint: str(phone.hint),
+    },
+    facebook: {
+      title: str(facebook.title),
+      url: str(facebook.url),
+      label: str(facebook.label),
+      hint: str(facebook.hint),
+    },
+    zalo: {
+      title: str(zalo.title),
+      url: str(zalo.url),
+      label: str(zalo.label),
+      hint: str(zalo.hint),
+    },
+    hours: {
+      title: str(hours.title),
+      schedule_line: str(hours.schedule_line),
+      footer_note: str(hours.footer_note),
+    },
+  };
+}
+
+export function buildShopContactPatch(form: ReturnType<typeof parseShopContactFormDefaults>): {
+  contact: ShopContactPayload;
+} {
+  return {
+    contact: {
+      page_title: form.page_title.trim(),
+      page_subtitle: form.page_subtitle.trim(),
+      phone: {
+        title: form.phone.title.trim(),
+        label: form.phone.label.trim(),
+        tel: form.phone.tel.trim(),
+        hint: form.phone.hint.trim(),
+      },
+      facebook: {
+        title: form.facebook.title.trim(),
+        url: form.facebook.url.trim(),
+        label: form.facebook.label.trim(),
+        hint: form.facebook.hint.trim(),
+      },
+      zalo: {
+        title: form.zalo.title.trim(),
+        url: form.zalo.url.trim(),
+        label: form.zalo.label.trim(),
+        hint: form.zalo.hint.trim(),
+      },
+      hours: {
+        title: form.hours.title.trim(),
+        schedule_line: form.hours.schedule_line.trim(),
+        footer_note: form.hours.footer_note.trim(),
+      },
+    },
+  };
+}

--- a/frontend/src/pages/admin/shops/shopSettingsForm.ts
+++ b/frontend/src/pages/admin/shops/shopSettingsForm.ts
@@ -1,0 +1,29 @@
+import type { ShopAppearanceFormState } from './types/shopSettings';
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+export function parseAppearanceFormDefaults(appearanceJson: unknown): ShopAppearanceFormState {
+  const root =
+    appearanceJson && typeof appearanceJson === 'object' && !Array.isArray(appearanceJson)
+      ? (appearanceJson as Record<string, unknown>)
+      : {};
+  return {
+    logo_url: str(root.logo_url),
+    favicon_url: str(root.favicon_url),
+    primary_color: str(root.primary_color),
+    accent_color: str(root.accent_color),
+    font_family: str(root.font_family),
+  };
+}
+
+export function buildAppearancePatch(form: ShopAppearanceFormState): Record<string, string> {
+  return {
+    logo_url: form.logo_url.trim(),
+    favicon_url: form.favicon_url.trim(),
+    primary_color: form.primary_color.trim(),
+    accent_color: form.accent_color.trim(),
+    font_family: form.font_family.trim(),
+  };
+}

--- a/frontend/src/pages/admin/shops/types.ts
+++ b/frontend/src/pages/admin/shops/types.ts
@@ -3,6 +3,7 @@ export interface Shop {
   name: string;
   slug: string;
   is_active: boolean;
+  contact_json?: Record<string, unknown> | null;
   _count?: { items: number; user_roles: number };
 }
 

--- a/frontend/src/pages/admin/shops/types/shopContact.ts
+++ b/frontend/src/pages/admin/shops/types/shopContact.ts
@@ -26,3 +26,32 @@ export type ShopContactPayload = {
     footer_note?: string;
   };
 };
+
+/** Full form state in admin modal — nested sections always present */
+export type ShopContactFormState = {
+  page_title: string;
+  page_subtitle: string;
+  phone: {
+    title: string;
+    label: string;
+    tel: string;
+    hint: string;
+  };
+  facebook: {
+    title: string;
+    url: string;
+    label: string;
+    hint: string;
+  };
+  zalo: {
+    title: string;
+    url: string;
+    label: string;
+    hint: string;
+  };
+  hours: {
+    title: string;
+    schedule_line: string;
+    footer_note: string;
+  };
+};

--- a/frontend/src/pages/admin/shops/types/shopContact.ts
+++ b/frontend/src/pages/admin/shops/types/shopContact.ts
@@ -1,0 +1,28 @@
+/** Payload for PATCH /admin/shops/:id { contact: ... } */
+export type ShopContactPayload = {
+  page_title?: string;
+  page_subtitle?: string;
+  phone?: {
+    title?: string;
+    label?: string;
+    tel?: string;
+    hint?: string;
+  };
+  facebook?: {
+    title?: string;
+    url?: string;
+    label?: string;
+    hint?: string;
+  };
+  zalo?: {
+    title?: string;
+    url?: string;
+    label?: string;
+    hint?: string;
+  };
+  hours?: {
+    title?: string;
+    schedule_line?: string;
+    footer_note?: string;
+  };
+};

--- a/frontend/src/pages/admin/shops/types/shopSettings.ts
+++ b/frontend/src/pages/admin/shops/types/shopSettings.ts
@@ -1,0 +1,7 @@
+export type ShopAppearanceFormState = {
+  logo_url: string;
+  favicon_url: string;
+  primary_color: string;
+  accent_color: string;
+  font_family: string;
+};

--- a/frontend/src/types/shopContactPublic.ts
+++ b/frontend/src/types/shopContactPublic.ts
@@ -1,0 +1,31 @@
+/** GET /api/v1/public/shops/:shopId/contact → data */
+export type PublicShopContactResponse = {
+  shop: { id: string; name: string; slug: string };
+  contact: {
+    page_title?: string;
+    page_subtitle?: string;
+    phone?: {
+      title?: string;
+      label?: string;
+      tel?: string;
+      hint?: string;
+    };
+    facebook?: {
+      title?: string;
+      url?: string;
+      label?: string;
+      hint?: string;
+    };
+    zalo?: {
+      title?: string;
+      url?: string;
+      label?: string;
+      hint?: string;
+    };
+    hours?: {
+      title?: string;
+      schedule_line?: string;
+      footer_note?: string;
+    };
+  };
+};

--- a/frontend/src/types/shopContactPublic.ts
+++ b/frontend/src/types/shopContactPublic.ts
@@ -28,4 +28,12 @@ export type PublicShopContactResponse = {
       footer_note?: string;
     };
   };
+  /** Branding keys for future public UI; optional until storefront consumes them */
+  appearance?: {
+    logo_url?: string;
+    favicon_url?: string;
+    primary_color?: string;
+    accent_color?: string;
+    font_family?: string;
+  };
 };

--- a/frontend/src/utils/jsonStableStringify.ts
+++ b/frontend/src/utils/jsonStableStringify.ts
@@ -1,0 +1,19 @@
+/** Same semantics as backend `jsonStableStringify` — for comparing settings payloads. */
+export function jsonStableStringify(value: unknown): string {
+  const normalize = (v: unknown): unknown => {
+    if (v === null || typeof v !== 'object') {
+      return v;
+    }
+    if (Array.isArray(v)) {
+      return v.map((item) => normalize(item));
+    }
+    const obj = v as Record<string, unknown>;
+    return Object.keys(obj)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = normalize(obj[key]);
+        return acc;
+      }, {});
+  };
+  return JSON.stringify(normalize(value));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Per-shop public contact + optional storefront branding, editable by **shop admin/staff** on a dedicated admin page; super admin retains platform shop list + modal.

## Backend
- `shops.contact_json` — public `/contact` copy (existing).
- `shops.appearance_json` (new migration) — logo URL, favicon URL, colors, font family (validated URLs where applicable); ready for future public UI.
- **`GET/PATCH /api/v1/shop-settings`** — `JwtAuthGuard` + `TenantGuard` + `Roles(shop_admin, shop_staff)`; scopes to JWT `active_shop_id`.
- `GET /api/v1/public/shops/:id/contact` response now includes optional **`appearance`** for storefront consumption later.
- Super admin `PATCH /admin/shops/:id` unchanged for name/active/contact.

## Frontend
- **`/admin/shop-settings`** — “Cấu hình shop”: contact fields + appearance placeholders; saves via `PATCH /shop-settings`.
- Sidebar link **“Cấu hình shop”** (Palette icon) for all logged-in admin users with tenant context.
- Shared **`ShopContactFields`** used by super admin shop modal and shop settings page.

## Deploy
Run Prisma migrations (includes `appearance_json`).

Closes #134
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49abdfda-2f29-4b03-a8f0-ffbfb6365e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49abdfda-2f29-4b03-a8f0-ffbfb6365e69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

