### PR TITLE
AI import: shop-scoped categories + ensure brands per tenant

### DIFF
--- a/backend/prisma/migrations/20260505140000_categories_shop_id/migration.sql
+++ b/backend/prisma/migrations/20260505140000_categories_shop_id/migration.sql
@@ -1,0 +1,18 @@
+-- Shop-scoped categories: AI import and admin create per shop without polluting other tenants.
+
+ALTER TABLE "categories" ADD COLUMN "shop_id" TEXT;
+
+ALTER TABLE "categories" ADD CONSTRAINT "categories_shop_id_fkey"
+  FOREIGN KEY ("shop_id") REFERENCES "shops"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE INDEX "categories_shop_id_type_idx" ON "categories"("shop_id", "type");
+
+DROP INDEX IF EXISTS "categories_type_name_key";
+
+CREATE UNIQUE INDEX "categories_global_type_name_key"
+  ON "categories"("type", "name")
+  WHERE "shop_id" IS NULL;
+
+CREATE UNIQUE INDEX "categories_shop_type_name_key"
+  ON "categories"("shop_id", "type", "name")
+  WHERE "shop_id" IS NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -82,6 +82,7 @@ model Shop {
   members    Member[]
   membership_tiers MembershipTier[]
   member_points_ledger MemberPointsLedger[]
+  categories Category[]
 
   @@map("shops")
   @@index([is_active])
@@ -380,6 +381,8 @@ model SpinFrame {
 
 model Category {
   id            String   @id @default(uuid())
+  /** Global seed rows use null; per-shop rows set to shop id (AI import, shop admin). */
+  shop_id       String?
   name          String
   type          String   // "car_brand" | "model_brand"
   is_active     Boolean  @default(true)
@@ -387,10 +390,13 @@ model Category {
   created_at    DateTime @default(now())
   updated_at    DateTime @updatedAt
 
+  shop Shop? @relation(fields: [shop_id], references: [id], onDelete: Cascade)
+
   @@map("categories")
-  @@unique([type, name])
   @@index([type, is_active])
   @@index([type, display_order])
+  @@index([shop_id, type])
+  @@index([shop_id, type, name])
 }
 
 model AiItemDraft {

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -255,10 +255,10 @@ Cấu trúc bài viết:
             content: `Bạn là chuyên gia về mô hình xe (diecast). Nhiệm vụ của bạn là phân tích hình ảnh và trích xuất thông tin chi tiết về sản phẩm.
             
             Hãy trích xuất các thông tin sau:
-            - Brand (Hãng sản xuất mô hình, ví dụ: Hot Wheels, MiniGT, Tarmac Works, Tomica, ...)
-            - Car Brand (Hãng xe thật, ví dụ: Nissan, Lamborghini, Ferrari, ...)
-            - Model Brand (Dòng xe, ví dụ: GT-R R35, Aventador, ...)
-            - Scale (Tỷ lệ, ví dụ: 1:64, 1:43, 1:18, ...). Nếu không chắc chắn, hãy đoán dựa trên kích thước phổ biến (thường là 1:64 nếu là Hot Wheels/MiniGT).
+            - Brand (Thương hiệu mô hình / nhà sản xuất diecast, ví dụ: Hot Wheels, Mini GT, Tarmac Works, Tomica, Inno64, ...)
+            - Car Brand (Hãng xe thật của mẫu được mô phỏng, ví dụ: Nissan, Lamborghini, Ferrari, ...)
+            - Model Brand (Dòng xe / mẫu xe thật, ví dụ: GT-R R35, Aventador SVJ — không nhầm với Brand diecast phía trên)
+            - Scale (Tỷ lệ, ví dụ: 1:64, 1:43, 1:18, ...). Nếu không chắc chắn, hãy đoán dựa trên kích thước phổ biến (thường là 1:64 nếu là Hot Wheels/Mini GT).
             - Color (Màu sắc chủ đạo)
             - Product Code (Mã sản phẩm nếu thấy trên bao bì)
             

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -10,7 +10,10 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
+  Req,
+  ParseUUIDPipe,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
@@ -18,50 +21,108 @@ import { QueryCategoriesDto } from './dto/query-categories.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { PlatformRoles } from '../common/decorators/platform-roles.decorator';
-import { PlatformRole } from '../generated/prisma/client';
+import { Roles } from '../common/decorators/roles.decorator';
+import { PlatformRole, ShopRole } from '../generated/prisma/client';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
+import { TenantGuard } from '../common/guards/tenant.guard';
+import { CurrentTenantId } from '../common/decorators/tenant.decorator';
+
+type JwtUser = {
+  id?: string;
+  active_shop_id?: string | null;
+  platform_role?: PlatformRole | null;
+};
 
 @Controller('categories')
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
-  // Public: used by frontend dropdowns (no auth required)
-  @Get()
-  findAll(@Query() queryDto: QueryCategoriesDto) {
-    return this.categoriesService.findAll(queryDto);
+  private categoriesListContext(req: Request): {
+    jwtTenantId?: string | null;
+    isPlatformSuper?: boolean;
+  } {
+    const user = req.user as JwtUser | undefined;
+    return {
+      jwtTenantId: user?.active_shop_id ?? null,
+      isPlatformSuper: user?.platform_role === PlatformRole.platform_super,
+    };
   }
 
-  // Public: category detail (no auth required)
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.categoriesService.findOne(id);
+  /** Catalog dropdowns: anonymous merges global + optional shop_id query or JWT shop */
+  @Get()
+  @UseGuards(OptionalJwtAuthGuard)
+  findAll(@Query() queryDto: QueryCategoriesDto, @Req() req: Request) {
+    return this.categoriesService.findAll(queryDto, this.categoriesListContext(req));
+  }
+
+  /** Shop admin: create category scoped to active shop (before :id routes) */
+  @Post('shop')
+  @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+  @Roles(ShopRole.shop_admin)
+  createForShop(
+    @Body() createDto: CreateCategoryDto,
+    @CurrentTenantId() tenantId: string,
+  ) {
+    return this.categoriesService.createForShop(createDto, tenantId);
   }
 
   @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)
   @PlatformRoles(PlatformRole.platform_super)
-  create(@Body() createDto: CreateCategoryDto) {
-    return this.categoriesService.create(createDto);
+  createGlobal(@Body() createDto: CreateCategoryDto) {
+    return this.categoriesService.createGlobal(createDto);
+  }
+
+  @Get(':id')
+  @UseGuards(OptionalJwtAuthGuard)
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.categoriesService.findOne(id);
   }
 
   @Patch(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @PlatformRoles(PlatformRole.platform_super)
-  update(@Param('id') id: string, @Body() updateDto: UpdateCategoryDto) {
-    return this.categoriesService.update(id, updateDto);
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateDto: UpdateCategoryDto,
+    @Req() req: Request,
+  ) {
+    const user = req.user as JwtUser | undefined;
+    const platformSuper = user?.platform_role === PlatformRole.platform_super;
+    if (platformSuper) {
+      return this.categoriesService.update(id, updateDto, { isPlatformSuper: true });
+    }
+    return this.categoriesService.update(id, updateDto, {
+      tenantId: user?.active_shop_id ?? null,
+      isPlatformSuper: false,
+    });
   }
 
   @Patch(':id/toggle')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @PlatformRoles(PlatformRole.platform_super)
-  toggleActive(@Param('id') id: string) {
-    return this.categoriesService.toggleActive(id);
+  async toggleActive(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const user = req.user as JwtUser | undefined;
+    const platformSuper = user?.platform_role === PlatformRole.platform_super;
+    if (platformSuper) {
+      return this.categoriesService.toggleActive(id, { isPlatformSuper: true });
+    }
+    return this.categoriesService.toggleActive(id, {
+      tenantId: user?.active_shop_id ?? null,
+      isPlatformSuper: false,
+    });
   }
 
   @Delete(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @PlatformRoles(PlatformRole.platform_super)
   @HttpCode(HttpStatus.OK)
-  remove(@Param('id') id: string) {
-    return this.categoriesService.remove(id);
+  async remove(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
+    const user = req.user as JwtUser | undefined;
+    const platformSuper = user?.platform_role === PlatformRole.platform_super;
+    if (platformSuper) {
+      return this.categoriesService.remove(id, { isPlatformSuper: true });
+    }
+    return this.categoriesService.remove(id, {
+      tenantId: user?.active_shop_id ?? null,
+      isPlatformSuper: false,
+    });
   }
 }

--- a/backend/src/categories/categories.controller.ts
+++ b/backend/src/categories/categories.controller.ts
@@ -81,6 +81,8 @@ export class CategoriesController {
 
   @Patch(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @PlatformRoles(PlatformRole.platform_super)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   async update(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() updateDto: UpdateCategoryDto,
@@ -99,6 +101,8 @@ export class CategoriesController {
 
   @Patch(':id/toggle')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @PlatformRoles(PlatformRole.platform_super)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   async toggleActive(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
     const user = req.user as JwtUser | undefined;
     const platformSuper = user?.platform_role === PlatformRole.platform_super;
@@ -113,6 +117,8 @@ export class CategoriesController {
 
   @Delete(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @PlatformRoles(PlatformRole.platform_super)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
   @HttpCode(HttpStatus.OK)
   async remove(@Param('id', ParseUUIDPipe) id: string, @Req() req: Request) {
     const user = req.user as JwtUser | undefined;

--- a/backend/src/categories/categories.service.spec.ts
+++ b/backend/src/categories/categories.service.spec.ts
@@ -1,18 +1,22 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoriesService } from './categories.service';
 import { PrismaService } from '../common/prisma/prisma.service';
-import { NotFoundException, ConflictException } from '@nestjs/common';
+import { ForbiddenException } from '@nestjs/common';
 
 describe('CategoriesService', () => {
   let service: CategoriesService;
   let prisma: {
     category: Record<string, jest.Mock>;
     item: Record<string, jest.Mock>;
+    shop: Record<string, jest.Mock>;
     $transaction: jest.Mock;
   };
 
-  const mockCategory = {
+  const SHOP_A = '00000000-0000-0000-0000-0000000000aa';
+
+  const mockGlobalCategory = {
     id: 'cat-1',
+    shop_id: null as string | null,
     name: 'BMW',
     type: 'car_brand',
     is_active: true,
@@ -25,6 +29,7 @@ describe('CategoriesService', () => {
     prisma = {
       category: {
         findMany: jest.fn(),
+        findFirst: jest.fn(),
         findUnique: jest.fn(),
         create: jest.fn(),
         update: jest.fn(),
@@ -36,9 +41,16 @@ describe('CategoriesService', () => {
         count: jest.fn(),
         updateMany: jest.fn(),
       },
-      $transaction: jest.fn(async (operations: Promise<unknown>[]) => {
+      shop: {
+        findFirst: jest.fn(),
+      },
+      $transaction: jest.fn(async (arg: unknown) => {
+        if (typeof arg === 'function') {
+          return arg(prisma);
+        }
+        const ops = arg as Promise<unknown>[];
         const results = [];
-        for (const op of operations) {
+        for (const op of ops) {
           results.push(await op);
         }
         return results;
@@ -54,7 +66,6 @@ describe('CategoriesService', () => {
 
     service = module.get<CategoriesService>(CategoriesService);
 
-    // Suppress logger output in tests
     jest.spyOn((service as unknown as { logger: { log: jest.Mock } }).logger, 'log').mockImplementation();
   });
 
@@ -66,291 +77,98 @@ describe('CategoriesService', () => {
     expect(service).toBeDefined();
   });
 
-  // ============================================================
-  // findAll
-  // ============================================================
   describe('findAll', () => {
-    it('should return all categories without filters', async () => {
-      prisma.category.findMany.mockResolvedValue([mockCategory]);
+    it('merges global + shop rows when shop_id query resolves', async () => {
+      prisma.shop.findFirst.mockResolvedValue({ id: SHOP_A });
+      prisma.category.findMany.mockResolvedValue([mockGlobalCategory]);
 
-      const result = await service.findAll({});
+      await service.findAll({ type: 'car_brand', shop_id: SHOP_A }, {});
 
-      expect(result).toEqual({ categories: [mockCategory] });
+      expect(prisma.category.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ shop_id: null }, { shop_id: { in: [SHOP_A] } }],
+          type: 'car_brand',
+        },
+        orderBy: [{ display_order: 'asc' }, { name: 'asc' }],
+      });
+    });
+
+    it('platform super without shop returns all rows', async () => {
+      prisma.category.findMany.mockResolvedValue([]);
+
+      await service.findAll({}, { isPlatformSuper: true });
+
       expect(prisma.category.findMany).toHaveBeenCalledWith({
         where: {},
         orderBy: [{ display_order: 'asc' }, { name: 'asc' }],
       });
     });
-
-    it('should filter by type', async () => {
-      prisma.category.findMany.mockResolvedValue([mockCategory]);
-
-      await service.findAll({ type: 'car_brand' });
-
-      expect(prisma.category.findMany).toHaveBeenCalledWith({
-        where: { type: 'car_brand' },
-        orderBy: [{ display_order: 'asc' }, { name: 'asc' }],
-      });
-    });
-
-    it('should filter by is_active', async () => {
-      prisma.category.findMany.mockResolvedValue([]);
-
-      await service.findAll({ is_active: true });
-
-      expect(prisma.category.findMany).toHaveBeenCalledWith({
-        where: { is_active: true },
-        orderBy: [{ display_order: 'asc' }, { name: 'asc' }],
-      });
-    });
-
-    it('should filter by both type and is_active', async () => {
-      prisma.category.findMany.mockResolvedValue([]);
-
-      await service.findAll({ type: 'model_brand', is_active: false });
-
-      expect(prisma.category.findMany).toHaveBeenCalledWith({
-        where: { type: 'model_brand', is_active: false },
-        orderBy: [{ display_order: 'asc' }, { name: 'asc' }],
-      });
-    });
   });
 
-  // ============================================================
-  // findOne
-  // ============================================================
-  describe('findOne', () => {
-    it('should return a category by id', async () => {
-      prisma.category.findUnique.mockResolvedValue(mockCategory);
-
-      const result = await service.findOne('cat-1');
-
-      expect(result).toEqual({ category: mockCategory });
-    });
-
-    it('should throw NotFoundException if category not found', async () => {
-      prisma.category.findUnique.mockResolvedValue(null);
-
-      await expect(service.findOne('not-exist')).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-  });
-
-  // ============================================================
-  // create
-  // ============================================================
-  describe('create', () => {
-    it('should create a new category with auto display_order', async () => {
-      prisma.category.findUnique.mockResolvedValue(null); // no duplicate
+  describe('createGlobal', () => {
+    it('creates category with shop_id null', async () => {
+      prisma.category.findFirst.mockResolvedValue(null);
       prisma.category.aggregate.mockResolvedValue({ _max: { display_order: 5 } });
-      prisma.category.create.mockResolvedValue({ ...mockCategory, display_order: 6 });
+      prisma.category.create.mockResolvedValue({ ...mockGlobalCategory, display_order: 6 });
 
-      const result = await service.create({ name: 'BMW', type: 'car_brand' });
-
-      expect(result.category.display_order).toBe(6);
-      expect(prisma.category.create).toHaveBeenCalledWith({
-        data: { name: 'BMW', type: 'car_brand', display_order: 6 },
-      });
-    });
-
-    it('should create with explicit display_order', async () => {
-      prisma.category.findUnique.mockResolvedValue(null);
-      prisma.category.create.mockResolvedValue({ ...mockCategory, display_order: 10 });
-
-      await service.create({ name: 'BMW', type: 'car_brand', display_order: 10 });
+      await service.createGlobal({ name: 'Audi', type: 'car_brand' });
 
       expect(prisma.category.create).toHaveBeenCalledWith({
-        data: { name: 'BMW', type: 'car_brand', display_order: 10 },
+        data: {
+          shop_id: null,
+          name: 'Audi',
+          type: 'car_brand',
+          display_order: 6,
+        },
       });
-      // aggregate should NOT be called when display_order is provided
-      expect(prisma.category.aggregate).not.toHaveBeenCalled();
     });
+  });
 
-    it('should set display_order to 0 when no categories exist', async () => {
-      prisma.category.findUnique.mockResolvedValue(null);
+  describe('createForShop', () => {
+    it('creates scoped category', async () => {
+      prisma.category.findFirst.mockResolvedValue(null);
       prisma.category.aggregate.mockResolvedValue({ _max: { display_order: null } });
-      prisma.category.create.mockResolvedValue({ ...mockCategory, display_order: 0 });
+      prisma.category.create.mockResolvedValue({
+        ...mockGlobalCategory,
+        shop_id: SHOP_A,
+        display_order: 0,
+      });
 
-      await service.create({ name: 'BMW', type: 'car_brand' });
+      await service.createForShop({ name: 'Custom', type: 'car_brand' }, SHOP_A);
 
       expect(prisma.category.create).toHaveBeenCalledWith({
-        data: { name: 'BMW', type: 'car_brand', display_order: 0 },
+        data: {
+          shop_id: SHOP_A,
+          name: 'Custom',
+          type: 'car_brand',
+          display_order: 0,
+        },
       });
     });
+  });
 
-    it('should throw ConflictException if duplicate name+type exists', async () => {
-      prisma.category.findUnique.mockResolvedValue(mockCategory); // duplicate found
+  describe('update', () => {
+    it('shop admin cannot rename global category', async () => {
+      prisma.category.findUnique.mockResolvedValue(mockGlobalCategory);
 
       await expect(
-        service.create({ name: 'BMW', type: 'car_brand' }),
-      ).rejects.toThrow(ConflictException);
+        service.update('cat-1', { name: 'X' }, { tenantId: SHOP_A, isPlatformSuper: false }),
+      ).rejects.toThrow(ForbiddenException);
     });
-  });
 
-  // ============================================================
-  // update
-  // ============================================================
-  describe('update', () => {
-    it('should update name and cascade rename to items', async () => {
-      prisma.category.findUnique
-        .mockResolvedValueOnce(mockCategory) // existing
-        .mockResolvedValueOnce(null); // no duplicate
+    it('platform super can rename global category', async () => {
+      prisma.category.findUnique.mockResolvedValueOnce(mockGlobalCategory);
+      prisma.category.findFirst.mockResolvedValue(null);
+      prisma.$transaction.mockResolvedValue([{ ...mockGlobalCategory, name: 'BMW Group' }, { count: 1 }]);
+      prisma.item.count.mockResolvedValue(1);
 
-      const updatedCategory = { ...mockCategory, name: 'BMW Group' };
-      prisma.category.update.mockResolvedValue(updatedCategory);
-      prisma.item.updateMany.mockResolvedValue({ count: 3 });
-      prisma.item.count.mockResolvedValue(3);
-
-      // $transaction returns array of results
-      prisma.$transaction.mockResolvedValue([updatedCategory, { count: 3 }]);
-
-      const result = await service.update('cat-1', { name: 'BMW Group' });
+      const result = await service.update(
+        'cat-1',
+        { name: 'BMW Group' },
+        { isPlatformSuper: true },
+      );
 
       expect(result.category.name).toBe('BMW Group');
-      expect(prisma.$transaction).toHaveBeenCalled();
-    });
-
-    it('should update display_order without triggering rename cascade', async () => {
-      prisma.category.findUnique.mockResolvedValue(mockCategory);
-      const updatedCategory = { ...mockCategory, display_order: 5 };
-      prisma.category.update.mockResolvedValue(updatedCategory);
-
-      const result = await service.update('cat-1', { display_order: 5 });
-
-      expect(result.category.display_order).toBe(5);
-      // Should NOT trigger transaction for non-rename updates
-      expect(prisma.$transaction).not.toHaveBeenCalled();
-      expect(prisma.category.update).toHaveBeenCalledWith({
-        where: { id: 'cat-1' },
-        data: { display_order: 5 },
-      });
-    });
-
-    it('should throw NotFoundException if category not found', async () => {
-      prisma.category.findUnique.mockResolvedValue(null);
-
-      await expect(
-        service.update('not-exist', { name: 'New Name' }),
-      ).rejects.toThrow(NotFoundException);
-    });
-
-    it('should throw ConflictException if rename conflicts with existing name', async () => {
-      prisma.category.findUnique
-        .mockResolvedValueOnce(mockCategory) // existing category
-        .mockResolvedValueOnce({ id: 'cat-2', name: 'Audi', type: 'car_brand' }); // conflict
-
-      await expect(
-        service.update('cat-1', { name: 'Audi' }),
-      ).rejects.toThrow(ConflictException);
-    });
-
-    it('should skip duplicate check if name is unchanged', async () => {
-      prisma.category.findUnique.mockResolvedValue(mockCategory);
-      prisma.category.update.mockResolvedValue(mockCategory);
-
-      await service.update('cat-1', { name: 'BMW' }); // same name
-
-      // findUnique should only be called once (for the existing check, not for duplicate)
-      expect(prisma.category.findUnique).toHaveBeenCalledTimes(1);
-      expect(prisma.$transaction).not.toHaveBeenCalled();
-    });
-  });
-
-  // ============================================================
-  // toggleActive
-  // ============================================================
-  describe('toggleActive', () => {
-    it('should toggle active → inactive', async () => {
-      prisma.category.findUnique.mockResolvedValue(mockCategory);
-      prisma.category.update.mockResolvedValue({ ...mockCategory, is_active: false });
-
-      const result = await service.toggleActive('cat-1');
-
-      expect(result.category.is_active).toBe(false);
-      expect(prisma.category.update).toHaveBeenCalledWith({
-        where: { id: 'cat-1' },
-        data: { is_active: false },
-      });
-    });
-
-    it('should toggle inactive → active', async () => {
-      const inactiveCategory = { ...mockCategory, is_active: false };
-      prisma.category.findUnique.mockResolvedValue(inactiveCategory);
-      prisma.category.update.mockResolvedValue({ ...inactiveCategory, is_active: true });
-
-      const result = await service.toggleActive('cat-1');
-
-      expect(result.category.is_active).toBe(true);
-      expect(prisma.category.update).toHaveBeenCalledWith({
-        where: { id: 'cat-1' },
-        data: { is_active: true },
-      });
-    });
-
-    it('should throw NotFoundException if category not found', async () => {
-      prisma.category.findUnique.mockResolvedValue(null);
-
-      await expect(service.toggleActive('not-exist')).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-  });
-
-  // ============================================================
-  // remove
-  // ============================================================
-  describe('remove', () => {
-    it('should delete category when not in use', async () => {
-      prisma.category.findUnique.mockResolvedValue(mockCategory);
-      prisma.item.count.mockResolvedValue(0); // not in use
-
-      const result = await service.remove('cat-1');
-
-      expect(result).toEqual({ message: 'Đã xoá danh mục thành công' });
-      expect(prisma.category.delete).toHaveBeenCalledWith({
-        where: { id: 'cat-1' },
-      });
-    });
-
-    it('should throw ConflictException when category is in use by items', async () => {
-      prisma.category.findUnique.mockResolvedValue(mockCategory);
-      prisma.item.count.mockResolvedValue(5); // used by 5 items
-
-      await expect(service.remove('cat-1')).rejects.toThrow(ConflictException);
-      expect(prisma.category.delete).not.toHaveBeenCalled();
-    });
-
-    it('should check correct item field based on category type', async () => {
-      // Test car_brand → checks car_brand field
-      prisma.category.findUnique.mockResolvedValue(mockCategory);
-      prisma.item.count.mockResolvedValue(0);
-
-      await service.remove('cat-1');
-
-      expect(prisma.item.count).toHaveBeenCalledWith({
-        where: { car_brand: 'BMW', deleted_at: null },
-      });
-
-      // Test model_brand → checks model_brand field
-      jest.clearAllMocks();
-      const modelCategory = { ...mockCategory, type: 'model_brand', name: 'Mini GT' };
-      prisma.category.findUnique.mockResolvedValue(modelCategory);
-      prisma.item.count.mockResolvedValue(0);
-
-      await service.remove('cat-1');
-
-      expect(prisma.item.count).toHaveBeenCalledWith({
-        where: { model_brand: 'Mini GT', deleted_at: null },
-      });
-    });
-
-    it('should throw NotFoundException if category not found', async () => {
-      prisma.category.findUnique.mockResolvedValue(null);
-
-      await expect(service.remove('not-exist')).rejects.toThrow(
-        NotFoundException,
-      );
     });
   });
 });

--- a/backend/src/categories/categories.service.spec.ts
+++ b/backend/src/categories/categories.service.spec.ts
@@ -78,6 +78,31 @@ describe('CategoriesService', () => {
   });
 
   describe('findAll', () => {
+    it('falls back to global-only when shop_id query does not resolve', async () => {
+      prisma.shop.findFirst.mockResolvedValue(null);
+      prisma.category.findMany.mockResolvedValue([mockGlobalCategory]);
+
+      await service.findAll({ shop_id: 'no-such-slug' }, {});
+
+      expect(prisma.category.findMany).toHaveBeenCalledWith({
+        where: {
+          shop_id: null,
+        },
+        orderBy: [{ display_order: 'asc' }, { name: 'asc' }],
+      });
+    });
+
+    it('anonymous without shop uses global-only rows', async () => {
+      prisma.category.findMany.mockResolvedValue([]);
+
+      await service.findAll({}, {});
+
+      expect(prisma.category.findMany).toHaveBeenCalledWith({
+        where: { shop_id: null },
+        orderBy: [{ display_order: 'asc' }, { name: 'asc' }],
+      });
+    });
+
     it('merges global + shop rows when shop_id query resolves', async () => {
       prisma.shop.findFirst.mockResolvedValue({ id: SHOP_A });
       prisma.category.findMany.mockResolvedValue([mockGlobalCategory]);
@@ -159,7 +184,17 @@ describe('CategoriesService', () => {
     it('platform super can rename global category', async () => {
       prisma.category.findUnique.mockResolvedValueOnce(mockGlobalCategory);
       prisma.category.findFirst.mockResolvedValue(null);
-      prisma.$transaction.mockResolvedValue([{ ...mockGlobalCategory, name: 'BMW Group' }, { count: 1 }]);
+      prisma.$transaction.mockImplementation(async (ops: unknown) => {
+        if (Array.isArray(ops)) {
+          for (const op of ops as Promise<unknown>[]) {
+            await op;
+          }
+          return [{ ...mockGlobalCategory, name: 'BMW Group' }, { count: 1 }];
+        }
+        return undefined;
+      });
+      prisma.category.update.mockResolvedValue({ ...mockGlobalCategory, name: 'BMW Group' });
+      prisma.item.updateMany.mockResolvedValue({ count: 1 });
       prisma.item.count.mockResolvedValue(1);
 
       const result = await service.update(
@@ -169,6 +204,14 @@ describe('CategoriesService', () => {
       );
 
       expect(result.category.name).toBe('BMW Group');
+      expect(prisma.item.updateMany).toHaveBeenCalledWith({
+        where: {
+          car_brand: 'BMW',
+          deleted_at: null,
+          shop_id: null,
+        },
+        data: { car_brand: 'BMW Group' },
+      });
     });
   });
 });

--- a/backend/src/categories/categories.service.ts
+++ b/backend/src/categories/categories.service.ts
@@ -13,7 +13,7 @@ import { QueryCategoriesDto } from './dto/query-categories.dto';
 import { isUUID } from 'class-validator';
 import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
 import { isPrismaUniqueConstraintError } from '../common/prisma/prisma-error.utils';
-import { normalizeCategoryBrandField } from '../common/utils/category-brand.utils';
+import { normalizeCategoryBrandField, MAX_CATEGORY_BRAND_NAME_LENGTH } from '../common/utils/category-brand.utils';
 
 /**
  * Maps category type to the corresponding field on the Item model.
@@ -344,6 +344,13 @@ export class CategoriesService {
         typeof spec.value === 'string' ? spec.value.trim() : '';
       if (!trimmed) continue;
 
+      if (trimmed.length > MAX_CATEGORY_BRAND_NAME_LENGTH) {
+        this.logger.warn(
+          `Skipping AI category ensure for ${spec.type}: name length ${trimmed.length} exceeds max ${MAX_CATEGORY_BRAND_NAME_LENGTH}`,
+        );
+        continue;
+      }
+
       const existingShop = await tx.category.findFirst({
         where: { type: spec.type, name: trimmed, shop_id: shopId },
       });
@@ -447,6 +454,7 @@ export class CategoriesService {
       return;
     }
     if (categoryShopId === null) {
+      this.logger.warn('Category mutation denied: global category requires platform_super');
       throw new ForbiddenException('Chỉ quản trị nền tảng mới sửa được danh mục chung.');
     }
     const tid =
@@ -454,6 +462,9 @@ export class CategoriesService {
         ? opts.tenantId.trim()
         : null;
     if (!tid || tid !== categoryShopId) {
+      this.logger.warn(
+        `Category mutation denied: tenant=${tid ?? 'none'} category_shop=${categoryShopId ?? 'none'}`,
+      );
       throw new ForbiddenException('Không có quyền thao tác danh mục của shop khác.');
     }
   }

--- a/backend/src/categories/categories.service.ts
+++ b/backend/src/categories/categories.service.ts
@@ -47,6 +47,10 @@ export class CategoriesService {
 
     const where: Prisma.CategoryWhereInput = {};
 
+    if (shopScope.mode === 'global_only') {
+      where.shop_id = null;
+    }
+
     if (shopScope.mode === 'shop_merge' && shopScope.shopIds.length > 0) {
       where.OR = [
         { shop_id: null },
@@ -77,7 +81,10 @@ export class CategoriesService {
     const trimmed = rawShopId?.trim();
     if (trimmed) {
       const id = await this.resolveShopIdFromQuery(trimmed);
-      return { mode: 'shop_merge', shopIds: id ? [id] : [] };
+      // Invalid or unknown shop → do not return every row (treat as global-only filter).
+      return id
+        ? { mode: 'shop_merge' as const, shopIds: [id] }
+        : { mode: 'global_only' as const, shopIds: [] };
     }
 
     if (ctx.isPlatformSuper) {
@@ -223,6 +230,9 @@ export class CategoriesService {
       };
       if (existing.shop_id !== null) {
         itemWhere.shop_id = existing.shop_id;
+      } else {
+        // Global seed row: only cascade rename to legacy items without tenant (avoid rewriting every shop).
+        itemWhere.shop_id = null;
       }
 
       const [category] = await this.prisma.$transaction([
@@ -237,7 +247,9 @@ export class CategoriesService {
         where: {
           [itemField]: dto.name,
           deleted_at: null,
-          ...(existing.shop_id !== null ? { shop_id: existing.shop_id } : {}),
+          ...(existing.shop_id !== null
+            ? { shop_id: existing.shop_id }
+            : { shop_id: null }),
         },
       });
 

--- a/backend/src/categories/categories.service.ts
+++ b/backend/src/categories/categories.service.ts
@@ -2,21 +2,32 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  ForbiddenException,
   Logger,
 } from '@nestjs/common';
+import { Prisma } from '../generated/prisma/client';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
 import { UpdateCategoryDto } from './dto/update-category.dto';
 import { QueryCategoriesDto } from './dto/query-categories.dto';
+import { isUUID } from 'class-validator';
+import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
+import { isPrismaUniqueConstraintError } from '../common/prisma/prisma-error.utils';
+import { normalizeCategoryBrandField } from '../common/utils/category-brand.utils';
 
 /**
  * Maps category type to the corresponding field on the Item model.
- * When adding a new category type, add its mapping here.
  */
 const CATEGORY_TYPE_TO_ITEM_FIELD: Record<string, string> = {
   car_brand: 'car_brand',
   model_brand: 'model_brand',
 };
+
+export interface CategoriesListContext {
+  /** JWT active shop (optional). */
+  jwtTenantId?: string | null;
+  isPlatformSuper?: boolean;
+}
 
 @Injectable()
 export class CategoriesService {
@@ -24,8 +35,24 @@ export class CategoriesService {
 
   constructor(private prisma: PrismaService) {}
 
-  async findAll(queryDto: QueryCategoriesDto) {
-    const where: Record<string, unknown> = {};
+  /**
+   * List categories for dropdowns / filters.
+   * - With `?shop_id=` (UUID or slug): global seed rows + that shop's rows.
+   * - Authenticated shop user without query: global + active JWT shop.
+   * - Platform super without shop filter: all rows.
+   * - Anonymous without shop: global seed only (backward compatible).
+   */
+  async findAll(queryDto: QueryCategoriesDto, ctx: CategoriesListContext = {}) {
+    const shopScope = await this.resolveCategoryListShopScope(queryDto.shop_id, ctx);
+
+    const where: Prisma.CategoryWhereInput = {};
+
+    if (shopScope.mode === 'shop_merge' && shopScope.shopIds.length > 0) {
+      where.OR = [
+        { shop_id: null },
+        { shop_id: { in: shopScope.shopIds } },
+      ];
+    }
 
     if (queryDto.type) {
       where.type = queryDto.type;
@@ -43,6 +70,45 @@ export class CategoriesService {
     return { categories };
   }
 
+  private async resolveCategoryListShopScope(
+    rawShopId: string | undefined,
+    ctx: CategoriesListContext,
+  ): Promise<{ mode: 'all' | 'global_only' | 'shop_merge'; shopIds: string[] }> {
+    const trimmed = rawShopId?.trim();
+    if (trimmed) {
+      const id = await this.resolveShopIdFromQuery(trimmed);
+      return { mode: 'shop_merge', shopIds: id ? [id] : [] };
+    }
+
+    if (ctx.isPlatformSuper) {
+      return { mode: 'all', shopIds: [] };
+    }
+
+    const jwtShop =
+      typeof ctx.jwtTenantId === 'string' && ctx.jwtTenantId.trim().length > 0
+        ? ctx.jwtTenantId.trim()
+        : null;
+    if (jwtShop) {
+      return { mode: 'shop_merge', shopIds: [jwtShop] };
+    }
+
+    return { mode: 'global_only', shopIds: [] };
+  }
+
+  /** Resolve public/admin `shop_id` query param (UUID or slug) to canonical shop UUID. */
+  private async resolveShopIdFromQuery(trimmed: string): Promise<string | null> {
+    const shop = isUUID(trimmed)
+      ? await this.prisma.shop.findFirst({
+          where: { id: trimmed, is_active: true },
+          select: { id: true },
+        })
+      : await this.prisma.shop.findFirst({
+          where: { slug: trimmed, is_active: true },
+          select: { id: true },
+        });
+    return shop?.id ?? null;
+  }
+
   async findOne(id: string) {
     const category = await this.prisma.category.findUnique({
       where: { id },
@@ -55,10 +121,23 @@ export class CategoriesService {
     return { category };
   }
 
-  async create(dto: CreateCategoryDto) {
-    // Check for duplicate name+type
-    const existing = await this.prisma.category.findUnique({
-      where: { type_name: { type: dto.type, name: dto.name } },
+  /** Platform seed / global catalog (shop_id = null). */
+  async createGlobal(dto: CreateCategoryDto) {
+    return this.createWithShopId(dto, null);
+  }
+
+  /** Shop-scoped category (AI import quick-add, shop admin). */
+  async createForShop(dto: CreateCategoryDto, shopId: string) {
+    return this.createWithShopId(dto, shopId);
+  }
+
+  private async createWithShopId(dto: CreateCategoryDto, shopId: string | null) {
+    const existing = await this.prisma.category.findFirst({
+      where: {
+        type: dto.type,
+        name: dto.name,
+        shop_id: shopId,
+      },
     });
 
     if (existing) {
@@ -67,11 +146,10 @@ export class CategoriesService {
       );
     }
 
-    // If no display_order provided, set to max + 1
     let displayOrder = dto.display_order;
     if (displayOrder === undefined) {
       const maxOrder = await this.prisma.category.aggregate({
-        where: { type: dto.type },
+        where: { type: dto.type, shop_id: shopId },
         _max: { display_order: true },
       });
       displayOrder = (maxOrder._max.display_order ?? -1) + 1;
@@ -79,18 +157,25 @@ export class CategoriesService {
 
     const category = await this.prisma.category.create({
       data: {
+        shop_id: shopId,
         name: dto.name,
         type: dto.type,
         display_order: displayOrder,
       },
     });
 
-    this.logger.log(`Category created: ${category.name} (${category.type})`);
+    this.logger.log(
+      `Category created: ${category.name} (${category.type}) shop=${shopId ?? 'global'}`,
+    );
 
     return { category };
   }
 
-  async update(id: string, dto: UpdateCategoryDto) {
+  async update(
+    id: string,
+    dto: UpdateCategoryDto,
+    opts: { tenantId?: string | null; isPlatformSuper?: boolean },
+  ) {
     const existing = await this.prisma.category.findUnique({
       where: { id },
     });
@@ -99,12 +184,18 @@ export class CategoriesService {
       throw new NotFoundException('Danh mục không tồn tại');
     }
 
+    this.assertCanMutateCategory(existing.shop_id, opts);
+
     const isRenaming = dto.name && dto.name !== existing.name;
 
-    // If renaming, check for duplicates
     if (isRenaming) {
-      const duplicate = await this.prisma.category.findUnique({
-        where: { type_name: { type: existing.type, name: dto.name! } },
+      const duplicate = await this.prisma.category.findFirst({
+        where: {
+          type: existing.type,
+          name: dto.name!,
+          shop_id: existing.shop_id,
+          NOT: { id: existing.id },
+        },
       });
 
       if (duplicate) {
@@ -118,20 +209,36 @@ export class CategoriesService {
     if (dto.name !== undefined) data.name = dto.name;
     if (dto.display_order !== undefined) data.display_order = dto.display_order;
 
-    // Use transaction to cascade rename to items
+    const itemField = CATEGORY_TYPE_TO_ITEM_FIELD[existing.type];
+    if (!itemField) {
+      throw new ConflictException(
+        `Loại danh mục "${existing.type}" không có ánh xạ trường hợp lệ`,
+      );
+    }
+
     if (isRenaming) {
-      const itemField = CATEGORY_TYPE_TO_ITEM_FIELD[existing.type];
+      const itemWhere: Prisma.ItemWhereInput = {
+        [itemField]: existing.name,
+        deleted_at: null,
+      };
+      if (existing.shop_id !== null) {
+        itemWhere.shop_id = existing.shop_id;
+      }
 
       const [category] = await this.prisma.$transaction([
         this.prisma.category.update({ where: { id }, data }),
         this.prisma.item.updateMany({
-          where: { [itemField]: existing.name, deleted_at: null },
+          where: itemWhere,
           data: { [itemField]: dto.name },
         }),
       ]);
 
       const updatedCount = await this.prisma.item.count({
-        where: { [itemField]: dto.name, deleted_at: null },
+        where: {
+          [itemField]: dto.name,
+          deleted_at: null,
+          ...(existing.shop_id !== null ? { shop_id: existing.shop_id } : {}),
+        },
       });
 
       this.logger.log(
@@ -149,7 +256,7 @@ export class CategoriesService {
     return { category };
   }
 
-  async toggleActive(id: string) {
+  async toggleActive(id: string, opts: { tenantId?: string | null; isPlatformSuper?: boolean }) {
     const existing = await this.prisma.category.findUnique({
       where: { id },
     });
@@ -157,6 +264,8 @@ export class CategoriesService {
     if (!existing) {
       throw new NotFoundException('Danh mục không tồn tại');
     }
+
+    this.assertCanMutateCategory(existing.shop_id, opts);
 
     const category = await this.prisma.category.update({
       where: { id },
@@ -170,7 +279,7 @@ export class CategoriesService {
     return { category };
   }
 
-  async remove(id: string) {
+  async remove(id: string, opts: { tenantId?: string | null; isPlatformSuper?: boolean }) {
     const existing = await this.prisma.category.findUnique({
       where: { id },
     });
@@ -179,7 +288,8 @@ export class CategoriesService {
       throw new NotFoundException('Danh mục không tồn tại');
     }
 
-    // Check if any items are using this category
+    this.assertCanMutateCategory(existing.shop_id, opts);
+
     const itemField = CATEGORY_TYPE_TO_ITEM_FIELD[existing.type];
     if (!itemField) {
       throw new ConflictException(
@@ -187,11 +297,16 @@ export class CategoriesService {
       );
     }
 
+    const usageWhere: Prisma.ItemWhereInput = {
+      [itemField]: existing.name,
+      deleted_at: null,
+    };
+    if (existing.shop_id !== null) {
+      usageWhere.shop_id = existing.shop_id;
+    }
+
     const usageCount = await this.prisma.item.count({
-      where: {
-        [itemField]: existing.name,
-        deleted_at: null,
-      },
+      where: usageWhere,
     });
 
     if (usageCount > 0) {
@@ -207,5 +322,139 @@ export class CategoriesService {
     this.logger.log(`Category deleted: ${existing.name} (${existing.type})`);
 
     return { message: 'Đã xoá danh mục thành công' };
+  }
+
+  /**
+   * AI item create: ensure shop-scoped Category rows for car/model brand strings.
+   * Does not modify global (shop_id null) seed rows.
+   */
+  async ensureCategoriesForAiImportInTx(
+    tx: Prisma.TransactionClient,
+    shopId: string,
+    carBrand?: string | null,
+    modelBrand?: string | null,
+  ) {
+    const specs: Array<{ type: 'car_brand' | 'model_brand'; value?: string | null }> = [
+      { type: 'car_brand', value: carBrand },
+      { type: 'model_brand', value: modelBrand },
+    ];
+
+    for (const spec of specs) {
+      const trimmed =
+        typeof spec.value === 'string' ? spec.value.trim() : '';
+      if (!trimmed) continue;
+
+      const existingShop = await tx.category.findFirst({
+        where: { type: spec.type, name: trimmed, shop_id: shopId },
+      });
+      const existingGlobal = await tx.category.findFirst({
+        where: { type: spec.type, name: trimmed, shop_id: null },
+      });
+      const existing = existingShop ?? existingGlobal;
+
+      if (!existing) {
+        const maxOrder = await tx.category.aggregate({
+          where: { type: spec.type, shop_id: shopId },
+          _max: { display_order: true },
+        });
+        const displayOrder = (maxOrder._max.display_order ?? -1) + 1;
+
+        try {
+          await tx.category.create({
+            data: {
+              shop_id: shopId,
+              name: trimmed,
+              type: spec.type,
+              is_active: true,
+              display_order: displayOrder,
+            },
+          });
+        } catch (error) {
+          if (!isPrismaUniqueConstraintError(error)) {
+            throw error;
+          }
+          const afterRace = await tx.category.findFirst({
+            where: { type: spec.type, name: trimmed, shop_id: shopId },
+          });
+          if (afterRace && !afterRace.is_active) {
+            await tx.category.update({
+              where: { id: afterRace.id },
+              data: { is_active: true },
+            });
+          }
+        }
+        continue;
+      }
+
+      if (!existing.is_active && existing.shop_id === shopId) {
+        await tx.category.update({
+          where: { id: existing.id },
+          data: { is_active: true },
+        });
+      }
+    }
+  }
+
+  async validateCategoryMetadataForShop(
+    shopId: string,
+    carBrand?: string | null,
+    modelBrand?: string | null,
+    db: Prisma.TransactionClient | PrismaService = this.prisma,
+  ) {
+    const checks: Array<{ type: 'car_brand' | 'model_brand'; value?: string | null }> = [
+      { type: 'car_brand', value: carBrand },
+      { type: 'model_brand', value: modelBrand },
+    ];
+
+    for (const check of checks) {
+      const normalized = normalizeCategoryBrandField(check.value);
+      if (!normalized) continue;
+
+      const shopCat = await db.category.findFirst({
+        where: {
+          type: check.type,
+          name: normalized,
+          shop_id: shopId,
+          is_active: true,
+        },
+      });
+      const globalCat =
+        shopCat ??
+        (await db.category.findFirst({
+          where: {
+            type: check.type,
+            name: normalized,
+            shop_id: null,
+            is_active: true,
+          },
+        }));
+
+      if (!globalCat) {
+        throw new AppException(
+          ErrorCode.ITEM_CATEGORY_INVALID,
+          `Invalid ${check.type} value "${normalized}". Category must exist and be active.`,
+          [{ type: check.type, value: normalized }],
+        );
+      }
+    }
+  }
+
+  private assertCanMutateCategory(
+    categoryShopId: string | null,
+    opts: { tenantId?: string | null; isPlatformSuper?: boolean },
+  ) {
+    if (opts.isPlatformSuper) {
+      return;
+    }
+    if (categoryShopId === null) {
+      throw new ForbiddenException('Chỉ quản trị nền tảng mới sửa được danh mục chung.');
+    }
+    const tid =
+      typeof opts.tenantId === 'string' && opts.tenantId.trim().length > 0
+        ? opts.tenantId.trim()
+        : null;
+    if (!tid || tid !== categoryShopId) {
+      throw new ForbiddenException('Không có quyền thao tác danh mục của shop khác.');
+    }
   }
 }

--- a/backend/src/categories/dto/query-categories.dto.ts
+++ b/backend/src/categories/dto/query-categories.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, IsIn } from 'class-validator';
+import { IsOptional, IsString, IsIn, MaxLength } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 export class QueryCategoriesDto {
@@ -6,6 +6,12 @@ export class QueryCategoriesDto {
   @IsString()
   @IsIn(['car_brand', 'model_brand'])
   type?: string;
+
+  /** UUID or shop slug — merges global seed categories with this shop's categories */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  shop_id?: string;
 
   @IsOptional()
   @Transform(({ value }) => {

--- a/backend/src/common/utils/category-brand.utils.ts
+++ b/backend/src/common/utils/category-brand.utils.ts
@@ -1,0 +1,8 @@
+/** Normalizes optional car_brand / model_brand values (trim; empty → null). */
+export function normalizeCategoryBrandField(value: string | undefined | null): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const t = typeof value === 'string' ? value.trim() : '';
+  return t.length === 0 ? null : t;
+}

--- a/backend/src/common/utils/category-brand.utils.ts
+++ b/backend/src/common/utils/category-brand.utils.ts
@@ -1,3 +1,6 @@
+/** Same max length as admin category create (`CreateCategoryDto`). */
+export const MAX_CATEGORY_BRAND_NAME_LENGTH = 100;
+
 /** Normalizes optional car_brand / model_brand values (trim; empty → null). */
 export function normalizeCategoryBrandField(value: string | undefined | null): string | null {
   if (value === undefined || value === null) {

--- a/backend/src/items/dto/create-item.dto.ts
+++ b/backend/src/items/dto/create-item.dto.ts
@@ -75,13 +75,6 @@ export class CreateItemDto {
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsString()
   draft_id?: string;
-
-  /**
-   * AI import flow only: auto-create missing categories when paired with a valid `draft_id`.
-   */
-  @IsOptional()
-  @IsBoolean()
-  from_ai_import?: boolean;
 }
 
 

--- a/backend/src/items/dto/create-item.dto.ts
+++ b/backend/src/items/dto/create-item.dto.ts
@@ -75,6 +75,11 @@ export class CreateItemDto {
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsString()
   draft_id?: string;
+
+  /** When true (AI import flow), missing car/model brand categories are created automatically. */
+  @IsOptional()
+  @IsBoolean()
+  from_ai_import?: boolean;
 }
 
 

--- a/backend/src/items/dto/create-item.dto.ts
+++ b/backend/src/items/dto/create-item.dto.ts
@@ -1,7 +1,20 @@
-import { IsString, IsOptional, IsBoolean, IsIn, IsNumber, Min, IsEnum, IsNotEmpty, IsInt, ValidateIf } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsIn,
+  IsNumber,
+  Min,
+  IsEnum,
+  IsNotEmpty,
+  IsInt,
+  ValidateIf,
+  MaxLength,
+} from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ItemStatus } from '../../generated/prisma/client';
 import { IsItemAttributes, type ItemAttributesInput } from './item-attributes.validator';
+import { MAX_CATEGORY_BRAND_NAME_LENGTH } from '../../common/utils/category-brand.utils';
 
 export class CreateItemDto {
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
@@ -29,12 +42,14 @@ export class CreateItemDto {
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsString()
   @IsNotEmpty()
+  @MaxLength(MAX_CATEGORY_BRAND_NAME_LENGTH)
   car_brand?: string;
 
   @IsOptional()
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsString()
   @IsNotEmpty()
+  @MaxLength(MAX_CATEGORY_BRAND_NAME_LENGTH)
   model_brand?: string;
 
   @IsOptional()

--- a/backend/src/items/dto/create-item.dto.ts
+++ b/backend/src/items/dto/create-item.dto.ts
@@ -76,7 +76,9 @@ export class CreateItemDto {
   @IsString()
   draft_id?: string;
 
-  /** When true (AI import flow), missing car/model brand categories are created automatically. */
+  /**
+   * AI import flow only: auto-create missing categories when paired with a valid `draft_id`.
+   */
   @IsOptional()
   @IsBoolean()
   from_ai_import?: boolean;

--- a/backend/src/items/dto/update-item.dto.ts
+++ b/backend/src/items/dto/update-item.dto.ts
@@ -76,10 +76,5 @@ export class UpdateItemDto {
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsString()
   fb_post_content?: string;
-
-  /** When true (AI import flow), missing car/model brand categories are created automatically. */
-  @IsOptional()
-  @IsBoolean()
-  from_ai_import?: boolean;
 }
 

--- a/backend/src/items/dto/update-item.dto.ts
+++ b/backend/src/items/dto/update-item.dto.ts
@@ -76,5 +76,10 @@ export class UpdateItemDto {
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsString()
   fb_post_content?: string;
+
+  /** When true (AI import flow), missing car/model brand categories are created automatically. */
+  @IsOptional()
+  @IsBoolean()
+  from_ai_import?: boolean;
 }
 

--- a/backend/src/items/dto/update-item.dto.ts
+++ b/backend/src/items/dto/update-item.dto.ts
@@ -1,7 +1,20 @@
-import { IsString, IsOptional, IsBoolean, IsIn, IsNumber, Min, IsEnum, IsNotEmpty, IsInt, ValidateIf } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsIn,
+  IsNumber,
+  Min,
+  IsEnum,
+  IsNotEmpty,
+  IsInt,
+  ValidateIf,
+  MaxLength,
+} from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { ItemStatus } from '../../generated/prisma/client';
 import { IsItemAttributes, type ItemAttributesInput } from './item-attributes.validator';
+import { MAX_CATEGORY_BRAND_NAME_LENGTH } from '../../common/utils/category-brand.utils';
 
 export class UpdateItemDto {
   @IsOptional()
@@ -30,12 +43,14 @@ export class UpdateItemDto {
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsString()
   @IsNotEmpty()
+  @MaxLength(MAX_CATEGORY_BRAND_NAME_LENGTH)
   car_brand?: string;
 
   @IsOptional()
   @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
   @IsString()
   @IsNotEmpty()
+  @MaxLength(MAX_CATEGORY_BRAND_NAME_LENGTH)
   model_brand?: string;
 
   @IsOptional()

--- a/backend/src/items/items.module.ts
+++ b/backend/src/items/items.module.ts
@@ -5,11 +5,12 @@ import { AiModule } from '../ai/ai.module';
 import { PrismaModule } from '../common/prisma/prisma.module';
 import { StorageModule } from '../storage/storage.module';
 import { FacebookModule } from '../integrations/facebook/facebook.module';
+import { CategoriesModule } from '../categories/categories.module';
 
 import { AiDraftController } from './ai-draft.controller';
 
 @Module({
-  imports: [PrismaModule, StorageModule, AiModule, FacebookModule],
+  imports: [PrismaModule, StorageModule, AiModule, FacebookModule, CategoriesModule],
   controllers: [ItemsController, AiDraftController],
   providers: [ItemsService],
   exports: [ItemsService],

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -8,6 +8,7 @@ import { AppException } from '../common/exceptions/http-exception.filter';
 import { ItemStatus } from '../generated/prisma/client';
 import { FacebookGraphService } from '../integrations/facebook/facebook-graph.service';
 import { FacebookConfigService } from '../integrations/facebook/facebook-config.service';
+import { CategoriesService } from '../categories/categories.service';
 
 
 describe('ItemsService', () => {
@@ -139,6 +140,7 @@ describe('ItemsService', () => {
         { provide: EmbeddingService, useValue: embeddingService },
         { provide: FacebookGraphService, useValue: mockFacebookGraph },
         { provide: FacebookConfigService, useValue: mockFbConfig },
+        CategoriesService,
       ],
     }).compile();
 
@@ -242,7 +244,9 @@ describe('ItemsService', () => {
     });
 
     it('should reject create when category metadata is invalid', async () => {
-      prisma.category.findFirst.mockResolvedValue(null);
+      prisma.category.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
 
       await expect(
         service.create({ name: 'Test Item', car_brand: 'Unknown Brand' }, TEST_SHOP_ID),
@@ -253,7 +257,6 @@ describe('ItemsService', () => {
 
     it('should create item without draft processing when draft_id does not exist', async () => {
       prisma.aiItemDraft.findUnique.mockResolvedValue(null);
-      prisma.category.findFirst.mockResolvedValue(null);
 
       const result = await service.create(
         {
@@ -296,14 +299,18 @@ describe('ItemsService', () => {
       prisma.category.findFirst
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({
           id: 'c-nissan',
+          shop_id: TEST_SHOP_ID,
           type: 'car_brand',
           name: 'Nissan',
           is_active: true,
         })
         .mockResolvedValueOnce({
           id: 'm-gtr',
+          shop_id: TEST_SHOP_ID,
           type: 'model_brand',
           name: 'GT-R R35',
           is_active: true,
@@ -324,6 +331,7 @@ describe('ItemsService', () => {
       expect(prisma.category.create).toHaveBeenCalledTimes(2);
       expect(prisma.category.create).toHaveBeenNthCalledWith(1, {
         data: expect.objectContaining({
+          shop_id: TEST_SHOP_ID,
           name: 'Nissan',
           type: 'car_brand',
           is_active: true,
@@ -332,6 +340,7 @@ describe('ItemsService', () => {
       });
       expect(prisma.category.create).toHaveBeenNthCalledWith(2, {
         data: expect.objectContaining({
+          shop_id: TEST_SHOP_ID,
           name: 'GT-R R35',
           type: 'model_brand',
           is_active: true,
@@ -345,27 +354,32 @@ describe('ItemsService', () => {
         id: 'draft-1',
         images_json: JSON.stringify([]),
       });
+
       prisma.category.findFirst
         .mockResolvedValueOnce({
           id: 'c-toyota',
+          shop_id: TEST_SHOP_ID,
           type: 'car_brand',
           name: 'Toyota',
           is_active: false,
         })
         .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({
           id: 'c-toyota',
+          shop_id: TEST_SHOP_ID,
           type: 'car_brand',
           name: 'Toyota',
           is_active: true,
         })
         .mockResolvedValueOnce({
           id: 'm-ae86',
+          shop_id: TEST_SHOP_ID,
           type: 'model_brand',
           name: 'AE86',
           is_active: true,
         });
-
       prisma.category.aggregate.mockResolvedValue({ _max: { display_order: 5 } });
       prisma.category.create.mockResolvedValue({ id: 'new-model' });
 
@@ -394,14 +408,18 @@ describe('ItemsService', () => {
       prisma.category.findFirst
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({
           id: 'c-nissan',
+          shop_id: TEST_SHOP_ID,
           type: 'car_brand',
           name: 'Nissan',
           is_active: true,
         })
         .mockResolvedValueOnce({
           id: 'm-gtr',
+          shop_id: TEST_SHOP_ID,
           type: 'model_brand',
           name: 'GT-R R35',
           is_active: true,
@@ -809,6 +827,7 @@ describe('ItemsService', () => {
         where: {
           type: 'car_brand',
           name: 'Toyota',
+          shop_id: TEST_SHOP_ID,
           is_active: true,
         },
       });

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -280,6 +280,7 @@ describe('ItemsService', () => {
         errorCode: ErrorCode.VALIDATION_ERROR,
       });
       expect(prisma.category.create).not.toHaveBeenCalled();
+      expect(prisma.item.create).not.toHaveBeenCalled();
     });
 
     it('should create missing car_brand and model_brand categories when from_ai_import is true', async () => {
@@ -387,6 +388,51 @@ describe('ItemsService', () => {
         data: { is_active: true },
       });
       expect(prisma.category.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should trim car_brand and model_brand so validation matches ensured categories', async () => {
+      prisma.aiItemDraft.findUnique
+        .mockResolvedValueOnce({ id: 'draft-1' })
+        .mockResolvedValueOnce({
+          id: 'draft-1',
+          images_json: JSON.stringify([]),
+          status: 'PENDING',
+        });
+      prisma.category.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          id: 'c-nissan',
+          type: 'car_brand',
+          name: 'Nissan',
+          is_active: true,
+        })
+        .mockResolvedValueOnce({
+          id: 'm-gtr',
+          type: 'model_brand',
+          name: 'GT-R R35',
+          is_active: true,
+        });
+      prisma.category.aggregate.mockResolvedValue({ _max: { display_order: 10 } });
+      prisma.category.create.mockResolvedValue({ id: 'new-id' });
+
+      await service.create(
+        {
+          name: 'AI Item',
+          draft_id: 'draft-1',
+          car_brand: '  Nissan ',
+          model_brand: ' GT-R R35 ',
+          from_ai_import: true,
+        },
+        TEST_SHOP_ID,
+      );
+
+      expect(prisma.item.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          car_brand: 'Nissan',
+          model_brand: 'GT-R R35',
+        }),
+      });
     });
 
     it('should reject create when original_price is lower than price', async () => {
@@ -745,6 +791,38 @@ describe('ItemsService', () => {
       expect(prisma.item.update).toHaveBeenCalledWith({
         where: { id: 'item-123' },
         data: expect.objectContaining({ name: 'Updated Name' }),
+      });
+    });
+
+    it('should trim car_brand when validating category metadata on update', async () => {
+      prisma.item.findFirst.mockResolvedValue({
+        ...mockItem,
+        car_brand: null,
+        model_brand: null,
+      });
+      prisma.category.findFirst.mockResolvedValue({
+        id: 'c-t',
+        type: 'car_brand',
+        name: 'Toyota',
+        is_active: true,
+      });
+      prisma.item.update.mockResolvedValue({
+        ...mockItem,
+        car_brand: 'Toyota',
+      });
+
+      await service.update('item-123', { car_brand: '  Toyota ' }, TEST_SHOP_ID);
+
+      expect(prisma.category.findFirst).toHaveBeenCalledWith({
+        where: {
+          type: 'car_brand',
+          name: 'Toyota',
+          is_active: true,
+        },
+      });
+      expect(prisma.item.update).toHaveBeenCalledWith({
+        where: { id: 'item-123' },
+        data: expect.objectContaining({ car_brand: 'Toyota' }),
       });
     });
 

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -270,6 +270,26 @@ describe('ItemsService', () => {
       expect(prisma.item.create).not.toHaveBeenCalled();
     });
 
+    it('should reject create when draft images_json is not valid JSON', async () => {
+      prisma.aiItemDraft.findUnique.mockResolvedValue({
+        id: 'draft-bad',
+        images_json: 'not-json',
+      });
+
+      await expect(
+        service.create(
+          {
+            name: 'AI Item',
+            draft_id: 'draft-bad',
+          },
+          TEST_SHOP_ID,
+        ),
+      ).rejects.toMatchObject({
+        errorCode: ErrorCode.VALIDATION_ERROR,
+      });
+      expect(prisma.item.create).not.toHaveBeenCalled();
+    });
+
     it('should create missing car_brand and model_brand categories when creating from an AI draft', async () => {
       prisma.aiItemDraft.findUnique.mockResolvedValue({
         id: 'draft-1',

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -251,26 +251,13 @@ describe('ItemsService', () => {
       });
     });
 
-    it('should reject create when from_ai_import is true without draft_id', async () => {
-      await expect(
-        service.create(
-          { name: 'AI Item', from_ai_import: true, car_brand: 'X' },
-          TEST_SHOP_ID,
-        ),
-      ).rejects.toMatchObject({
-        errorCode: ErrorCode.VALIDATION_ERROR,
-      });
-      expect(prisma.category.create).not.toHaveBeenCalled();
-    });
-
-    it('should reject create when from_ai_import is true but draft does not exist', async () => {
+    it('should reject create when draft_id is provided but draft does not exist', async () => {
       prisma.aiItemDraft.findUnique.mockResolvedValue(null);
 
       await expect(
         service.create(
           {
             name: 'AI Item',
-            from_ai_import: true,
             draft_id: 'missing-draft',
             car_brand: 'X',
           },
@@ -283,14 +270,11 @@ describe('ItemsService', () => {
       expect(prisma.item.create).not.toHaveBeenCalled();
     });
 
-    it('should create missing car_brand and model_brand categories when from_ai_import is true', async () => {
-      prisma.aiItemDraft.findUnique
-        .mockResolvedValueOnce({ id: 'draft-1' })
-        .mockResolvedValueOnce({
-          id: 'draft-1',
-          images_json: JSON.stringify([]),
-          status: 'PENDING',
-        });
+    it('should create missing car_brand and model_brand categories when creating from an AI draft', async () => {
+      prisma.aiItemDraft.findUnique.mockResolvedValue({
+        id: 'draft-1',
+        images_json: JSON.stringify([]),
+      });
       prisma.category.findFirst
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)
@@ -315,7 +299,6 @@ describe('ItemsService', () => {
           draft_id: 'draft-1',
           car_brand: 'Nissan',
           model_brand: 'GT-R R35',
-          from_ai_import: true,
         },
         TEST_SHOP_ID,
       );
@@ -339,15 +322,11 @@ describe('ItemsService', () => {
       });
     });
 
-    it('should reactivate inactive car_brand category when from_ai_import is true', async () => {
-      prisma.aiItemDraft.findUnique
-        .mockResolvedValueOnce({ id: 'draft-1' })
-        .mockResolvedValueOnce({
-          id: 'draft-1',
-          images_json: JSON.stringify([]),
-          status: 'PENDING',
-        });
-
+    it('should reactivate inactive car_brand category when creating from an AI draft', async () => {
+      prisma.aiItemDraft.findUnique.mockResolvedValue({
+        id: 'draft-1',
+        images_json: JSON.stringify([]),
+      });
       prisma.category.findFirst
         .mockResolvedValueOnce({
           id: 'c-toyota',
@@ -378,7 +357,6 @@ describe('ItemsService', () => {
           draft_id: 'draft-1',
           car_brand: 'Toyota',
           model_brand: 'AE86',
-          from_ai_import: true,
         },
         TEST_SHOP_ID,
       );
@@ -391,13 +369,10 @@ describe('ItemsService', () => {
     });
 
     it('should trim car_brand and model_brand so validation matches ensured categories', async () => {
-      prisma.aiItemDraft.findUnique
-        .mockResolvedValueOnce({ id: 'draft-1' })
-        .mockResolvedValueOnce({
-          id: 'draft-1',
-          images_json: JSON.stringify([]),
-          status: 'PENDING',
-        });
+      prisma.aiItemDraft.findUnique.mockResolvedValue({
+        id: 'draft-1',
+        images_json: JSON.stringify([]),
+      });
       prisma.category.findFirst
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)
@@ -422,7 +397,6 @@ describe('ItemsService', () => {
           draft_id: 'draft-1',
           car_brand: '  Nissan ',
           model_brand: ' GT-R R35 ',
-          from_ai_import: true,
         },
         TEST_SHOP_ID,
       );

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -251,7 +251,45 @@ describe('ItemsService', () => {
       });
     });
 
+    it('should reject create when from_ai_import is true without draft_id', async () => {
+      await expect(
+        service.create(
+          { name: 'AI Item', from_ai_import: true, car_brand: 'X' },
+          TEST_SHOP_ID,
+        ),
+      ).rejects.toMatchObject({
+        errorCode: ErrorCode.VALIDATION_ERROR,
+      });
+      expect(prisma.category.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject create when from_ai_import is true but draft does not exist', async () => {
+      prisma.aiItemDraft.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.create(
+          {
+            name: 'AI Item',
+            from_ai_import: true,
+            draft_id: 'missing-draft',
+            car_brand: 'X',
+          },
+          TEST_SHOP_ID,
+        ),
+      ).rejects.toMatchObject({
+        errorCode: ErrorCode.VALIDATION_ERROR,
+      });
+      expect(prisma.category.create).not.toHaveBeenCalled();
+    });
+
     it('should create missing car_brand and model_brand categories when from_ai_import is true', async () => {
+      prisma.aiItemDraft.findUnique
+        .mockResolvedValueOnce({ id: 'draft-1' })
+        .mockResolvedValueOnce({
+          id: 'draft-1',
+          images_json: JSON.stringify([]),
+          status: 'PENDING',
+        });
       prisma.category.findFirst
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null)
@@ -273,6 +311,7 @@ describe('ItemsService', () => {
       await service.create(
         {
           name: 'AI Item',
+          draft_id: 'draft-1',
           car_brand: 'Nissan',
           model_brand: 'GT-R R35',
           from_ai_import: true,
@@ -297,6 +336,57 @@ describe('ItemsService', () => {
           display_order: 11,
         }),
       });
+    });
+
+    it('should reactivate inactive car_brand category when from_ai_import is true', async () => {
+      prisma.aiItemDraft.findUnique
+        .mockResolvedValueOnce({ id: 'draft-1' })
+        .mockResolvedValueOnce({
+          id: 'draft-1',
+          images_json: JSON.stringify([]),
+          status: 'PENDING',
+        });
+
+      prisma.category.findFirst
+        .mockResolvedValueOnce({
+          id: 'c-toyota',
+          type: 'car_brand',
+          name: 'Toyota',
+          is_active: false,
+        })
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          id: 'c-toyota',
+          type: 'car_brand',
+          name: 'Toyota',
+          is_active: true,
+        })
+        .mockResolvedValueOnce({
+          id: 'm-ae86',
+          type: 'model_brand',
+          name: 'AE86',
+          is_active: true,
+        });
+
+      prisma.category.aggregate.mockResolvedValue({ _max: { display_order: 5 } });
+      prisma.category.create.mockResolvedValue({ id: 'new-model' });
+
+      await service.create(
+        {
+          name: 'AI Item',
+          draft_id: 'draft-1',
+          car_brand: 'Toyota',
+          model_brand: 'AE86',
+          from_ai_import: true,
+        },
+        TEST_SHOP_ID,
+      );
+
+      expect(prisma.category.update).toHaveBeenCalledWith({
+        where: { id: 'c-toyota' },
+        data: { is_active: true },
+      });
+      expect(prisma.category.create).toHaveBeenCalledTimes(1);
     });
 
     it('should reject create when original_price is lower than price', async () => {

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -251,23 +251,21 @@ describe('ItemsService', () => {
       });
     });
 
-    it('should reject create when draft_id is provided but draft does not exist', async () => {
+    it('should create item without draft processing when draft_id does not exist', async () => {
       prisma.aiItemDraft.findUnique.mockResolvedValue(null);
+      prisma.category.findFirst.mockResolvedValue(null);
 
-      await expect(
-        service.create(
-          {
-            name: 'AI Item',
-            draft_id: 'missing-draft',
-            car_brand: 'X',
-          },
-          TEST_SHOP_ID,
-        ),
-      ).rejects.toMatchObject({
-        errorCode: ErrorCode.VALIDATION_ERROR,
-      });
+      const result = await service.create(
+        {
+          name: 'AI Item',
+          draft_id: 'missing-draft',
+        },
+        TEST_SHOP_ID,
+      );
+
+      expect(result.item).toBeDefined();
       expect(prisma.category.create).not.toHaveBeenCalled();
-      expect(prisma.item.create).not.toHaveBeenCalled();
+      expect(storage.moveFile).not.toHaveBeenCalled();
     });
 
     it('should reject create when draft images_json is not valid JSON', async () => {

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -93,6 +93,9 @@ describe('ItemsService', () => {
       },
       category: {
         findFirst: jest.fn(),
+        create: jest.fn(),
+        aggregate: jest.fn(),
+        update: jest.fn(),
       },
       aiItemDraft: {
         findUnique: jest.fn(),
@@ -245,6 +248,54 @@ describe('ItemsService', () => {
         service.create({ name: 'Test Item', car_brand: 'Unknown Brand' }, TEST_SHOP_ID),
       ).rejects.toMatchObject({
         errorCode: ErrorCode.ITEM_CATEGORY_INVALID,
+      });
+    });
+
+    it('should create missing car_brand and model_brand categories when from_ai_import is true', async () => {
+      prisma.category.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          id: 'c-nissan',
+          type: 'car_brand',
+          name: 'Nissan',
+          is_active: true,
+        })
+        .mockResolvedValueOnce({
+          id: 'm-gtr',
+          type: 'model_brand',
+          name: 'GT-R R35',
+          is_active: true,
+        });
+      prisma.category.aggregate.mockResolvedValue({ _max: { display_order: 10 } });
+      prisma.category.create.mockResolvedValue({ id: 'new-id' });
+
+      await service.create(
+        {
+          name: 'AI Item',
+          car_brand: 'Nissan',
+          model_brand: 'GT-R R35',
+          from_ai_import: true,
+        },
+        TEST_SHOP_ID,
+      );
+
+      expect(prisma.category.create).toHaveBeenCalledTimes(2);
+      expect(prisma.category.create).toHaveBeenNthCalledWith(1, {
+        data: expect.objectContaining({
+          name: 'Nissan',
+          type: 'car_brand',
+          is_active: true,
+          display_order: 11,
+        }),
+      });
+      expect(prisma.category.create).toHaveBeenNthCalledWith(2, {
+        data: expect.objectContaining({
+          name: 'GT-R R35',
+          type: 'model_brand',
+          is_active: true,
+          display_order: 11,
+        }),
       });
     });
 

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -291,6 +291,29 @@ describe('ItemsService', () => {
       expect(prisma.item.create).not.toHaveBeenCalled();
     });
 
+    it('should reject create when car_brand exceeds max category name length (AI draft)', async () => {
+      prisma.aiItemDraft.findUnique.mockResolvedValue({
+        id: 'draft-1',
+        images_json: JSON.stringify([]),
+      });
+      const longBrand = 'x'.repeat(101);
+
+      await expect(
+        service.create(
+          {
+            name: 'AI Item',
+            draft_id: 'draft-1',
+            car_brand: longBrand,
+          },
+          TEST_SHOP_ID,
+        ),
+      ).rejects.toMatchObject({
+        errorCode: ErrorCode.ITEM_CATEGORY_INVALID,
+      });
+
+      expect(prisma.category.create).not.toHaveBeenCalled();
+    });
+
     it('should create missing car_brand and model_brand categories when creating from an AI draft', async () => {
       prisma.aiItemDraft.findUnique.mockResolvedValue({
         id: 'draft-1',

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { Prisma, ItemStatus } from '../generated/prisma/client';
 import { PrismaService } from '../common/prisma/prisma.service';
-import { isPrismaUniqueConstraintError } from '../common/prisma/prisma-error.utils';
 import { IStorageService } from '../storage/storage.interface';
 import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
 import { CreateItemDto } from './dto/create-item.dto';
@@ -16,6 +15,8 @@ import { FacebookGraphService } from '../integrations/facebook/facebook-graph.se
 import { FacebookConfigService } from '../integrations/facebook/facebook-config.service';
 import { PublishFacebookPostDto } from './dto/publish-facebook-post.dto';
 import type { ItemAttributesInput } from './dto/item-attributes.validator';
+import { CategoriesService } from '../categories/categories.service';
+import { normalizeCategoryBrandField } from '../common/utils/category-brand.utils';
 
 const ALLOWED_STATUS_TRANSITIONS: Record<ItemStatus, ItemStatus[]> = {
   con_hang: ['con_hang', 'giu_cho', 'da_ban'],
@@ -41,15 +42,6 @@ function resolveQuantityForStatus(status: ItemStatus, requestedQuantity?: number
     return getInitialQuantityForStatus(status);
   }
   return requestedQuantity;
-}
-
-/** Trims and collapses empty optional brand fields to null (car_brand / model_brand). */
-function normalizeCategoryBrandField(value: string | undefined | null): string | null {
-  if (value === undefined || value === null) {
-    return null;
-  }
-  const t = typeof value === 'string' ? value.trim() : '';
-  return t.length === 0 ? null : t;
 }
 
 function parseDraftImageUrls(imagesJson: string): string[] {
@@ -82,6 +74,7 @@ export class ItemsService {
     // to detect whether the feature is enabled instead of null-checking the service.
     private facebookGraph: FacebookGraphService,
     private fbConfig: FacebookConfigService,
+    private categoriesService: CategoriesService,
   ) {}
 
   /**
@@ -410,10 +403,20 @@ Condition: ${item.condition || ''}`;
           if (aiDraftForCategories.images_json) {
             draftImageUrls = parseDraftImageUrls(aiDraftForCategories.images_json);
           }
-          await this.ensureCategoriesForAiImportInTx(tx, carBrandNorm, modelBrandNorm);
+          await this.categoriesService.ensureCategoriesForAiImportInTx(
+            tx,
+            shopId,
+            carBrandNorm,
+            modelBrandNorm,
+          );
         }
       }
-      await this.validateCategoryMetadata(carBrandNorm, modelBrandNorm, tx);
+      await this.categoriesService.validateCategoryMetadataForShop(
+        shopId,
+        carBrandNorm,
+        modelBrandNorm,
+        tx,
+      );
 
       const item = await tx.item.create({
         data: {
@@ -574,7 +577,7 @@ Condition: ${item.condition || ''}`;
     if (updateDto.is_public !== undefined) updateData.is_public = updateDto.is_public;
     if (updateDto.fb_post_content !== undefined) updateData.fb_post_content = updateDto.fb_post_content;
 
-    if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
+      if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
       const nextCarBrand =
         updateDto.car_brand !== undefined
           ? normalizeCategoryBrandField(updateDto.car_brand)
@@ -583,7 +586,11 @@ Condition: ${item.condition || ''}`;
         updateDto.model_brand !== undefined
           ? normalizeCategoryBrandField(updateDto.model_brand)
           : normalizeCategoryBrandField(existingItem.model_brand);
-      await this.validateCategoryMetadata(nextCarBrand, nextModelBrand);
+      await this.categoriesService.validateCategoryMetadataForShop(
+        shopId,
+        nextCarBrand,
+        nextModelBrand,
+      );
     }
 
     const item = await this.prisma.item.update({
@@ -928,103 +935,6 @@ Condition: ${item.condition || ''}`;
         `Invalid item status transition from "${current}" to "${next}"`,
         [{ from: current, to: next }],
       );
-    }
-  }
-
-  /**
-   * Ensures car_brand and model_brand names exist as Category rows (active).
-   * Used by AI import so extracted names appear in admin category lists without manual setup.
-   */
-  private async ensureCategoriesForAiImportInTx(
-    tx: Prisma.TransactionClient,
-    carBrand?: string | null,
-    modelBrand?: string | null,
-  ) {
-    const specs: Array<{ type: 'car_brand' | 'model_brand'; value?: string | null }> = [
-      { type: 'car_brand', value: carBrand },
-      { type: 'model_brand', value: modelBrand },
-    ];
-
-    for (const spec of specs) {
-      const trimmed =
-        typeof spec.value === 'string' ? spec.value.trim() : '';
-      if (!trimmed) continue;
-
-      const existing = await tx.category.findFirst({
-        where: { type: spec.type, name: trimmed },
-      });
-
-      if (!existing) {
-        const maxOrder = await tx.category.aggregate({
-          where: { type: spec.type },
-          _max: { display_order: true },
-        });
-        const displayOrder = (maxOrder._max.display_order ?? -1) + 1;
-
-        try {
-          await tx.category.create({
-            data: {
-              name: trimmed,
-              type: spec.type,
-              is_active: true,
-              display_order: displayOrder,
-            },
-          });
-        } catch (error) {
-          if (!isPrismaUniqueConstraintError(error)) {
-            throw error;
-          }
-          const afterRace = await tx.category.findFirst({
-            where: { type: spec.type, name: trimmed },
-          });
-          if (afterRace && !afterRace.is_active) {
-            await tx.category.update({
-              where: { id: afterRace.id },
-              data: { is_active: true },
-            });
-          }
-        }
-        continue;
-      }
-
-      if (!existing.is_active) {
-        await tx.category.update({
-          where: { id: existing.id },
-          data: { is_active: true },
-        });
-      }
-    }
-  }
-
-  private async validateCategoryMetadata(
-    carBrand?: string | null,
-    modelBrand?: string | null,
-    db: Prisma.TransactionClient | PrismaService = this.prisma,
-  ) {
-    const checks: Array<{ type: 'car_brand' | 'model_brand'; value?: string | null }> = [
-      { type: 'car_brand', value: carBrand },
-      { type: 'model_brand', value: modelBrand },
-    ];
-
-    for (const check of checks) {
-      const normalized = normalizeCategoryBrandField(check.value);
-      if (!normalized) continue;
-
-      const category = await db.category.findFirst({
-        where: {
-          type: check.type,
-          name: normalized,
-          is_active: true,
-        },
-      });
-
-      if (!category) {
-        throw new AppException(
-          ErrorCode.ITEM_CATEGORY_INVALID,
-          `Invalid ${check.type} value "${normalized}". Category must exist and be active.`,
-          [{ type: check.type, value: normalized }],
-        );
-      }
     }
   }
 

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -358,6 +358,23 @@ Condition: ${item.condition || ''}`;
     const shopId = this.requireActiveShopId(tenantId);
     this.validatePriceFields(createDto.price, createDto.original_price);
 
+    if (createDto.from_ai_import) {
+      const draftId = typeof createDto.draft_id === 'string' ? createDto.draft_id.trim() : '';
+      if (!draftId) {
+        throw new AppException(
+          ErrorCode.VALIDATION_ERROR,
+          'draft_id is required when from_ai_import is true',
+        );
+      }
+      const draftExists = await this.prisma.aiItemDraft.findUnique({
+        where: { id: draftId },
+        select: { id: true },
+      });
+      if (!draftExists) {
+        throw new AppException(ErrorCode.VALIDATION_ERROR, 'AI draft not found');
+      }
+    }
+
     // Declared outside transaction; cleared inside to handle potential retries
     let failedImages: { filename: string; error: string }[] = [];
     let totalImages = 0;
@@ -368,7 +385,7 @@ Condition: ${item.condition || ''}`;
       totalImages = 0;
       const initialStatus = (createDto.status as ItemStatus | undefined) ?? 'con_hang';
 
-      if (createDto.from_ai_import) {
+      if (createDto.from_ai_import && createDto.draft_id) {
         await this.ensureCategoriesForAiImportInTx(
           tx,
           createDto.car_brand,
@@ -538,27 +555,13 @@ Condition: ${item.condition || ''}`;
     if (updateDto.is_public !== undefined) updateData.is_public = updateDto.is_public;
     if (updateDto.fb_post_content !== undefined) updateData.fb_post_content = updateDto.fb_post_content;
 
-    const item = await this.prisma.$transaction(async (tx) => {
-      if (updateDto.from_ai_import) {
-        await this.ensureCategoriesForAiImportInTx(
-          tx,
-          updateDto.car_brand !== undefined ? updateDto.car_brand : existingItem.car_brand,
-          updateDto.model_brand !== undefined ? updateDto.model_brand : existingItem.model_brand,
-        );
-      }
+    if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
+      await this.validateCategoryMetadata(updateDto.car_brand, updateDto.model_brand);
+    }
 
-      if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
-        await this.validateCategoryMetadata(
-          updateDto.car_brand !== undefined ? updateDto.car_brand : existingItem.car_brand,
-          updateDto.model_brand !== undefined ? updateDto.model_brand : existingItem.model_brand,
-          tx,
-        );
-      }
-
-      return tx.item.update({
-        where: { id },
-        data: updateData,
-      });
+    const item = await this.prisma.item.update({
+      where: { id },
+      data: updateData,
     });
 
     // Sync with vector store

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -374,13 +374,6 @@ Condition: ${item.condition || ''}`;
         ? createDto.draft_id.trim()
         : null;
 
-    if (createDto.from_ai_import && !draftIdNorm) {
-      throw new AppException(
-        ErrorCode.VALIDATION_ERROR,
-        'draft_id is required when from_ai_import is true',
-      );
-    }
-
     // Declared outside transaction; cleared inside to handle potential retries
     let failedImages: { filename: string; error: string }[] = [];
     let totalImages = 0;
@@ -391,12 +384,13 @@ Condition: ${item.condition || ''}`;
       totalImages = 0;
       const initialStatus = (createDto.status as ItemStatus | undefined) ?? 'con_hang';
 
-      if (createDto.from_ai_import && draftIdNorm) {
-        const draftRow = await tx.aiItemDraft.findUnique({
+      let aiDraftForCategories: { id: string; images_json: string | null } | null = null;
+      if (draftIdNorm) {
+        aiDraftForCategories = await tx.aiItemDraft.findUnique({
           where: { id: draftIdNorm },
-          select: { id: true },
+          select: { id: true, images_json: true },
         });
-        if (!draftRow) {
+        if (!aiDraftForCategories) {
           throw new AppException(ErrorCode.VALIDATION_ERROR, 'AI draft not found');
         }
         await this.ensureCategoriesForAiImportInTx(tx, carBrandNorm, modelBrandNorm);
@@ -422,54 +416,52 @@ Condition: ${item.condition || ''}`;
         },
       });
 
-      // Handle Draft if provided
-      if (draftIdNorm) {
-        const draft = await tx.aiItemDraft.findUnique({ where: { id: draftIdNorm } });
-        if (draft && draft.images_json) {
-          const imageUrls = JSON.parse(draft.images_json) as string[];
-          totalImages = imageUrls.length;
+      // Handle Draft if provided (single fetch above when draftIdNorm set)
+      if (draftIdNorm && aiDraftForCategories?.images_json) {
+        const draft = aiDraftForCategories;
+        const imageUrls = JSON.parse(draft.images_json) as string[];
+        totalImages = imageUrls.length;
 
-          let displayOrder = 0;
-          for (const url of imageUrls) {
-            const filename = url.split('/').pop();
-            if (filename) {
-              try {
-                const newFilename = `item_${item.id}_${Date.now()}_${Math.floor(Math.random() * 1000)}.jpg`;
-                const newPath = await this.storage.moveFile(`drafts/${filename}`, newFilename, 'images');
+        let displayOrder = 0;
+        for (const url of imageUrls) {
+          const filename = url.split('/').pop();
+          if (filename) {
+            try {
+              const newFilename = `item_${item.id}_${Date.now()}_${Math.floor(Math.random() * 1000)}.jpg`;
+              const newPath = await this.storage.moveFile(`drafts/${filename}`, newFilename, 'images');
 
-                await tx.itemImage.create({
-                  data: {
-                    item_id: item.id,
-                    file_path: newPath,
-                    is_cover: displayOrder === 0,
-                    display_order: displayOrder,
-                  },
-                });
-                displayOrder++;
-              } catch (e) {
-                const errorMessage = e instanceof Error ? e.message : String(e);
-                failedImages.push({ filename, error: errorMessage });
-                this.logger.error(
-                  `Failed to process draft image "${filename}" for item ${item.id}`,
-                  e instanceof Error ? e.stack : undefined,
-                  `ItemsService.create | draftId=${draftIdNorm}`,
-                );
-              }
+              await tx.itemImage.create({
+                data: {
+                  item_id: item.id,
+                  file_path: newPath,
+                  is_cover: displayOrder === 0,
+                  display_order: displayOrder,
+                },
+              });
+              displayOrder++;
+            } catch (e) {
+              const errorMessage = e instanceof Error ? e.message : String(e);
+              failedImages.push({ filename, error: errorMessage });
+              this.logger.error(
+                `Failed to process draft image "${filename}" for item ${item.id}`,
+                e instanceof Error ? e.stack : undefined,
+                `ItemsService.create | draftId=${draftIdNorm}`,
+              );
             }
           }
-
-          // Update draft status based on image processing results
-          const draftStatus = failedImages.length === 0
-            ? 'CONFIRMED'
-            : failedImages.length < totalImages
-              ? 'PARTIAL'
-              : 'FAILED';
-
-          await tx.aiItemDraft.update({
-            where: { id: draft.id },
-            data: { status: draftStatus },
-          });
         }
+
+        // Update draft status based on image processing results
+        const draftStatus = failedImages.length === 0
+          ? 'CONFIRMED'
+          : failedImages.length < totalImages
+            ? 'PARTIAL'
+            : 'FAILED';
+
+        await tx.aiItemDraft.update({
+          where: { id: draft.id },
+          data: { status: draftStatus },
+        });
       }
 
       return item;
@@ -492,7 +484,7 @@ Condition: ${item.condition || ''}`;
 
       this.logger.error(
         `Item ${item.id} created with ${failedImages.length}/${totalImages} failed image(s) ` +
-        `from draft ${createDto.draft_id}. Details: ${failedImages.map((f) => `${f.filename}: ${f.error}`).join('; ')}`,
+        `from draft ${draftIdNorm ?? createDto.draft_id}. Details: ${failedImages.map((f) => `${f.filename}: ${f.error}`).join('; ')}`,
       );
     }
 

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -43,6 +43,15 @@ function resolveQuantityForStatus(status: ItemStatus, requestedQuantity?: number
   return requestedQuantity;
 }
 
+/** Trims and collapses empty optional brand fields to null (car_brand / model_brand). */
+function normalizeCategoryBrandField(value: string | undefined | null): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const t = typeof value === 'string' ? value.trim() : '';
+  return t.length === 0 ? null : t;
+}
+
 @Injectable()
 export class ItemsService {
   private readonly logger = new Logger(ItemsService.name);
@@ -358,21 +367,18 @@ Condition: ${item.condition || ''}`;
     const shopId = this.requireActiveShopId(tenantId);
     this.validatePriceFields(createDto.price, createDto.original_price);
 
-    if (createDto.from_ai_import) {
-      const draftId = typeof createDto.draft_id === 'string' ? createDto.draft_id.trim() : '';
-      if (!draftId) {
-        throw new AppException(
-          ErrorCode.VALIDATION_ERROR,
-          'draft_id is required when from_ai_import is true',
-        );
-      }
-      const draftExists = await this.prisma.aiItemDraft.findUnique({
-        where: { id: draftId },
-        select: { id: true },
-      });
-      if (!draftExists) {
-        throw new AppException(ErrorCode.VALIDATION_ERROR, 'AI draft not found');
-      }
+    const carBrandNorm = normalizeCategoryBrandField(createDto.car_brand);
+    const modelBrandNorm = normalizeCategoryBrandField(createDto.model_brand);
+    const draftIdNorm =
+      typeof createDto.draft_id === 'string' && createDto.draft_id.trim().length > 0
+        ? createDto.draft_id.trim()
+        : null;
+
+    if (createDto.from_ai_import && !draftIdNorm) {
+      throw new AppException(
+        ErrorCode.VALIDATION_ERROR,
+        'draft_id is required when from_ai_import is true',
+      );
     }
 
     // Declared outside transaction; cleared inside to handle potential retries
@@ -385,18 +391,17 @@ Condition: ${item.condition || ''}`;
       totalImages = 0;
       const initialStatus = (createDto.status as ItemStatus | undefined) ?? 'con_hang';
 
-      if (createDto.from_ai_import && createDto.draft_id) {
-        await this.ensureCategoriesForAiImportInTx(
-          tx,
-          createDto.car_brand,
-          createDto.model_brand,
-        );
+      if (createDto.from_ai_import && draftIdNorm) {
+        const draftRow = await tx.aiItemDraft.findUnique({
+          where: { id: draftIdNorm },
+          select: { id: true },
+        });
+        if (!draftRow) {
+          throw new AppException(ErrorCode.VALIDATION_ERROR, 'AI draft not found');
+        }
+        await this.ensureCategoriesForAiImportInTx(tx, carBrandNorm, modelBrandNorm);
       }
-      await this.validateCategoryMetadata(
-        createDto.car_brand,
-        createDto.model_brand,
-        tx,
-      );
+      await this.validateCategoryMetadata(carBrandNorm, modelBrandNorm, tx);
 
       const item = await tx.item.create({
         data: {
@@ -404,8 +409,8 @@ Condition: ${item.condition || ''}`;
           description: createDto.description,
           scale: createDto.scale || '1:64',
           brand: createDto.brand,
-          car_brand: createDto.car_brand || null,
-          model_brand: createDto.model_brand || null,
+          car_brand: carBrandNorm,
+          model_brand: modelBrandNorm,
           condition: (createDto.condition as 'new' | 'old' | undefined) || null,
           price: createDto.price !== undefined && createDto.price !== null ? createDto.price : null,
           original_price: createDto.original_price !== undefined && createDto.original_price !== null ? createDto.original_price : null,
@@ -418,8 +423,8 @@ Condition: ${item.condition || ''}`;
       });
 
       // Handle Draft if provided
-      if (createDto.draft_id) {
-        const draft = await tx.aiItemDraft.findUnique({ where: { id: createDto.draft_id } });
+      if (draftIdNorm) {
+        const draft = await tx.aiItemDraft.findUnique({ where: { id: draftIdNorm } });
         if (draft && draft.images_json) {
           const imageUrls = JSON.parse(draft.images_json) as string[];
           totalImages = imageUrls.length;
@@ -447,7 +452,7 @@ Condition: ${item.condition || ''}`;
                 this.logger.error(
                   `Failed to process draft image "${filename}" for item ${item.id}`,
                   e instanceof Error ? e.stack : undefined,
-                  `ItemsService.create | draftId=${createDto.draft_id}`,
+                  `ItemsService.create | draftId=${draftIdNorm}`,
                 );
               }
             }
@@ -538,8 +543,12 @@ Condition: ${item.condition || ''}`;
     if (updateDto.description !== undefined) updateData.description = updateDto.description;
     if (updateDto.scale !== undefined) updateData.scale = updateDto.scale;
     if (updateDto.brand !== undefined) updateData.brand = updateDto.brand;
-    if (updateDto.car_brand !== undefined) updateData.car_brand = updateDto.car_brand;
-    if (updateDto.model_brand !== undefined) updateData.model_brand = updateDto.model_brand;
+    if (updateDto.car_brand !== undefined) {
+      updateData.car_brand = normalizeCategoryBrandField(updateDto.car_brand);
+    }
+    if (updateDto.model_brand !== undefined) {
+      updateData.model_brand = normalizeCategoryBrandField(updateDto.model_brand);
+    }
     if (updateDto.condition !== undefined) updateData.condition = updateDto.condition;
     if (updateDto.price !== undefined) updateData.price = updateDto.price ?? null;
     if (updateDto.original_price !== undefined) updateData.original_price = updateDto.original_price ?? null;
@@ -556,7 +565,15 @@ Condition: ${item.condition || ''}`;
     if (updateDto.fb_post_content !== undefined) updateData.fb_post_content = updateDto.fb_post_content;
 
     if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
-      await this.validateCategoryMetadata(updateDto.car_brand, updateDto.model_brand);
+      const nextCarBrand =
+        updateDto.car_brand !== undefined
+          ? normalizeCategoryBrandField(updateDto.car_brand)
+          : normalizeCategoryBrandField(existingItem.car_brand);
+      const nextModelBrand =
+        updateDto.model_brand !== undefined
+          ? normalizeCategoryBrandField(updateDto.model_brand)
+          : normalizeCategoryBrandField(existingItem.model_brand);
+      await this.validateCategoryMetadata(nextCarBrand, nextModelBrand);
     }
 
     const item = await this.prisma.item.update({
@@ -980,12 +997,13 @@ Condition: ${item.condition || ''}`;
     ];
 
     for (const check of checks) {
-      if (!check.value) continue;
+      const normalized = normalizeCategoryBrandField(check.value);
+      if (!normalized) continue;
 
       const category = await db.category.findFirst({
         where: {
           type: check.type,
-          name: check.value,
+          name: normalized,
           is_active: true,
         },
       });
@@ -993,8 +1011,8 @@ Condition: ${item.condition || ''}`;
       if (!category) {
         throw new AppException(
           ErrorCode.ITEM_CATEGORY_INVALID,
-          `Invalid ${check.type} value "${check.value}". Category must exist and be active.`,
-          [{ type: check.type, value: check.value }],
+          `Invalid ${check.type} value "${normalized}". Category must exist and be active.`,
+          [{ type: check.type, value: normalized }],
         );
       }
     }

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -52,6 +52,21 @@ function normalizeCategoryBrandField(value: string | undefined | null): string |
   return t.length === 0 ? null : t;
 }
 
+function parseDraftImageUrls(imagesJson: string): string[] {
+  try {
+    const parsed = JSON.parse(imagesJson) as unknown;
+    if (!Array.isArray(parsed)) {
+      throw new Error('Expected JSON array');
+    }
+    return parsed.filter((u): u is string => typeof u === 'string');
+  } catch {
+    throw new AppException(
+      ErrorCode.VALIDATION_ERROR,
+      'AI draft images_json is invalid or corrupted',
+    );
+  }
+}
+
 @Injectable()
 export class ItemsService {
   private readonly logger = new Logger(ItemsService.name);
@@ -385,6 +400,7 @@ Condition: ${item.condition || ''}`;
       const initialStatus = (createDto.status as ItemStatus | undefined) ?? 'con_hang';
 
       let aiDraftForCategories: { id: string; images_json: string | null } | null = null;
+      let draftImageUrls: string[] = [];
       if (draftIdNorm) {
         aiDraftForCategories = await tx.aiItemDraft.findUnique({
           where: { id: draftIdNorm },
@@ -392,6 +408,9 @@ Condition: ${item.condition || ''}`;
         });
         if (!aiDraftForCategories) {
           throw new AppException(ErrorCode.VALIDATION_ERROR, 'AI draft not found');
+        }
+        if (aiDraftForCategories.images_json) {
+          draftImageUrls = parseDraftImageUrls(aiDraftForCategories.images_json);
         }
         await this.ensureCategoriesForAiImportInTx(tx, carBrandNorm, modelBrandNorm);
       }
@@ -417,9 +436,9 @@ Condition: ${item.condition || ''}`;
       });
 
       // Handle Draft if provided (single fetch above when draftIdNorm set)
-      if (draftIdNorm && aiDraftForCategories?.images_json) {
+      if (draftIdNorm && aiDraftForCategories) {
         const draft = aiDraftForCategories;
-        const imageUrls = JSON.parse(draft.images_json) as string[];
+        const imageUrls = draftImageUrls;
         totalImages = imageUrls.length;
 
         let displayOrder = 0;

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -577,7 +577,7 @@ Condition: ${item.condition || ''}`;
     if (updateDto.is_public !== undefined) updateData.is_public = updateDto.is_public;
     if (updateDto.fb_post_content !== undefined) updateData.fb_post_content = updateDto.fb_post_content;
 
-      if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
+    if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
       const nextCarBrand =
         updateDto.car_brand !== undefined
           ? normalizeCategoryBrandField(updateDto.car_brand)

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { Prisma, ItemStatus } from '../generated/prisma/client';
 import { PrismaService } from '../common/prisma/prisma.service';
+import { isPrismaUniqueConstraintError } from '../common/prisma/prisma-error.utils';
 import { IStorageService } from '../storage/storage.interface';
 import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
 import { CreateItemDto } from './dto/create-item.dto';
@@ -356,7 +357,6 @@ Condition: ${item.condition || ''}`;
   async create(createDto: CreateItemDto, tenantId: string) {
     const shopId = this.requireActiveShopId(tenantId);
     this.validatePriceFields(createDto.price, createDto.original_price);
-    await this.validateCategoryMetadata(createDto.car_brand, createDto.model_brand);
 
     // Declared outside transaction; cleared inside to handle potential retries
     let failedImages: { filename: string; error: string }[] = [];
@@ -367,6 +367,19 @@ Condition: ${item.condition || ''}`;
       failedImages = [];
       totalImages = 0;
       const initialStatus = (createDto.status as ItemStatus | undefined) ?? 'con_hang';
+
+      if (createDto.from_ai_import) {
+        await this.ensureCategoriesForAiImportInTx(
+          tx,
+          createDto.car_brand,
+          createDto.model_brand,
+        );
+      }
+      await this.validateCategoryMetadata(
+        createDto.car_brand,
+        createDto.model_brand,
+        tx,
+      );
 
       const item = await tx.item.create({
         data: {
@@ -503,10 +516,6 @@ Condition: ${item.condition || ''}`;
     const nextStatus = updateDto.status ?? existingItem.status;
     this.validatePriceFields(nextPrice ?? undefined, nextOriginalPrice ?? undefined);
 
-    if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
-      await this.validateCategoryMetadata(updateDto.car_brand, updateDto.model_brand);
-    }
-
     const updateData: Prisma.ItemUpdateInput = {};
     if (updateDto.name !== undefined) updateData.name = updateDto.name;
     if (updateDto.description !== undefined) updateData.description = updateDto.description;
@@ -529,9 +538,27 @@ Condition: ${item.condition || ''}`;
     if (updateDto.is_public !== undefined) updateData.is_public = updateDto.is_public;
     if (updateDto.fb_post_content !== undefined) updateData.fb_post_content = updateDto.fb_post_content;
 
-    const item = await this.prisma.item.update({
-      where: { id },
-      data: updateData,
+    const item = await this.prisma.$transaction(async (tx) => {
+      if (updateDto.from_ai_import) {
+        await this.ensureCategoriesForAiImportInTx(
+          tx,
+          updateDto.car_brand !== undefined ? updateDto.car_brand : existingItem.car_brand,
+          updateDto.model_brand !== undefined ? updateDto.model_brand : existingItem.model_brand,
+        );
+      }
+
+      if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
+        await this.validateCategoryMetadata(
+          updateDto.car_brand !== undefined ? updateDto.car_brand : existingItem.car_brand,
+          updateDto.model_brand !== undefined ? updateDto.model_brand : existingItem.model_brand,
+          tx,
+        );
+      }
+
+      return tx.item.update({
+        where: { id },
+        data: updateData,
+      });
     });
 
     // Sync with vector store
@@ -874,9 +901,75 @@ Condition: ${item.condition || ''}`;
     }
   }
 
+  /**
+   * Ensures car_brand and model_brand names exist as Category rows (active).
+   * Used by AI import so extracted names appear in admin category lists without manual setup.
+   */
+  private async ensureCategoriesForAiImportInTx(
+    tx: Prisma.TransactionClient,
+    carBrand?: string | null,
+    modelBrand?: string | null,
+  ) {
+    const specs: Array<{ type: 'car_brand' | 'model_brand'; value?: string | null }> = [
+      { type: 'car_brand', value: carBrand },
+      { type: 'model_brand', value: modelBrand },
+    ];
+
+    for (const spec of specs) {
+      const trimmed =
+        typeof spec.value === 'string' ? spec.value.trim() : '';
+      if (!trimmed) continue;
+
+      const existing = await tx.category.findFirst({
+        where: { type: spec.type, name: trimmed },
+      });
+
+      if (!existing) {
+        const maxOrder = await tx.category.aggregate({
+          where: { type: spec.type },
+          _max: { display_order: true },
+        });
+        const displayOrder = (maxOrder._max.display_order ?? -1) + 1;
+
+        try {
+          await tx.category.create({
+            data: {
+              name: trimmed,
+              type: spec.type,
+              is_active: true,
+              display_order: displayOrder,
+            },
+          });
+        } catch (error) {
+          if (!isPrismaUniqueConstraintError(error)) {
+            throw error;
+          }
+          const afterRace = await tx.category.findFirst({
+            where: { type: spec.type, name: trimmed },
+          });
+          if (afterRace && !afterRace.is_active) {
+            await tx.category.update({
+              where: { id: afterRace.id },
+              data: { is_active: true },
+            });
+          }
+        }
+        continue;
+      }
+
+      if (!existing.is_active) {
+        await tx.category.update({
+          where: { id: existing.id },
+          data: { is_active: true },
+        });
+      }
+    }
+  }
+
   private async validateCategoryMetadata(
     carBrand?: string | null,
     modelBrand?: string | null,
+    db: Prisma.TransactionClient | PrismaService = this.prisma,
   ) {
     const checks: Array<{ type: 'car_brand' | 'model_brand'; value?: string | null }> = [
       { type: 'car_brand', value: carBrand },
@@ -886,7 +979,7 @@ Condition: ${item.condition || ''}`;
     for (const check of checks) {
       if (!check.value) continue;
 
-      const category = await this.prisma.category.findFirst({
+      const category = await db.category.findFirst({
         where: {
           type: check.type,
           name: check.value,

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -406,13 +406,12 @@ Condition: ${item.condition || ''}`;
           where: { id: draftIdNorm },
           select: { id: true, images_json: true },
         });
-        if (!aiDraftForCategories) {
-          throw new AppException(ErrorCode.VALIDATION_ERROR, 'AI draft not found');
+        if (aiDraftForCategories) {
+          if (aiDraftForCategories.images_json) {
+            draftImageUrls = parseDraftImageUrls(aiDraftForCategories.images_json);
+          }
+          await this.ensureCategoriesForAiImportInTx(tx, carBrandNorm, modelBrandNorm);
         }
-        if (aiDraftForCategories.images_json) {
-          draftImageUrls = parseDraftImageUrls(aiDraftForCategories.images_json);
-        }
-        await this.ensureCategoriesForAiImportInTx(tx, carBrandNorm, modelBrandNorm);
       }
       await this.validateCategoryMetadata(carBrandNorm, modelBrandNorm, tx);
 
@@ -435,7 +434,7 @@ Condition: ${item.condition || ''}`;
         },
       });
 
-      // Handle Draft if provided (single fetch above when draftIdNorm set)
+      // Handle Draft if provided and row exists (ignore stale client draft_id)
       if (draftIdNorm && aiDraftForCategories) {
         const draft = aiDraftForCategories;
         const imageUrls = draftImageUrls;

--- a/frontend/src/components/admin/CategoryQuickManage.tsx
+++ b/frontend/src/components/admin/CategoryQuickManage.tsx
@@ -4,6 +4,8 @@ import { Settings, Plus, ToggleLeft, ToggleRight, X, Pencil, Trash2, Check } fro
 import { apiClient } from '../../api/client';
 import type { CategoryItem, ApiError } from '../../types/category';
 import styles from './CategoryQuickManage.module.css';
+import { useOptionalActiveShopId } from '../../hooks/useOptionalActiveShopId';
+import { useOptionalPlatformSuper } from '../../hooks/useOptionalPlatformSuper';
 
 interface Props {
   type: 'car_brand' | 'model_brand';
@@ -12,6 +14,8 @@ interface Props {
 
 export const CategoryQuickManage = ({ type, categories }: Props) => {
   const queryClient = useQueryClient();
+  const activeShopId = useOptionalActiveShopId();
+  const isPlatformSuperUser = useOptionalPlatformSuper();
   const [isOpen, setIsOpen] = useState(false);
   const [newName, setNewName] = useState('');
   const [error, setError] = useState('');
@@ -58,10 +62,13 @@ export const CategoryQuickManage = ({ type, categories }: Props) => {
 
   const createMutation = useMutation({
     mutationFn: async (name: string) => {
-      return apiClient.post('/categories', { name, type });
+      if (isPlatformSuperUser) {
+        return apiClient.post('/categories', { name, type });
+      }
+      return apiClient.post('/categories/shop', { name, type });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['categories', type] });
+      queryClient.invalidateQueries({ queryKey: ['categories', type, activeShopId ?? ''] });
       setNewName('');
       setError('');
     },
@@ -76,7 +83,7 @@ export const CategoryQuickManage = ({ type, categories }: Props) => {
       return apiClient.patch(`/categories/${id}`, { name });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['categories', type] });
+      queryClient.invalidateQueries({ queryKey: ['categories', type, activeShopId ?? ''] });
       setEditingId(null);
       setError('');
     },
@@ -91,7 +98,7 @@ export const CategoryQuickManage = ({ type, categories }: Props) => {
       return apiClient.patch(`/categories/${id}/toggle`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['categories', type] });
+      queryClient.invalidateQueries({ queryKey: ['categories', type, activeShopId ?? ''] });
     },
   });
 
@@ -100,7 +107,7 @@ export const CategoryQuickManage = ({ type, categories }: Props) => {
       return apiClient.delete(`/categories/${id}`);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['categories', type] });
+      queryClient.invalidateQueries({ queryKey: ['categories', type, activeShopId ?? ''] });
       setDeleteConfirmId(null);
       setError('');
     },

--- a/frontend/src/components/catalog/CatalogFilters.tsx
+++ b/frontend/src/components/catalog/CatalogFilters.tsx
@@ -5,6 +5,7 @@ import type { CategoryItem } from '../../types/category';
 import { cn } from '../../lib/utils';
 
 interface CatalogFiltersProps {
+  shopId: string | null;
   carBrand: string | null;
   modelBrand: string | null;
   condition: 'new' | 'old' | null;
@@ -21,6 +22,7 @@ const chipActive =
   'border-transparent bg-gradient-to-r from-shop to-shopAccent text-white shadow-corporate-btn hover:-translate-y-0.5 hover:shadow-corporate-card-hover';
 
 export const CatalogFilters = ({
+  shopId,
   carBrand,
   modelBrand,
   condition,
@@ -33,26 +35,31 @@ export const CatalogFilters = ({
     isLoading: isCategoriesLoading,
     isError: isCategoriesError,
   } = useQuery<{ categories: CategoryItem[] }>({
-    queryKey: ['catalog-filters', 'all'],
+    queryKey: ['catalog-filters', shopId ?? 'none'],
     queryFn: async () => {
-      const response = await apiClient.get('/categories?is_active=true');
+      const params = new URLSearchParams({ is_active: 'true' });
+      if (shopId) {
+        params.set('shop_id', shopId);
+      }
+      const response = await apiClient.get(`/categories?${params.toString()}`);
       return response.data;
     },
+    enabled: Boolean(shopId),
     staleTime: 5 * 60 * 1000,
   });
 
   const carBrands = useMemo(
     () => (categoriesData?.categories ?? [])
-      .filter((category) => category.type === 'car_brand')
-      .map((category) => category.name)
+      .filter((c) => c.type === 'car_brand' && c.is_active)
+      .map((c) => c.name)
       .sort((a, b) => a.localeCompare(b)),
     [categoriesData],
   );
 
   const modelBrands = useMemo(
     () => (categoriesData?.categories ?? [])
-      .filter((category) => category.type === 'model_brand')
-      .map((category) => category.name)
+      .filter((c) => c.type === 'model_brand' && c.is_active)
+      .map((c) => c.name)
       .sort((a, b) => a.localeCompare(b)),
     [categoriesData],
   );

--- a/frontend/src/hooks/useOptionalActiveShopId.ts
+++ b/frontend/src/hooks/useOptionalActiveShopId.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { ShopContext } from '../contexts/ShopContext';
+
+/** Same as useShop when inside ShopProvider; returns null when outside (e.g. unit tests). */
+export function useOptionalActiveShopId(): string | null {
+  const ctx = useContext(ShopContext);
+  return ctx?.activeShop?.id ?? null;
+}

--- a/frontend/src/hooks/useOptionalPlatformSuper.ts
+++ b/frontend/src/hooks/useOptionalPlatformSuper.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { AuthContext, isPlatformSuper } from '../contexts/AuthContext';
+
+/** Platform super check when AuthProvider may be absent (unit tests). */
+export function useOptionalPlatformSuper(): boolean {
+  const ctx = useContext(AuthContext);
+  return isPlatformSuper(ctx?.user ?? null);
+}

--- a/frontend/src/pages/PublicCatalogPage.tsx
+++ b/frontend/src/pages/PublicCatalogPage.tsx
@@ -227,6 +227,7 @@ export const PublicCatalogPage = () => {
 
         <div className="rounded-2xl border border-slate-100 bg-white p-5 shadow-corporate-card sm:p-6 lg:p-8">
           <CatalogFilters
+            shopId={effectiveShopId}
             carBrand={urlState.carBrand}
             modelBrand={urlState.modelBrand}
             condition={urlState.condition}

--- a/frontend/src/pages/admin/AiImportPage.tsx
+++ b/frontend/src/pages/admin/AiImportPage.tsx
@@ -110,7 +110,8 @@ export const AiImportPage = () => {
           ApiEnvelope<CreateItemResponse>
         >('/items', {
             ...formData,
-            draft_id: draft.draftId
+            draft_id: draft.draftId,
+            from_ai_import: true,
         });
         const result = response.data;
         if (result.warning) {

--- a/frontend/src/pages/admin/AiImportPage.tsx
+++ b/frontend/src/pages/admin/AiImportPage.tsx
@@ -111,7 +111,6 @@ export const AiImportPage = () => {
         >('/items', {
             ...formData,
             draft_id: draft.draftId,
-            from_ai_import: true,
         });
         const result = response.data;
         if (result.warning) {

--- a/frontend/src/pages/admin/CategoriesPage.tsx
+++ b/frontend/src/pages/admin/CategoriesPage.tsx
@@ -4,6 +4,8 @@ import { Tags, Plus, Pencil, ToggleLeft, ToggleRight, Trash2, AlertTriangle } fr
 import { apiClient } from '../../api/client';
 import type { CategoryItem, ApiError, ApiResponse, CategoryType } from '../../types/category';
 import { useIsMobile } from '../../hooks/useIsMobile';
+import { useShop } from '../../hooks/useShop';
+import { useOptionalPlatformSuper } from '../../hooks/useOptionalPlatformSuper';
 import { cn } from '../../lib/utils';
 import styles from './CategoriesPage.module.css';
 
@@ -150,6 +152,8 @@ const CategoryDesktopTable = ({
 export const CategoriesPage = () => {
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
+  const { activeShop } = useShop();
+  const isPlatformSuper = useOptionalPlatformSuper();
   const [activeType, setActiveType] = useState<CategoryType>('car_brand');
 
   // Modal states
@@ -162,18 +166,27 @@ export const CategoriesPage = () => {
   const [formType, setFormType] = useState<CategoryType>('car_brand');
 
   // Fetch categories
+  const shopQuerySuffix = activeShop?.id ?? '';
   const { data, isLoading, error } = useQuery({
-    queryKey: ['categories', activeType],
+    queryKey: ['categories', activeType, shopQuerySuffix],
     queryFn: async () => {
-      const response = await apiClient.get(`/categories?type=${activeType}`) as ApiResponse<CategoriesResponse>;
+      const params = new URLSearchParams({ type: activeType });
+      if (activeShop?.id) {
+        params.set('shop_id', activeShop.id);
+      }
+      const response = await apiClient.get(`/categories?${params.toString()}`) as ApiResponse<CategoriesResponse>;
       return response.data;
     },
+    enabled: Boolean(activeShop?.id) || isPlatformSuper,
   });
 
   // Create mutation
   const createMutation = useMutation({
     mutationFn: async (dto: { name: string; type: string }) => {
-      return apiClient.post('/categories', dto);
+      if (isPlatformSuper) {
+        return apiClient.post('/categories', dto);
+      }
+      return apiClient.post('/categories/shop', dto);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['categories'] });

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -13,6 +13,7 @@ import { jumpToStepWithAutoSave, navigateStepWithAutoSave, type ProductStep } fr
 import { buildStepUrlAfterCreate, evaluateFinishDecision, shouldBlockEnterSubmit } from './itemWorkflow';
 import { MAX_SPINNER_FRAMES } from '../../constants/spinner';
 import { useIsMobile } from '../../hooks/useIsMobile';
+import { useOptionalActiveShopId } from '../../hooks/useOptionalActiveShopId';
 
 // Helper functions for number formatting
 const formatNumber = (value: string): string => {
@@ -231,6 +232,7 @@ export const ItemDetailPage = () => {
   const [searchParams] = useSearchParams();
   const [currentStep, setCurrentStep] = useState<ProductStep>(1);
   const isMobile = useIsMobile();
+  const activeShopId = useOptionalActiveShopId();
 
   const { data, isLoading } = useQuery({
     queryKey: ['item', id],
@@ -243,19 +245,25 @@ export const ItemDetailPage = () => {
 
   // Fetch ALL categories per type (popup needs all, dropdown filters active in-memory)
   const { data: carBrandsData } = useQuery({
-    queryKey: ['categories', 'car_brand'],
+    queryKey: ['categories', 'car_brand', activeShopId ?? ''],
     queryFn: async () => {
-      const response = await apiClient.get('/categories?type=car_brand') as ApiResponse<{ categories: CategoryItem[] }>;
+      const params = new URLSearchParams({ type: 'car_brand' });
+      if (activeShopId) params.set('shop_id', activeShopId);
+      const response = await apiClient.get(`/categories?${params.toString()}`) as ApiResponse<{ categories: CategoryItem[] }>;
       return response.data;
     },
+    enabled: Boolean(activeShopId),
   });
 
   const { data: modelBrandsData } = useQuery({
-    queryKey: ['categories', 'model_brand'],
+    queryKey: ['categories', 'model_brand', activeShopId ?? ''],
     queryFn: async () => {
-      const response = await apiClient.get('/categories?type=model_brand') as ApiResponse<{ categories: CategoryItem[] }>;
+      const params = new URLSearchParams({ type: 'model_brand' });
+      if (activeShopId) params.set('shop_id', activeShopId);
+      const response = await apiClient.get(`/categories?${params.toString()}`) as ApiResponse<{ categories: CategoryItem[] }>;
       return response.data;
     },
+    enabled: Boolean(activeShopId),
   });
 
   // Derive active-only lists for dropdowns (in-memory filter, no extra API call)

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -2,6 +2,8 @@ export interface CategoryItem {
   id: string;
   name: string;
   type: string;
+  /** null = global seed; UUID = shop-specific */
+  shop_id?: string | null;
   is_active: boolean;
   display_order: number;
   created_at?: string;

--- a/frontend/src/types/item.types.ts
+++ b/frontend/src/types/item.types.ts
@@ -69,8 +69,6 @@ export interface ItemFormData {
   description: string;
   quantity?: number;
   attributes?: ItemAttributesPayload;
-  /** When creating from AI import — server auto-adds missing category rows (requires draft_id) */
-  from_ai_import?: boolean;
 }
 
 /**

--- a/frontend/src/types/item.types.ts
+++ b/frontend/src/types/item.types.ts
@@ -69,7 +69,7 @@ export interface ItemFormData {
   description: string;
   quantity?: number;
   attributes?: ItemAttributesPayload;
-  /** When creating from AI import — server auto-adds missing category rows */
+  /** When creating from AI import — server auto-adds missing category rows (requires draft_id) */
   from_ai_import?: boolean;
 }
 

--- a/frontend/src/types/item.types.ts
+++ b/frontend/src/types/item.types.ts
@@ -69,6 +69,8 @@ export interface ItemFormData {
   description: string;
   quantity?: number;
   attributes?: ItemAttributesPayload;
+  /** When creating from AI import — server auto-adds missing category rows */
+  from_ai_import?: boolean;
 }
 
 /**

--- a/frontend/tests/unit/CatalogFilters.test.tsx
+++ b/frontend/tests/unit/CatalogFilters.test.tsx
@@ -32,6 +32,7 @@ describe('CatalogFilters', () => {
 
     render(
       <CatalogFilters
+        shopId="11111111-1111-1111-1111-111111111111"
         carBrand={null}
         modelBrand={null}
         condition={null}
@@ -65,6 +66,7 @@ describe('CatalogFilters', () => {
 
     render(
       <CatalogFilters
+        shopId="11111111-1111-1111-1111-111111111111"
         carBrand={null}
         modelBrand={null}
         condition={null}
@@ -77,7 +79,7 @@ describe('CatalogFilters', () => {
     expect(useQueryMock).toHaveBeenCalledTimes(1);
     expect((useQueryMock.mock.calls[0][0] as { queryKey: unknown[] }).queryKey).toEqual([
       'catalog-filters',
-      'all',
+      '11111111-1111-1111-1111-111111111111',
     ]);
 
     const audiButton = screen.getByRole('button', { name: 'Audi' });
@@ -115,6 +117,7 @@ describe('CatalogFilters', () => {
 
     render(
       <CatalogFilters
+        shopId="11111111-1111-1111-1111-111111111111"
         carBrand="Audi"
         modelBrand="Mini GT"
         condition="old"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Recent updates

### RBAC (`c85161b`)
`PATCH` / `DELETE` `/categories/:id*` now declare `@PlatformRoles(platform_super)` + `@Roles(shop_admin, shop_staff)` so `RolesGuard` is not bypassed.

### Review follow-up (`2dca177`)
- **`car_brand` / `model_brand`**: `@MaxLength(100)` on create/update item DTOs (aligned with `CreateCategoryDto`).
- **AI ensure**: if trimmed brand exceeds 100 chars, skip auto category row and **warn** (validation still fails if no matching category).
- **`assertCanMutateCategory`**: **warn** logs when denying global edit or wrong-tenant edit.
- **Test**: oversize `car_brand` with draft rejects before `category.create`.

Backend: `npx jest --runInBand` (468 tests).

---

Shop-scoped categories, migration, and API behavior unchanged from earlier description.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-730641f6-cf55-4e84-afee-958bec705918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-730641f6-cf55-4e84-afee-958bec705918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

