### PR TITLE
Align Contact page channel colors with shop theme

### DIFF
--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -3,6 +3,14 @@ import { Phone, Facebook, MessageCircle } from 'lucide-react';
 import { usePublicShopContext } from '../hooks/usePublicShopContext';
 import { usePublicShopContact } from '../hooks/usePublicShopContact';
 
+/** Icon circles + links — same tokens as catalog / preorder CTAs (`ShopThemeProvider`). */
+const contactChannelAccent = {
+  link: 'var(--ct-primary, #4f46e5)',
+  iconBg:
+    'linear-gradient(135deg, var(--ct-primary, #4f46e5) 0%, var(--ct-secondary, #7c3aed) 100%)',
+  iconShadow: '0 4px 14px 0 rgb(var(--shop-primary-rgb) / 0.28)',
+} as const;
+
 /** Only allow http(s) links in href / window.open to avoid javascript: and other schemes. */
 function safeHttpUrl(url: string | undefined): string {
   if (!url) return '';
@@ -166,13 +174,13 @@ export const ContactPage = () => {
                 style={{
                   width: '64px',
                   height: '64px',
-                  backgroundColor: '#007bff',
+                  background: contactChannelAccent.iconBg,
                   borderRadius: '50%',
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
                   margin: '0 auto 20px',
-                  boxShadow: '0 4px 12px rgba(0, 123, 255, 0.3)',
+                  boxShadow: contactChannelAccent.iconShadow,
                 }}
               >
                 <Phone size={32} color="white" />
@@ -192,7 +200,7 @@ export const ContactPage = () => {
                   href={phoneTelHref}
                   style={{
                     fontSize: '18px',
-                    color: '#007bff',
+                    color: contactChannelAccent.link,
                     textDecoration: 'none',
                     fontWeight: '500',
                     display: 'block',
@@ -207,7 +215,7 @@ export const ContactPage = () => {
                 <span
                   style={{
                     fontSize: '18px',
-                    color: '#007bff',
+                    color: contactChannelAccent.link,
                     fontWeight: '500',
                     display: 'block',
                   }}
@@ -250,13 +258,13 @@ export const ContactPage = () => {
                 style={{
                   width: '64px',
                   height: '64px',
-                  backgroundColor: '#1877f2',
+                  background: contactChannelAccent.iconBg,
                   borderRadius: '50%',
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
                   margin: '0 auto 20px',
-                  boxShadow: '0 4px 12px rgba(24, 119, 242, 0.3)',
+                  boxShadow: contactChannelAccent.iconShadow,
                 }}
               >
                 <Facebook size={32} color="white" />
@@ -277,7 +285,7 @@ export const ContactPage = () => {
                 rel="noopener noreferrer"
                 style={{
                   fontSize: '18px',
-                  color: '#1877f2',
+                  color: contactChannelAccent.link,
                   textDecoration: 'none',
                   fontWeight: '500',
                   display: 'block',
@@ -325,13 +333,13 @@ export const ContactPage = () => {
                 style={{
                   width: '64px',
                   height: '64px',
-                  backgroundColor: '#0068ff',
+                  background: contactChannelAccent.iconBg,
                   borderRadius: '50%',
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
                   margin: '0 auto 20px',
-                  boxShadow: '0 4px 12px rgba(0, 104, 255, 0.3)',
+                  boxShadow: contactChannelAccent.iconShadow,
                 }}
               >
                 <MessageCircle size={32} color="white" />
@@ -352,7 +360,7 @@ export const ContactPage = () => {
                 rel="noopener noreferrer"
                 style={{
                   fontSize: '18px',
-                  color: '#0068ff',
+                  color: contactChannelAccent.link,
                   textDecoration: 'none',
                   fontWeight: '500',
                   display: 'block',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The public Contact page used hard-coded blues (`#007bff`, Facebook blue, Zalo blue) for icon circles and links. Those did not follow the same `--ct-primary` / `--ct-secondary` / `shop-primary-rgb` tokens as the rest of the public catalog and preorder CTAs (which respect `ShopThemeProvider`).

## Changes

- Introduced shared `contactChannelAccent` constants using `var(--ct-primary)`, gradient to `var(--ct-secondary)`, and `rgb(var(--shop-primary-rgb) / …)` for icon shadows.
- Applied to phone, Facebook, and Zalo cards so all three channels look consistent with each other and with the rest of the site, including per-shop branding colors.

## Verification

- `cd frontend && ./node_modules/.bin/tsc -b --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e130a7c4-53d4-4658-87df-cd2d145874e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e130a7c4-53d4-4658-87df-cd2d145874e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

