### PR TITLE
fix(frontend): keep shop theme CSS variables when no public shop id

### DIFF
--- a/frontend/src/contexts/ShopThemeProvider.tsx
+++ b/frontend/src/contexts/ShopThemeProvider.tsx
@@ -41,25 +41,9 @@ function applyBrandingVars(root: HTMLElement, primaryCss: string, accentCss: str
   root.style.setProperty('--accent-foreground', accentFg);
 }
 
-function clearBrandingVars(root: HTMLElement): void {
-  const keys = [
-    '--shop-primary-rgb',
-    '--shop-accent-rgb',
-    '--ct-primary',
-    '--ct-secondary',
-    '--primary',
-    '--primary-foreground',
-    '--secondary',
-    '--secondary-foreground',
-    '--ring',
-    '--chart-1',
-    '--chart-2',
-    '--accent',
-    '--accent-foreground',
-  ] as const;
-  for (const k of keys) {
-    root.style.removeProperty(k);
-  }
+/** When no shop is in scope (e.g. /admin/login), keep tokens aligned with `index.css` defaults instead of clearing — Tailwind `shop` / `shopAccent` need `--shop-*-rgb`. */
+function resetBrandingVarsToDefaults(root: HTMLElement): void {
+  applyBrandingVars(root, defaultPrimaryHex(), defaultAccentHex());
 }
 
 export const ShopThemeProvider: FC<{ children: ReactNode }> = ({ children }) => {
@@ -80,12 +64,12 @@ export const ShopThemeProvider: FC<{ children: ReactNode }> = ({ children }) => 
   useEffect(() => {
     const root = document.documentElement;
     if (!enabled) {
-      clearBrandingVars(root);
+      resetBrandingVarsToDefaults(root);
       return;
     }
     applyBrandingVars(root, primaryCss, accentCss);
     return () => {
-      clearBrandingVars(root);
+      resetBrandingVarsToDefaults(root);
     };
   }, [enabled, primaryCss, accentCss]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ShopThemeProvider` cleared `--shop-primary-rgb`, `--shop-accent-rgb`, and related tokens whenever there was no effective catalog `shop_id` (for example on `/admin/login` before authentication). Tailwind classes such as `from-shop`, `to-shopAccent`, and the `.text-gradient-trust` utility depend on those variables; removing them produced invalid `rgb(var(--shop-primary-rgb) / …)` values, so gradient buttons and trust text lost their colors.

## Change

When branding from the public contact API is not applied, the provider now resets the same CSS custom properties to the default primary/accent pair (matching `index.css`) instead of stripping them. Shop-scoped appearance still overrides once a shop is in scope.

## Testing

Local `npm run lint` / `npm run build` were not executed in this environment because Node/npm were unavailable in the agent shell.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3a8c912-35bb-4248-bb69-0a8a01b4f7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3a8c912-35bb-4248-bb69-0a8a01b4f7b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

