### PR TITLE
fix(frontend): shop color CSS variables + active press feedback

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -41,14 +41,14 @@ const publicNavLinkBase =
   'inline-flex min-h-[44px] items-center gap-2 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-600 transition-all duration-200 ease-out hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2';
 
 const publicNavLinkActive =
-  'bg-shop/10 text-shop ring-1 ring-shop/20 shadow-sm hover:bg-shop/15 hover:text-shop';
+  'bg-shop/10 text-shop ring-1 ring-shop/20 shadow-sm hover:bg-shop/15 active:bg-shop/15 hover:text-shop';
 
 /** Admin — menu cột trong sidebar trái. */
 const adminSidebarNavLinkBase =
   'flex w-full min-h-[44px] items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium text-slate-600 transition-all duration-200 ease-out hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2';
 
 const adminSidebarNavLinkActive =
-  'bg-shop/10 text-shop ring-1 ring-shop/20 shadow-sm hover:bg-shop/15 hover:text-shop';
+  'bg-shop/10 text-shop ring-1 ring-shop/20 shadow-sm hover:bg-shop/15 active:bg-shop/15 hover:text-shop';
 
 /** Shared gradient tile when no custom logo (public + admin). */
 function BrandFallbackTile({ className }: { className: string }) {
@@ -369,7 +369,7 @@ export const Layout = ({ children }: LayoutProps) => {
                 )}
                 <button
                   type="button"
-                  className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-700 shadow-sm transition-all duration-200 hover:border-shop/30 hover:bg-shop/10 hover:text-shop focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2 md:hidden"
+                  className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-700 shadow-sm transition-all duration-200 hover:border-shop/30 hover:bg-shop/10 active:bg-shop/15 hover:text-shop focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2 md:hidden"
                   onClick={toggleMobileMenu}
                   aria-label={isMenuOpen ? 'Đóng menu điều hướng' : 'Mở menu điều hướng'}
                   aria-expanded={isMenuOpen}
