### PR TITLE
Shop branding: upload logo & favicon (issue #135)

### DIFF
--- a/backend/src/shops/dto/shop-branding-upload.dto.ts
+++ b/backend/src/shops/dto/shop-branding-upload.dto.ts
@@ -1,0 +1,6 @@
+import { IsIn } from 'class-validator';
+
+export class ShopBrandingUploadDto {
+  @IsIn(['logo', 'favicon'])
+  kind!: 'logo' | 'favicon';
+}

--- a/backend/src/shops/shop-settings.controller.ts
+++ b/backend/src/shops/shop-settings.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Post,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { TenantGuard } from '../common/guards/tenant.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
@@ -8,6 +19,8 @@ import { CurrentUserId } from '../common/decorators/current-user-id.decorator';
 import { ShopRole } from '../generated/prisma/client';
 import { ShopsService } from './shops.service';
 import { UpdateShopSettingsDto } from './dto/update-shop-appearance.dto';
+import { ShopBrandingUploadDto } from './dto/shop-branding-upload.dto';
+import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
 
 /**
  * Tenant-scoped shop branding + public contact copy.
@@ -40,5 +53,22 @@ export class ShopSettingsController {
       dto.appearance,
       actorUserId,
     );
+  }
+
+  /** Multipart: field `file` + body `kind` = logo | favicon */
+  @Post('branding-upload')
+  @Throttle({ default: { ttl: 60000, limit: 20 } })
+  @Roles(ShopRole.shop_admin)
+  @UseInterceptors(FileInterceptor('file'))
+  uploadBranding(
+    @CurrentTenantId() tenantId: string,
+    @Body() body: ShopBrandingUploadDto,
+    @UploadedFile() file: Express.Multer.File,
+    @CurrentUserId() actorUserId: string | null,
+  ) {
+    if (!file) {
+      throw new AppException(ErrorCode.VALIDATION_ERROR, 'File is required');
+    }
+    return this.shopsService.uploadAppearanceAsset(tenantId, body.kind, file, actorUserId);
   }
 }

--- a/backend/src/shops/shops.module.ts
+++ b/backend/src/shops/shops.module.ts
@@ -3,9 +3,10 @@ import { ShopsService } from './shops.service';
 import { ShopsController } from './shops.controller';
 import { ShopSettingsController } from './shop-settings.controller';
 import { StorageModule } from '../storage/storage.module';
