### PR TITLE
fix(frontend): align accent theme tokens with shop accent_color

### DIFF
--- a/frontend/src/contexts/ShopThemeProvider.tsx
+++ b/frontend/src/contexts/ShopThemeProvider.tsx
@@ -24,7 +24,8 @@ function applyBrandingVars(root: HTMLElement, primaryCss: string, accentCss: str
   const aTriplet = rgbToCssTriplet(aRgb);
   const pFg = foregroundHslForBackground(pRgb);
   const aFg = foregroundHslForBackground(aRgb);
-  const { surface: accentBg, fg: accentFg } = accentSurfaceFromPrimary(pRgb);
+  /** Light accent chip/surface tokens follow configured accent hue (shop settings), not primary. */
+  const { surface: accentBg, fg: accentFg } = accentSurfaceFromPrimary(aRgb);
 
   root.style.setProperty('--shop-primary-rgb', pTriplet);
   root.style.setProperty('--shop-accent-rgb', aTriplet);

--- a/frontend/src/utils/shopThemeCss.ts
+++ b/frontend/src/utils/shopThemeCss.ts
@@ -98,9 +98,9 @@ export function foregroundHslForBackground(bg: Rgb): string {
   return relativeLuminance(bg) > 0.55 ? '222 47% 11%' : '0 0% 100%';
 }
 
-/** Light tint background + strong foreground from primary hue. */
-export function accentSurfaceFromPrimary(primary: Rgb): { surface: string; fg: string } {
-  const hsl = rgbToHslTriplet(primary).split(' ');
+/** Light tint background + strong foreground from the given sRGB (shop primary or accent hue). */
+export function accentSurfaceFromPrimary(rgb: Rgb): { surface: string; fg: string } {
+  const hsl = rgbToHslTriplet(rgb).split(' ');
   const h = hsl[0];
   return {
     surface: `${h} 100% 97%`,

--- a/frontend/tests/unit/shopThemeCss.test.ts
+++ b/frontend/tests/unit/shopThemeCss.test.ts
@@ -44,9 +44,12 @@ describe('shopThemeCss', () => {
     expect(l).toBeLessThan(1);
   });
 
-  it('accentSurfaceFromPrimary derives surface from hue', () => {
+  it('accentSurfaceFromPrimary derives surface from the given color hue', () => {
     const { surface, fg } = accentSurfaceFromPrimary({ r: 79, g: 70, b: 229 });
     expect(surface).toMatch(/^243 /);
     expect(fg).toMatch(/^243 /);
+    const accent = accentSurfaceFromPrimary({ r: 124, g: 58, b: 237 });
+    expect(accent.surface).toMatch(/^262 /);
+    expect(accent.fg).toMatch(/^262 /);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Shop appearance in admin exposes **Màu chủ** (`primary_color`) and **Màu nhấn** (`accent_color`). `ShopThemeProvider` maps these to CSS variables used by Tailwind (`shop`, `shopAccent`, `--primary`, `--secondary`, shadcn-style `--accent`).

## Bug

`--accent` and `--accent-foreground` were derived from the **primary** color via `accentSurfaceFromPrimary(pRgb)`, so any UI using `hsl(var(--accent))` / Tailwind `accent` colors ignored the configured accent.

## Fix

Derive the accent surface/foreground pair from the resolved **accent** RGB (`aRgb`) so **Màu nhấn** drives `--accent` tokens consistently with `--ct-secondary` / `--shop-accent-rgb`.

## Tests

- Updated `shopThemeCss.test.ts` to assert accent hue for a sample accent RGB.
- `pnpm --filter ./frontend test:unit` (all unit tests pass).

---

## Review (cursoragent)

**Verdict:** Change is correct and matches shop settings semantics. `--secondary` / `--secondary-foreground` already used accent RGB; aligning `--accent` / `--accent-foreground` removes the inconsistency.

**Notes:**

- Naming: `accentSurfaceFromPrimary` is now used with accent RGB as well; the helper docstring on `main` describes “shop primary or accent hue” — accurate after merge.
- Low usage: repo grep shows almost no `bg-accent` / `text-accent` Tailwind usage today, so visible impact may be small until more shadcn-style components use `accent` tokens.
- This branch was merged with latest `origin/main` (includes shop RGB space-separated fix + active states) and unit tests were re-run: **82 passed**.

No blocking issues found.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db85d3a0-464a-4a8b-abaa-653369bddf74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db85d3a0-464a-4a8b-abaa-653369bddf74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