@@ -509,7 +509,7 @@ export const Layout = ({ children }: LayoutProps) => {
           </Link>
           <button
             type="button"
-            className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-700 shadow-sm transition-all duration-200 hover:border-shop/30 hover:bg-shop/10 hover:text-shop focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2"
+            className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200 bg-white text-slate-700 shadow-sm transition-all duration-200 hover:border-shop/30 hover:bg-shop/10 active:bg-shop/15 hover:text-shop focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2"
             onClick={toggleMobileMenu}
             aria-label={isMenuOpen ? 'Đóng menu điều hướng' : 'Mở menu điều hướng'}
             aria-expanded={isMenuOpen}

--- a/frontend/src/components/catalog/CatalogFilters.tsx
+++ b/frontend/src/components/catalog/CatalogFilters.tsx
@@ -17,9 +17,10 @@ interface CatalogFiltersProps {
 const chipBase =
   'min-h-[44px] rounded-full border px-4 py-2 text-sm font-semibold transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2';
 
-const chipInactive = 'border-slate-200 bg-white text-slate-700 shadow-sm hover:border-shop/25 hover:bg-shop/5 hover:text-shop';
+const chipInactive =
+  'border-slate-200 bg-white text-slate-700 shadow-sm hover:border-shop/25 hover:bg-shop/5 active:bg-shop/10 hover:text-shop';
 const chipActive =
-  'border-transparent bg-gradient-to-r from-shop to-shopAccent text-white shadow-corporate-btn hover:-translate-y-0.5 hover:shadow-corporate-card-hover';
+  'border-transparent bg-gradient-to-r from-shop to-shopAccent text-white shadow-corporate-btn hover:-translate-y-0.5 hover:shadow-corporate-card-hover active:translate-y-0 active:brightness-95';
 
 export const CatalogFilters = ({
   shopId,

--- a/frontend/src/components/catalog/CatalogSort.tsx
+++ b/frontend/src/components/catalog/CatalogSort.tsx
@@ -9,8 +9,10 @@ interface CatalogSortProps {
 const btn =
   'min-h-[44px] rounded-lg border px-4 py-2 text-sm font-semibold transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2';
 
-const btnOff = 'border-slate-200 bg-white text-slate-700 shadow-sm hover:border-shop/25 hover:bg-slate-50';
-const btnOn = 'border-transparent bg-shop/10 text-shop ring-1 ring-shop/20';
+const btnOff =
+  'border-slate-200 bg-white text-slate-700 shadow-sm hover:border-shop/25 hover:bg-slate-50 active:bg-slate-100';
+const btnOn =
+  'border-transparent bg-shop/10 text-shop ring-1 ring-shop/20 hover:bg-shop/15 active:bg-shop/15';
 
 export const CatalogSort = ({ sortBy, sortOrder, onSortChange }: CatalogSortProps) => {
   const handleSortClick = (field: 'name' | 'price' | 'created_at') => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,8 +35,8 @@
     --chart-4: 43 96% 56%;
     --chart-5: 27 96% 61%;
     --radius: 0.75rem;
-    --shop-primary-rgb: 79, 70, 229;
-    --shop-accent-rgb: 124, 58, 237;
+    --shop-primary-rgb: 79 70 229;
+    --shop-accent-rgb: 124 58 237;
     --ct-primary: #4f46e5;
     --ct-secondary: #7c3aed;
     --ct-border: #e2e8f0;

--- a/frontend/src/pages/admin/members/CreateMemberForm.tsx
+++ b/frontend/src/pages/admin/members/CreateMemberForm.tsx
@@ -40,7 +40,7 @@ export function CreateMemberForm(props: CreateMemberFormProps) {
         />
         <button
           type="submit"
-          className="rounded-lg bg-shop hover:bg-shop/90 px-3 py-2 text-sm font-semibold text-white"
+          className="rounded-lg bg-shop hover:bg-shop/90 active:bg-shop/80 px-3 py-2 text-sm font-semibold text-white"
           disabled={props.isSubmitting}
         >
           {props.isSubmitting ? 'Đang tạo...' : 'Tạo hội viên'}

--- a/frontend/src/pages/admin/members/MemberEditModal.tsx
+++ b/frontend/src/pages/admin/members/MemberEditModal.tsx
@@ -56,7 +56,7 @@ export function MemberEditModal(props: MemberEditModalProps) {
             />
             <button
               type="submit"
-              className="rounded-lg bg-shop px-3 py-2 text-sm font-semibold text-white hover:bg-shop/90 disabled:cursor-not-allowed disabled:bg-shop/50"
+              className="rounded-lg bg-shop px-3 py-2 text-sm font-semibold text-white hover:bg-shop/90 active:bg-shop/80 disabled:cursor-not-allowed disabled:bg-shop/50"
               disabled={props.isSubmitting}
             >
               {props.isSubmitting ? 'Đang lưu...' : 'Lưu thay đổi'}

--- a/frontend/src/pages/admin/members/MemberListPanel.tsx
+++ b/frontend/src/pages/admin/members/MemberListPanel.tsx
@@ -27,7 +27,7 @@ export function MemberListPanel(props: MemberListPanelProps) {
         <button
           type="button"
           onClick={props.onOpenCreateModal}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-shop text-white shadow-sm transition hover:bg-shop/90"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-shop text-white shadow-sm transition hover:bg-shop/90 active:bg-shop/80"
           aria-label="Tạo hội viên mới"
           title="Tạo hội viên mới"
         >

--- a/frontend/src/utils/shopThemeCss.ts
+++ b/frontend/src/utils/shopThemeCss.ts
@@ -90,8 +90,9 @@ export function rgbToHslTriplet({ r, g, b }: Rgb): string {
   return `${H} ${S}% ${L}%`;
 }
 
+/** Space-separated channels for `rgb(var(--shop-primary-rgb) / α)` (CSS Color 4 — commas break alpha syntax). */
 export function rgbToCssTriplet({ r, g, b }: Rgb): string {
-  return `${clamp255(r)}, ${clamp255(g)}, ${clamp255(b)}`;
+  return `${clamp255(r)} ${clamp255(g)} ${clamp255(b)}`;
 }
 
 export function foregroundHslForBackground(bg: Rgb): string {

--- a/frontend/tests/unit/shopThemeCss.test.ts
+++ b/frontend/tests/unit/shopThemeCss.test.ts
@@ -8,6 +8,7 @@ import {
   relativeLuminance,
   resolveAccentRgb,
   resolvePrimaryRgb,
+  rgbToCssTriplet,
   rgbToHslTriplet,
 } from '../../src/utils/shopThemeCss';
 
@@ -25,6 +26,10 @@ describe('shopThemeCss', () => {
   it('resolvePrimaryRgb / resolveAccentRgb fall back when empty', () => {
     expect(resolvePrimaryRgb('   ')).toEqual({ r: 79, g: 70, b: 229 });
     expect(resolveAccentRgb('')).toEqual({ r: 124, g: 58, b: 237 });
+  });
+
+  it('rgbToCssTriplet uses space-separated channels for rgb(... / alpha)', () => {
+    expect(rgbToCssTriplet({ r: 79, g: 70, b: 229 })).toBe('79 70 229');
   });
 
   it('rgbToHslTriplet produces shadcn-style H S% L% string', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Buttons and chips use Tailwind classes like `hover:bg-shop/10`, `bg-shop/10` (selected nav/sort), and `shadow-corporate-*`, which compile to modern syntax:

`background-color: rgb(var(--shop-primary-rgb) / 0.1)`

Our custom properties were set to **comma-separated** values (`79, 70, 229`). After substitution that becomes `rgb(79, 70, 229 / 0.1)`, which is **invalid** in CSS Color Module Level 4 (the `/ alpha` form requires **space-separated** channels). Browsers drop the declaration, so hover **and** selected/active-looking backgrounds (anything using `shop` with opacity) were missing.

## Fix

- `rgbToCssTriplet` now returns space-separated channels (`79 70 229`).
- `:root` defaults in `index.css` updated to match.
- Added `active:` mirror classes where we use shop tints (`Layout` nav, `CatalogSort` / `CatalogFilters`, solid `bg-shop` member buttons) so touch press feedback is visible on mobile.

## Tests

- Unit assertion for `rgbToCssTriplet`.
- `pnpm --filter ./frontend test:unit` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db85d3a0-464a-4a8b-abaa-653369bddf74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db85d3a0-464a-4a8b-abaa-653369bddf74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