+import { UploadSupportModule } from '../common/upload/upload-support.module';
 
 @Module({
-  imports: [StorageModule],
+  imports: [StorageModule, UploadSupportModule],
   controllers: [ShopsController, ShopSettingsController],
   providers: [ShopsService],
   exports: [ShopsService],

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ShopsService } from './shops.service';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { AppException } from '../common/exceptions/http-exception.filter';
+import { UploadSupportService } from '../common/upload/upload-support.service';
 import { ShopRole } from '../generated/prisma/client';
 import { AddShopAdminDto } from './dto/add-shop-admin.dto';
 import { RolesGuard } from '../common/guards/roles.guard';
@@ -13,6 +14,8 @@ jest.mock('bcrypt', () => ({
 
 describe('ShopsService', () => {
   let service: ShopsService;
+  let storage: { saveFile: jest.Mock; getFileUrl: jest.Mock };
+  let uploadSupport: { resolveAllowedMimeTypes: jest.Mock; resolveMaxUploadBytes: jest.Mock; validateFile: jest.Mock };
   let prisma: {
     shop: Record<string, jest.Mock>;
     item: Record<string, jest.Mock>;
@@ -58,11 +61,22 @@ describe('ShopsService', () => {
 
     (bcrypt.hash as unknown as jest.Mock).mockResolvedValue('hashed-password');
 
+    storage = {
+      saveFile: jest.fn().mockResolvedValue('shop-branding/x.png'),
+      getFileUrl: jest.fn((p: string) => `https://signed.example/${p}`),
+    };
+    uploadSupport = {
+      resolveAllowedMimeTypes: jest.fn().mockReturnValue(['image/jpeg', 'image/png', 'image/webp']),
+      resolveMaxUploadBytes: jest.fn().mockReturnValue(2 * 1024 * 1024),
+      validateFile: jest.fn().mockResolvedValue(undefined),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ShopsService,
         { provide: PrismaService, useValue: prisma },
-        { provide: 'IStorageService', useValue: { getFileUrl: (p: string) => p } },
+        { provide: 'IStorageService', useValue: storage },
+        { provide: UploadSupportService, useValue: uploadSupport },
       ],
     }).compile();
 
@@ -652,6 +666,37 @@ describe('ShopsService', () => {
           }),
         }),
       );
+    });
+
+    it('uploadAppearanceAsset saves file and updates logo_url', async () => {
+      prisma.shop.findFirst.mockResolvedValue({
+        id: tenantId,
+        appearance_json: {},
+      });
+      prisma.shop.update.mockResolvedValue({
+        id: tenantId,
+        name: 'T',
+        slug: 't',
+        contact_json: {},
+        appearance_json: { logo_url: 'https://signed.example/shop-branding/x.png' },
+      });
+      prisma.shopAuditLog.create.mockResolvedValue({});
+
+      const file = {
+        buffer: Buffer.from([1, 2, 3]),
+        mimetype: 'image/png',
+        size: 100,
+      } as Express.Multer.File;
+
+      const out = await service.uploadAppearanceAsset(tenantId, 'logo', file, 'u1');
+
+      expect(uploadSupport.validateFile).toHaveBeenCalled();
+      expect(storage.saveFile).toHaveBeenCalled();
+      expect(out.url).toContain('shop-branding');
+      expect(out.shop.appearance_json).toEqual({
+        logo_url: 'https://signed.example/shop-branding/x.png',
+      });
+      expect(prisma.shopAuditLog.create).toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { ShopsService } from './shops.service';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { AppException } from '../common/exceptions/http-exception.filter';
@@ -7,6 +8,7 @@ import { ShopRole } from '../generated/prisma/client';
 import { AddShopAdminDto } from './dto/add-shop-admin.dto';
 import { RolesGuard } from '../common/guards/roles.guard';
 import * as bcrypt from 'bcrypt';
+import { buildSignedMediaFileUrl } from '../common/media/signed-media.util';
 
 jest.mock('bcrypt', () => ({
   hash: jest.fn(),
@@ -16,6 +18,8 @@ describe('ShopsService', () => {
   let service: ShopsService;
   let storage: { saveFile: jest.Mock; getFileUrl: jest.Mock; deleteFile: jest.Mock };
   let uploadSupport: { resolveAllowedMimeTypes: jest.Mock; resolveMaxUploadBytes: jest.Mock; validateFile: jest.Mock };
+  const testJwtSecret = 'a'.repeat(40);
+  let configGet: jest.Mock;
   let prisma: {
     shop: Record<string, jest.Mock>;
     item: Record<string, jest.Mock>;
@@ -72,12 +76,18 @@ describe('ShopsService', () => {
       validateFile: jest.fn().mockResolvedValue(undefined),
     };
 
+    configGet = jest.fn((key: string) => {
+      if (key === 'JWT_SECRET') return testJwtSecret;
+      return undefined;
+    });
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ShopsService,
         { provide: PrismaService, useValue: prisma },
         { provide: 'IStorageService', useValue: storage },
         { provide: UploadSupportService, useValue: uploadSupport },
+        { provide: ConfigService, useValue: { get: configGet } },
       ],
     }).compile();
 
@@ -698,6 +708,39 @@ describe('ShopsService', () => {
         logo_url: 'https://signed.example/shop-branding/x.png',
       });
       expect(prisma.shopAuditLog.create).toHaveBeenCalled();
+    });
+
+    it('uploadAppearanceAsset deletes prior shop-branding file after successful replace', async () => {
+      const prevPath = 'shop-branding/old-logo.png';
+      const prevSignedUrl = buildSignedMediaFileUrl(
+        'http://localhost:3000/api/v1',
+        prevPath,
+        testJwtSecret,
+        3600_000,
+      );
+
+      prisma.shop.findFirst.mockResolvedValue({
+        id: tenantId,
+        appearance_json: { logo_url: prevSignedUrl },
+      });
+      prisma.shop.update.mockResolvedValue({
+        id: tenantId,
+        name: 'T',
+        slug: 't',
+        contact_json: {},
+        appearance_json: { logo_url: 'https://signed.example/shop-branding/x.png' },
+      });
+      prisma.shopAuditLog.create.mockResolvedValue({});
+
+      const file = {
+        buffer: Buffer.from([1, 2, 3]),
+        mimetype: 'image/png',
+        size: 100,
+      } as Express.Multer.File;
+
+      await service.uploadAppearanceAsset(tenantId, 'logo', file, 'u1');
+
+      expect(storage.deleteFile).toHaveBeenCalledWith(prevPath);
     });
 
     it('uploadAppearanceAsset deletes saved file when DB update fails', async () => {

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -14,7 +14,7 @@ jest.mock('bcrypt', () => ({
 
 describe('ShopsService', () => {
   let service: ShopsService;
-  let storage: { saveFile: jest.Mock; getFileUrl: jest.Mock };
+  let storage: { saveFile: jest.Mock; getFileUrl: jest.Mock; deleteFile: jest.Mock };
   let uploadSupport: { resolveAllowedMimeTypes: jest.Mock; resolveMaxUploadBytes: jest.Mock; validateFile: jest.Mock };
   let prisma: {
     shop: Record<string, jest.Mock>;
@@ -64,6 +64,7 @@ describe('ShopsService', () => {
     storage = {
       saveFile: jest.fn().mockResolvedValue('shop-branding/x.png'),
       getFileUrl: jest.fn((p: string) => `https://signed.example/${p}`),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
     };
     uploadSupport = {
       resolveAllowedMimeTypes: jest.fn().mockReturnValue(['image/jpeg', 'image/png', 'image/webp']),
@@ -697,6 +698,25 @@ describe('ShopsService', () => {
         logo_url: 'https://signed.example/shop-branding/x.png',
       });
       expect(prisma.shopAuditLog.create).toHaveBeenCalled();
+    });
+
+    it('uploadAppearanceAsset deletes saved file when DB update fails', async () => {
+      prisma.shop.findFirst.mockResolvedValue({
+        id: tenantId,
+        appearance_json: {},
+      });
+      prisma.shop.update.mockRejectedValue(new Error('db down'));
+      prisma.shopAuditLog.create.mockResolvedValue({});
+
+      const file = {
+        buffer: Buffer.from([1, 2, 3]),
+        mimetype: 'image/png',
+        size: 100,
+      } as Express.Multer.File;
+
+      await expect(service.uploadAppearanceAsset(tenantId, 'logo', file, 'u1')).rejects.toThrow('db down');
+      expect(storage.deleteFile).toHaveBeenCalledWith('shop-branding/x.png');
+      expect(prisma.shopAuditLog.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -457,11 +457,12 @@ export class ShopsService {
     }
 
     if (appearanceChanged) {
+      // Delete prior hosting blob before audit so a rare audit failure cannot skip cleanup.
+      await this.tryDeletePriorShopBrandingFile(previousUrl);
       await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
         field: 'appearance_json',
         via: `upload_${kind}`,
       });
-      await this.tryDeletePriorShopBrandingFile(previousUrl);
     }
 
     return {

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -391,17 +391,23 @@ export class ShopsService {
     const appearanceChanged =
       jsonStableStringify(oldShop.appearance_json) !== jsonStableStringify(nextAppearance);
 
-    const updated = await this.prisma.shop.update({
-      where: { id: tenantId },
-      data: { appearance_json: nextAppearance },
-      select: {
-        id: true,
-        name: true,
-        slug: true,
-        contact_json: true,
-        appearance_json: true,
-      },
-    });
+    let updated;
+    try {
+      updated = await this.prisma.shop.update({
+        where: { id: tenantId },
+        data: { appearance_json: nextAppearance },
+        select: {
+          id: true,
+          name: true,
+          slug: true,
+          contact_json: true,
+          appearance_json: true,
+        },
+      });
+    } catch (e) {
+      await this.storage.deleteFile(relativePath);
+      throw e;
+    }
 
     if (appearanceChanged) {
       await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { ErrorCode, AppException } from '../common/exceptions/http-exception.filter';
 import { isPrismaUniqueConstraintError } from '../common/prisma/prisma-error.utils';
@@ -18,7 +19,11 @@ import { totalPagesFromCount } from '../common/utils/pagination.utils';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { jsonStableStringify } from './json-stable-stringify';
 import { UploadSupportService } from '../common/upload/upload-support.service';
+import { verifySignedMediaParams } from '../common/media/signed-media.util';
+import { resolveMediaSigningSecret } from '../common/media/media-signing-secret';
 import { v4 as uuidv4 } from 'uuid';
+
+const SHOP_BRANDING_MIME_ALLOWLIST = ['image/jpeg', 'image/png', 'image/webp'] as const;
 
 const MAX_SLUG_ALLOCATION_ATTEMPTS = 32;
 
@@ -30,6 +35,7 @@ export class ShopsService {
     private prisma: PrismaService,
     @Inject('IStorageService') private storage: IStorageService,
     private readonly uploadSupport: UploadSupportService,
+    private readonly config: ConfigService,
   ) {}
 
   private slugFromName(name: string): string {
@@ -124,6 +130,33 @@ export class ShopsService {
       }
     }
     return next as Prisma.InputJsonValue;
+  }
+
+  private extractAppearanceUrl(json: Prisma.JsonValue, key: 'logo_url' | 'favicon_url'): string | undefined {
+    if (typeof json !== 'object' || json === null || Array.isArray(json)) return undefined;
+    const v = (json as Record<string, unknown>)[key];
+    return typeof v === 'string' && v.trim() ? v.trim() : undefined;
+  }
+
+  /** Best-effort delete of a prior uploaded branding file (signed /media URL under shop-branding/). */
+  private async tryDeletePriorShopBrandingFile(previousUrl: string | undefined): Promise<void> {
+    if (!previousUrl) return;
+    let secret: string;
+    try {
+      secret = resolveMediaSigningSecret(this.config);
+    } catch {
+      return;
+    }
+    try {
+      const u = new URL(previousUrl);
+      const d = u.searchParams.get('d') ?? undefined;
+      const s = u.searchParams.get('s') ?? undefined;
+      const payload = verifySignedMediaParams(d, s, secret);
+      if (!payload?.p.startsWith('shop-branding/')) return;
+      await this.storage.deleteFile(payload.p);
+    } catch {
+      /* ignore malformed URLs or delete failures */
+    }
   }
 
   private async logAudit(
@@ -361,10 +394,19 @@ export class ShopsService {
     file: Express.Multer.File,
     actorUserId?: string | null,
   ) {
-    const allowedMimeTypes = this.uploadSupport.resolveAllowedMimeTypes(
+    let allowedMimeTypes = this.uploadSupport.resolveAllowedMimeTypes(
       this.logger,
       'image/jpeg,image/png,image/webp',
     );
+    allowedMimeTypes = allowedMimeTypes.filter((t) =>
+      (SHOP_BRANDING_MIME_ALLOWLIST as readonly string[]).includes(t),
+    );
+    if (allowedMimeTypes.length === 0) {
+      this.logger.warn(
+        'ALLOWED_MIME excludes all shop-branding types; using image/jpeg, image/png, image/webp',
+      );
+      allowedMimeTypes = [...SHOP_BRANDING_MIME_ALLOWLIST];
+    }
     const maxUploadBytes = Math.min(
       this.uploadSupport.resolveMaxUploadBytes(this.logger, 2),
       2 * 1024 * 1024,
@@ -378,6 +420,11 @@ export class ShopsService {
     if (!oldShop) {
       throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
     }
+
+    const previousUrl =
+      kind === 'logo'
+        ? this.extractAppearanceUrl(oldShop.appearance_json, 'logo_url')
+        : this.extractAppearanceUrl(oldShop.appearance_json, 'favicon_url');
 
     const ext =
       file.mimetype === 'image/png' ? '.png' : file.mimetype === 'image/webp' ? '.webp' : '.jpg';
@@ -414,6 +461,7 @@ export class ShopsService {
         field: 'appearance_json',
         via: `upload_${kind}`,
       });
+      await this.tryDeletePriorShopBrandingFile(previousUrl);
     }
 
     return {

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { ErrorCode, AppException } from '../common/exceptions/http-exception.filter';
 import { isPrismaUniqueConstraintError } from '../common/prisma/prisma-error.utils';
@@ -17,14 +17,19 @@ import { toNumber } from '../common/utils/decimal.utils';
 import { totalPagesFromCount } from '../common/utils/pagination.utils';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { jsonStableStringify } from './json-stable-stringify';
+import { UploadSupportService } from '../common/upload/upload-support.service';
+import { v4 as uuidv4 } from 'uuid';
 
 const MAX_SLUG_ALLOCATION_ATTEMPTS = 32;
 
 @Injectable()
 export class ShopsService {
+  private readonly logger = new Logger(ShopsService.name);
+
   constructor(
     private prisma: PrismaService,
     @Inject('IStorageService') private storage: IStorageService,
+    private readonly uploadSupport: UploadSupportService,
   ) {}
 
   private slugFromName(name: string): string {
@@ -345,6 +350,71 @@ export class ShopsService {
     }
 
     return updated;
+  }
+
+  /**
+   * Upload logo or favicon file for the active tenant; stores under shop-branding/ and sets appearance_json URL.
+   */
+  async uploadAppearanceAsset(
+    tenantId: string,
+    kind: 'logo' | 'favicon',
+    file: Express.Multer.File,
+    actorUserId?: string | null,
+  ) {
+    const allowedMimeTypes = this.uploadSupport.resolveAllowedMimeTypes(
+      this.logger,
+      'image/jpeg,image/png,image/webp',
+    );
+    const maxUploadBytes = Math.min(
+      this.uploadSupport.resolveMaxUploadBytes(this.logger, 2),
+      2 * 1024 * 1024,
+    );
+    await this.uploadSupport.validateFile(file, allowedMimeTypes, maxUploadBytes);
+
+    const oldShop = await this.prisma.shop.findFirst({
+      where: { id: tenantId, is_active: true },
+      select: { id: true, appearance_json: true },
+    });
+    if (!oldShop) {
+      throw new AppException(ErrorCode.NOT_FOUND, 'Shop not found');
+    }
+
+    const ext =
+      file.mimetype === 'image/png' ? '.png' : file.mimetype === 'image/webp' ? '.webp' : '.jpg';
+    const filename = `${tenantId}_${kind}_${uuidv4()}${ext}`;
+    const relativePath = await this.storage.saveFile(file.buffer, filename, 'shop-branding');
+    const publicUrl = this.storage.getFileUrl(relativePath);
+
+    const patch: ShopAppearancePatchDto =
+      kind === 'logo' ? { logo_url: publicUrl } : { favicon_url: publicUrl };
+    const nextAppearance = this.mergeAppearanceJson(oldShop.appearance_json, patch);
+    const appearanceChanged =
+      jsonStableStringify(oldShop.appearance_json) !== jsonStableStringify(nextAppearance);
+
+    const updated = await this.prisma.shop.update({
+      where: { id: tenantId },
+      data: { appearance_json: nextAppearance },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        contact_json: true,
+        appearance_json: true,
+      },
+    });
+
+    if (appearanceChanged) {
+      await this.logAudit(tenantId, ShopAuditAction.update_shop, actorUserId ?? null, 'shop', tenantId, {
+        field: 'appearance_json',
+        via: `upload_${kind}`,
+      });
+    }
+
+    return {
+      kind,
+      url: publicUrl,
+      shop: updated,
+    };
   }
 
   /**

--- a/frontend/src/pages/admin/ShopSettingsPage.tsx
+++ b/frontend/src/pages/admin/ShopSettingsPage.tsx
@@ -54,6 +54,16 @@ const sectionTitle: CSSProperties = {
 };
 const hint: CSSProperties = { fontSize: '12px', color: '#6b7280', margin: 0, lineHeight: 1.45 };
 
+function extractApiErrorMessage(err: unknown, fallback: string): string {
+  if (err && typeof err === 'object' && 'message' in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === 'string' && m.trim()) return m.trim();
+  }
+  const nested = (err as { response?: { data?: { message?: unknown } } })?.response?.data?.message;
+  if (typeof nested === 'string' && nested.trim()) return nested.trim();
+  return fallback;
+}
+
 export const ShopSettingsPage = () => {
   const { activeShop } = useShop();
   const { user } = useAuth();
@@ -131,11 +141,7 @@ export const ShopSettingsPage = () => {
       await queryClient.invalidateQueries({ queryKey: shopSettingsQueryKey });
     },
     onError: (err: unknown) => {
-      const msg =
-        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
-        (err as { message?: string })?.message ||
-        'Lưu thất bại.';
-      setSaveError(msg);
+      setSaveError(extractApiErrorMessage(err, 'Lưu thất bại.'));
       setSaveOk(null);
     },
   });
@@ -145,15 +151,6 @@ export const ShopSettingsPage = () => {
     setSaveOk(null);
     setSaveError(null);
     saveMutation.mutate();
-  };
-
-  const extractUploadMessage = (err: unknown): string => {
-    const data = err as { message?: string; response?: { data?: { message?: string } } };
-    return (
-      data?.response?.data?.message ||
-      data?.message ||
-      'Upload thất bại.'
-    );
   };
 
   const handleBrandingFile = async (kind: 'logo' | 'favicon', fileList: FileList | null) => {
@@ -178,7 +175,7 @@ export const ShopSettingsPage = () => {
       await queryClient.invalidateQueries({ queryKey: shopSettingsQueryKey });
       setSaveOk(kind === 'logo' ? 'Đã upload logo.' : 'Đã upload favicon.');
     } catch (err: unknown) {
-      setSaveError(extractUploadMessage(err));
+      setSaveError(extractApiErrorMessage(err, 'Upload thất bại.'));
     } finally {
       if (kind === 'logo') setUploadingLogo(false);
       else setUploadingFavicon(false);

--- a/frontend/src/pages/admin/ShopSettingsPage.tsx
+++ b/frontend/src/pages/admin/ShopSettingsPage.tsx
@@ -54,6 +54,9 @@ const sectionTitle: CSSProperties = {
 };
 const hint: CSSProperties = { fontSize: '12px', color: '#6b7280', margin: 0, lineHeight: 1.45 };
 
+/** Match backend shop-branding upload cap (see ShopsService.uploadAppearanceAsset). */
+const MAX_BRANDING_UPLOAD_BYTES = 2 * 1024 * 1024;
+
 function extractApiErrorMessage(err: unknown, fallback: string): string {
   if (err && typeof err === 'object' && 'message' in err) {
     const m = (err as { message?: unknown }).message;
@@ -156,6 +159,11 @@ export const ShopSettingsPage = () => {
   const handleBrandingFile = async (kind: 'logo' | 'favicon', fileList: FileList | null) => {
     const file = fileList?.[0];
     if (!file || !canEditSettings || !activeShop?.id) return;
+    if (file.size > MAX_BRANDING_UPLOAD_BYTES) {
+      setSaveOk(null);
+      setSaveError(`File quá lớn (tối đa ${Math.floor(MAX_BRANDING_UPLOAD_BYTES / (1024 * 1024))}MB).`);
+      return;
+    }
     setSaveOk(null);
     setSaveError(null);
     if (kind === 'logo') setUploadingLogo(true);

--- a/frontend/src/pages/admin/ShopSettingsPage.tsx
+++ b/frontend/src/pages/admin/ShopSettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type CSSProperties, type FormEvent } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Palette } from 'lucide-react';
-import { apiClient } from '../../api/client';
+import { apiClient, uploadFile } from '../../api/client';
 import { useAuth } from '../../hooks/useAuth';
 import { useShop } from '../../hooks/useShop';
 import { jsonStableStringify } from '../../utils/jsonStableStringify';
@@ -62,6 +62,8 @@ export const ShopSettingsPage = () => {
   const [appearance, setAppearance] = useState<ShopAppearanceFormState>(() => parseAppearanceFormDefaults(undefined));
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveOk, setSaveOk] = useState<string | null>(null);
+  const [uploadingLogo, setUploadingLogo] = useState(false);
+  const [uploadingFavicon, setUploadingFavicon] = useState(false);
 
   const shopSettingsQueryKey = ['shop-settings', activeShop?.id ?? null] as const;
 
@@ -143,6 +145,44 @@ export const ShopSettingsPage = () => {
     setSaveOk(null);
     setSaveError(null);
     saveMutation.mutate();
+  };
+
+  const extractUploadMessage = (err: unknown): string => {
+    const data = err as { message?: string; response?: { data?: { message?: string } } };
+    return (
+      data?.response?.data?.message ||
+      data?.message ||
+      'Upload thất bại.'
+    );
+  };
+
+  const handleBrandingFile = async (kind: 'logo' | 'favicon', fileList: FileList | null) => {
+    const file = fileList?.[0];
+    if (!file || !canEditSettings || !activeShop?.id) return;
+    setSaveOk(null);
+    setSaveError(null);
+    if (kind === 'logo') setUploadingLogo(true);
+    else setUploadingFavicon(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      formData.append('kind', kind);
+      const raw = await uploadFile<{ ok?: boolean; data?: { shop?: { appearance_json?: unknown } } }>(
+        '/shop-settings/branding-upload',
+        formData,
+      );
+      const appearanceJson = raw?.data?.shop?.appearance_json;
+      if (appearanceJson !== undefined) {
+        setAppearance(parseAppearanceFormDefaults(appearanceJson));
+      }
+      await queryClient.invalidateQueries({ queryKey: shopSettingsQueryKey });
+      setSaveOk(kind === 'logo' ? 'Đã upload logo.' : 'Đã upload favicon.');
+    } catch (err: unknown) {
+      setSaveError(extractUploadMessage(err));
+    } finally {
+      if (kind === 'logo') setUploadingLogo(false);
+      else setUploadingFavicon(false);
+    }
   };
 
   if (settingsQuery.isLoading) {
@@ -239,6 +279,31 @@ export const ShopSettingsPage = () => {
               placeholder="https://..."
               disabled={!canEditSettings}
             />
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '10px', marginTop: '4px' }}>
+              <input
+                id="appearance-logo-file"
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                disabled={!canEditSettings || uploadingLogo}
+                style={{ fontSize: '13px', maxWidth: '100%' }}
+                onChange={(e) => {
+                  void handleBrandingFile('logo', e.target.files);
+                  e.target.value = '';
+                }}
+              />
+              {uploadingLogo ? (
+                <span style={{ ...hint, margin: 0 }}>Đang upload logo...</span>
+              ) : (
+                <span style={{ ...hint, margin: 0 }}>Hoặc chọn ảnh: JPEG, PNG, WebP · tối đa 2MB.</span>
+              )}
+            </div>
+            {appearance.logo_url.trim() ? (
+              <img
+                src={appearance.logo_url.trim()}
+                alt="Logo xem trước"
+                style={{ marginTop: '8px', maxHeight: '56px', maxWidth: '220px', objectFit: 'contain' }}
+              />
+            ) : null}
           </div>
           <div style={formRow}>
             <label style={label} htmlFor="appearance-favicon">
@@ -252,6 +317,31 @@ export const ShopSettingsPage = () => {
               placeholder="https://..."
               disabled={!canEditSettings}
             />
+            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '10px', marginTop: '4px' }}>
+              <input
+                id="appearance-favicon-file"
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                disabled={!canEditSettings || uploadingFavicon}
+                style={{ fontSize: '13px', maxWidth: '100%' }}
+                onChange={(e) => {
+                  void handleBrandingFile('favicon', e.target.files);
+                  e.target.value = '';
+                }}
+              />
+              {uploadingFavicon ? (
+                <span style={{ ...hint, margin: 0 }}>Đang upload favicon...</span>
+              ) : (
+                <span style={{ ...hint, margin: 0 }}>Hoặc chọn ảnh: JPEG, PNG, WebP · tối đa 2MB.</span>
+              )}
+            </div>
+            {appearance.favicon_url.trim() ? (
+              <img
+                src={appearance.favicon_url.trim()}
+                alt="Favicon xem trước"
+                style={{ marginTop: '8px', width: '32px', height: '32px', objectFit: 'contain' }}
+              />
+            ) : null}
           </div>
           <div style={formRow}>
             <label style={label} htmlFor="appearance-primary">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completes the remaining work from issue #135 for **admin upload** of shop logo and favicon (in addition to existing HTTPS URL fields).

### Backend
- New `POST /api/v1/shop-settings/branding-upload` (multipart): field `file`, body field `kind` = `logo` | `favicon`.
- Restricted to **shop_admin** on the active tenant; throttled (20/min).
- Validates MIME/content via existing `UploadSupportService` (JPEG, PNG, WebP); **max 2MB** per file.
- **`ALLOWED_MIME` intersection:** branding uploads always allow jpeg/png/webp even if env narrows other uploads.
- Saves under `shop-branding/` using `IStorageService`, merges signed URL into `appearance_json`, audit log on change.
- **Rollback:** if `shop.update` fails after `saveFile`, delete the new object from storage.
- **Prior asset cleanup:** after a successful replace, best-effort `deleteFile` for the previous URL when it is a valid signed `/media` link pointing at `shop-branding/*`.

### Frontend
- **Cấu hình shop**: file inputs for logo and favicon next to URL fields; previews after upload; invalidates shop-settings query.
- **Errors:** save/upload surfaces messages from the API interceptor shape (`message` at top level), not only nested `response.data`.
- **Client:** reject files over **2MB** before upload.

### Testing
- Unit tests for `uploadAppearanceAsset`: success, DB-failure rollback, and prior-file deletion on replace.

Fixes / relates to: https://github.com/nguyenhoangtin1404/Diecast360/issues/135
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25b93c96-4aa9-4b29-b8f1-e46dae51416f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25b93c96-4aa9-4b29-b8f1-e46dae51416f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

