### PR TITLE
Add dev environment setup: AGENTS.md and pnpm build config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Diecast360 is a pnpm monorepo (`backend/` + `frontend/`) for a diecast model car inventory app with 360° image viewer, public catalog, and social-selling tools.
+
+### Services
+
+| Service | Port | How to start |
+|---------|------|--------------|
+| PostgreSQL 16 | 5432 | `pg_ctlcluster 16 main start` (already running after setup) |
+| Backend (NestJS) | 3000 | `pnpm run dev:backend` |
+| Frontend (Vite) | 5173 | `pnpm run dev:frontend` |
+| Both together | — | `pnpm dev` (uses `concurrently`) |
+
+### Key gotchas
+
+- **COOKIE_SECRET** must be at least 32 characters in `backend/.env` or the app will throw at startup.
+- **pnpm.onlyBuiltDependencies** in root `package.json` is required so that native modules (`sharp`, `bcrypt`, `prisma`, `esbuild`) build during `pnpm install`. Without it, pnpm v10+ silently skips their build scripts.
+- After `pnpm install`, the backend `postinstall` runs `prisma generate` automatically.
+- `prisma migrate dev` prompts interactively for a migration name if the schema drifts; use `prisma migrate deploy` (non-interactive) when only applying existing migrations.
+- Frontend lint (`pnpm --filter ./frontend lint`) currently has pre-existing lint errors in the codebase — these are not regressions.
+- Node.js version must satisfy `>=20.19.0 <21 || >=22.12.0` (env ships v22.22.2 via nvm at `/home/ubuntu/.nvm`).
+
+### Lint / Test / Build commands
+
+See `docs/DEV.md` for full reference. Quick summary:
+
+| Task | Command |
+|------|---------|
+| Backend lint | `pnpm --filter ./backend lint` |
+| Frontend lint | `pnpm --filter ./frontend lint` |
+| Backend tests (Jest) | `pnpm --filter ./backend test` |
+| Frontend unit tests (Vitest) | `pnpm --filter ./frontend test:unit` |
+| Frontend E2E (Playwright) | `pnpm --filter ./frontend test:e2e` |
+| Backend build | `pnpm --filter ./backend build` |
+| Frontend build | `pnpm --filter ./frontend build` |
+| TypeScript check (frontend) | `cd frontend && npx tsc -b --noEmit` |
+
+### Admin credentials (dev only)
+
+Created by `pnpm --filter ./backend create:admin:quick -- <email> <password>`. Default dev account: `admin@diecast360.dev` / `admin123456`. Login URL: `http://localhost:5173/admin/login`.
+
+### Database
+
+PostgreSQL 16 at `localhost:5432`, database `diecast360`, user/password `postgres`/`postgres`. Start with `pg_ctlcluster 16 main start`. Run migrations with `pnpm --filter ./backend exec prisma migrate deploy`.

--- a/package.json
+++ b/package.json
@@ -9,5 +9,17 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@nestjs/core",
+      "@prisma/client",
+      "@prisma/engines",
+      "bcrypt",
+      "esbuild",
+      "prisma",
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment configuration for Cursor Cloud agents and resolves native module build issues with pnpm v10+.

### Changes

- **`AGENTS.md`**: Added Cursor Cloud specific instructions documenting services, ports, key gotchas (COOKIE_SECRET length, Prisma interactive prompts), lint/test/build commands, and dev admin credentials.
- **`package.json`**: Added `pnpm.onlyBuiltDependencies` array to allow native module build scripts (`sharp`, `bcrypt`, `prisma`, `esbuild`, `@prisma/client`, `@prisma/engines`, `@nestjs/core`, `unrs-resolver`) which pnpm v10+ skips by default.

### Testing

- Backend: 477 tests pass (44 suites)
- Frontend: 81 unit tests pass (17 suites)
- Backend lint: 0 errors, 3 warnings
- Frontend TypeScript: compiles cleanly
- Backend build: successful
- Full app demo: login, create item, verify public catalog

### Demo

<a href="https://cursor.com/agents/bc-8001f0c6-12bc-4667-b045-53cda20a7c20/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdiecast360_admin_login_and_create_item.mp4"><img src="https://cursor.com/artifacts/c/art-b0a82ddb-5dd5-4404-a1d3-45daee240521" alt="diecast360_admin_login_and_create_item.mp4" /></a>

![Admin dashboard](https://cursor.com/artifacts/c/art-8e8dcc42-86c8-473a-beb9-36f7d2c7ea03)
![Items list with two products](https://cursor.com/artifacts/c/art-1378adc8-fb0f-4efb-b7f0-0fa3939925bd)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8001f0c6-12bc-4667-b045-53cda20a7c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8001f0c6-12bc-4667-b045-53cda20a7c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

