### PR TITLE
Admin & catalog: audit UI for shop-scoped categories

### DIFF
--- a/frontend/src/components/catalog/CatalogFilters.tsx
+++ b/frontend/src/components/catalog/CatalogFilters.tsx
@@ -6,6 +6,8 @@ import { cn } from '../../lib/utils';
 
 interface CatalogFiltersProps {
   shopId: string | null;
+  /** Resolved shop name for audit copy (optional). */
+  shopDisplayName?: string | null;
   carBrand: string | null;
   modelBrand: string | null;
   condition: 'new' | 'old' | null;
@@ -23,6 +25,7 @@ const chipActive =
 
 export const CatalogFilters = ({
   shopId,
+  shopDisplayName,
   carBrand,
   modelBrand,
   condition,
@@ -78,6 +81,21 @@ export const CatalogFilters = ({
 
   return (
     <div className="mb-2 space-y-8">
+      {Boolean(shopId) && (
+        <p
+          className="mb-1 rounded-lg border border-slate-100 bg-slate-50/90 px-3 py-2 text-xs leading-relaxed text-slate-600"
+          role="note"
+        >
+          Bộ lọc hãng xe và hãng mô hình gồm{' '}
+          <strong>danh mục chung (toàn hệ thống)</strong> và{' '}
+          <strong>
+            danh mục riêng của shop
+            {shopDisplayName ? ` «${shopDisplayName}»` : ''}
+          </strong>
+          . Danh mục chỉ thuộc shop khác không xuất hiện ở đây.
+        </p>
+      )}
+
       {isCategoriesError && (
         <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900">
           Không thể tải bộ lọc lúc này.

--- a/frontend/src/pages/admin/CategoriesPage.module.css
+++ b/frontend/src/pages/admin/CategoriesPage.module.css
@@ -45,6 +45,39 @@
   font-weight: 500;
 }
 
+.auditHint {
+  margin: 10px 0 0 0;
+  max-width: 52rem;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #475569;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.scopeBadge {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 999px;
+  letter-spacing: 0.01em;
+}
+
+.scopeGlobal {
+  background: #eef2ff;
+  color: #4338ca;
+  border: 1px solid #c7d2fe;
+}
+
+.scopeShop {
+  background: #ecfdf5;
+  color: #047857;
+  border: 1px solid #a7f3d0;
+}
+
 /* Tab Filter */
 .tabBar {
   display: inline-flex;

--- a/frontend/src/pages/admin/CategoriesPage.tsx
+++ b/frontend/src/pages/admin/CategoriesPage.tsx
@@ -13,6 +13,20 @@ interface CategoriesResponse {
   categories: CategoryItem[];
 }
 
+/** Audit helper: how this row relates to shop scope (global seed vs shop-specific). */
+function categoryScopeLabel(
+  category: CategoryItem,
+  activeShopId: string | null | undefined,
+): string {
+  if (category.shop_id == null || category.shop_id === '') {
+    return 'Chung';
+  }
+  if (activeShopId && category.shop_id === activeShopId) {
+    return 'Shop này';
+  }
+  return 'Shop khác';
+}
+
 const TYPE_LABELS: Record<CategoryType, string> = {
   car_brand: 'Hãng xe',
   model_brand: 'Hãng mô hình',
@@ -33,10 +47,12 @@ interface CategoryListActionProps {
 
 interface CategoryMobileListProps extends CategoryListActionProps {
   categories: CategoryItem[];
+  activeShopId: string | null;
 }
 
 interface CategoryDesktopTableProps extends CategoryListActionProps {
   categories: CategoryItem[];
+  activeShopId: string | null;
 }
 
 const CategoryActions = ({ category, onEdit, onToggle, onDelete }: CategoryActionProps) => (
@@ -71,6 +87,7 @@ const CategoryActions = ({ category, onEdit, onToggle, onDelete }: CategoryActio
 
 const CategoryMobileList = ({
   categories,
+  activeShopId,
   onEdit,
   onToggle,
   onDelete,
@@ -84,6 +101,20 @@ const CategoryMobileList = ({
             <div className={styles.mobileTitle}>{category.name}</div>
           </div>
           <span className={styles.orderNumber}>{index + 1}</span>
+        </div>
+
+        <div className={styles.mobileRow}>
+          <span className={styles.mobileLabel}>Phạm vi</span>
+          <span
+            className={cn(
+              styles.scopeBadge,
+              category.shop_id == null || category.shop_id === ''
+                ? styles.scopeGlobal
+                : styles.scopeShop,
+            )}
+          >
+            {categoryScopeLabel(category, activeShopId)}
+          </span>
         </div>
 
         <div className={styles.mobileRow}>
@@ -108,6 +139,7 @@ const CategoryMobileList = ({
 
 const CategoryDesktopTable = ({
   categories,
+  activeShopId,
   onEdit,
   onToggle,
   onDelete,
@@ -117,6 +149,7 @@ const CategoryDesktopTable = ({
       <tr>
         <th className={styles.th} style={{ width: '50px' }}>#</th>
         <th className={styles.th}>Tên</th>
+        <th className={styles.th} style={{ width: '140px' }}>Phạm vi</th>
         <th className={styles.th} style={{ width: '120px' }}>Trạng thái</th>
         <th className={styles.th} style={{ width: '120px' }}>Thao tác</th>
       </tr>
@@ -128,6 +161,18 @@ const CategoryDesktopTable = ({
             <span className={styles.orderNumber}>{index + 1}</span>
           </td>
           <td className={styles.td}>{category.name}</td>
+          <td className={styles.td}>
+            <span
+              className={cn(
+                styles.scopeBadge,
+                category.shop_id == null || category.shop_id === ''
+                  ? styles.scopeGlobal
+                  : styles.scopeShop,
+              )}
+            >
+              {categoryScopeLabel(category, activeShopId)}
+            </span>
+          </td>
           <td className={`${styles.td} ${styles.tdCenter}`}>
             <span className={`${styles.activeBadge} ${category.is_active ? styles.badgeActive : styles.badgeInactive}`}>
               {category.is_active ? '● Hoạt động' : '○ Tắt'}
@@ -299,6 +344,18 @@ export const CategoriesPage = () => {
             <p className={styles.headerSubtitle}>
               Quản lý hãng xe và hãng mô hình
             </p>
+            {activeShop?.id ? (
+              <p className={styles.auditHint} role="note">
+                Đang xem danh mục <strong>chung (toàn hệ thống)</strong> và danh mục{' '}
+                <strong>riêng của shop {activeShop.name}</strong>. Mục &quot;Chung&quot; dùng chung cho mọi shop;
+                mục &quot;Shop này&quot; chỉ hiện ở shop này và trong catalog khi khách xem đúng shop.
+              </p>
+            ) : isPlatformSuper ? (
+              <p className={styles.auditHint} role="note">
+                Góc nhìn quản trị nền tảng: hiển thị mọi dòng (chung và theo từng shop). Cột &quot;Phạm vi&quot;
+                giúp đối chiếu nguồn danh mục.
+              </p>
+            ) : null}
           </div>
         </div>
       </div>
@@ -338,6 +395,7 @@ export const CategoriesPage = () => {
       ) : isMobile ? (
         <CategoryMobileList
           categories={categories}
+          activeShopId={activeShop?.id ?? null}
           onEdit={openEditModal}
           onToggle={(id) => toggleMutation.mutate(id)}
           onDelete={setDeleteConfirm}
@@ -345,6 +403,7 @@ export const CategoriesPage = () => {
       ) : (
         <CategoryDesktopTable
           categories={categories}
+          activeShopId={activeShop?.id ?? null}
           onEdit={openEditModal}
           onToggle={(id) => toggleMutation.mutate(id)}
           onDelete={setDeleteConfirm}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Separate PR for **reviewing how categories appear per shop** in admin and on the public catalog, stacked on top of the shop-scoped categories branch (`cursor/ai-import-auto-categories-5918`).

Does **not** change backend behavior — UI and copy only.

## Changes

- **Admin (`CategoriesPage`)**: Column **Phạm vi** (Chung / Shop này / Shop khác) when `CategoryItem.shop_id` is present; header note for shop admin vs platform super.
- **Catalog (`CatalogFilters`)**: Short **audit note** that filter chips merge **global** and **current shop** brand lists (other shops’ private labels are not shown here).
- **Styles**: Badges and hint block in `CategoriesPage.module.css`.

## Merge order

1. Merge `cursor/ai-import-auto-categories-5918` (or the PR that contains `shop_id` + API) first.
2. Then merge this PR into that line (or rebase onto `main` after the first is merged).

## Checks

- `npm run lint`, `npx tsc --noEmit`, `npm run test:unit` (frontend)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-730641f6-cf55-4e84-afee-958bec705918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-730641f6-cf55-4e84-afee-958bec705918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

