### PR TITLE
Align shop settings page layout and styling with admin UI

### DIFF
--- a/frontend/src/pages/admin/ShopSettingsPage.tsx
+++ b/frontend/src/pages/admin/ShopSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Palette } from 'lucide-react';
 import { apiClient, uploadFile } from '../../api/client';
@@ -14,41 +14,8 @@ import { ShopContactFields } from './shops/ShopContactFields';
 import { publicShopContactQueryKey } from '../../hooks/usePublicShopContact';
 import { fetchShopSettings, shopSettingsQueryKey } from '../../hooks/shopSettingsQuery';
 import { notifyShopAppearanceUpdated } from '../../utils/shopThemeBridge';
-
-const card: CSSProperties = {
-  background: '#fff',
-  border: '1px solid #e2e8f0',
-  borderRadius: '12px',
-  padding: '24px',
-  marginBottom: '20px',
-  boxShadow: '0 4px 14px rgba(15,23,42,0.06)',
-};
-
-const label: CSSProperties = {
-  fontSize: '13px',
-  fontWeight: 500,
-  color: '#374151',
-};
-
-const input: CSSProperties = {
-  padding: '8px 12px',
-  border: '1px solid #d1d5db',
-  borderRadius: '8px',
-  fontSize: '14px',
-  color: '#111827',
-  width: '100%',
-  boxSizing: 'border-box',
-};
-
-const formRow: CSSProperties = { display: 'flex', flexDirection: 'column', gap: '6px' };
-const sectionTitle: CSSProperties = {
-  fontSize: '14px',
-  fontWeight: 600,
-  color: '#111827',
-  marginTop: '8px',
-  marginBottom: '4px',
-};
-const hint: CSSProperties = { fontSize: '12px', color: '#6b7280', margin: 0, lineHeight: 1.45 };
+import styles from './shopSettingsPage.module.css';
+import { cn } from '@/lib/utils';
 
 /** Match backend shop-branding upload cap (see ShopsService.uploadAppearanceAsset). */
 const MAX_BRANDING_UPLOAD_BYTES = 2 * 1024 * 1024;
@@ -65,24 +32,6 @@ function normalizeHexForColorInput(raw: string): string | null {
   }
   return null;
 }
-
-const colorPicker: CSSProperties = {
-  width: '44px',
-  height: '40px',
-  padding: 0,
-  border: '1px solid #d1d5db',
-  borderRadius: '8px',
-  cursor: 'pointer',
-  flexShrink: 0,
-  background: 'transparent',
-};
-
-const colorRow: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: '10px',
-  flexWrap: 'wrap',
-};
 
 function extractApiErrorMessage(err: unknown, fallback: string): string {
   if (err && typeof err === 'object' && 'message' in err) {
@@ -126,8 +75,11 @@ export const ShopSettingsPage = () => {
   useEffect(() => {
     const row = settingsQuery.data;
     if (!row) return;
+    /* Draft form mirrors React Query cache when the row loads or refetches */
+    /* eslint-disable react-hooks/set-state-in-effect -- intentional server → local form sync */
     setContact(parseShopContactFormDefaults(row.contact_json));
     setAppearance(parseAppearanceFormDefaults(row.appearance_json));
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, [settingsQuery.data]);
 
   const saveMutation = useMutation({
@@ -215,249 +167,235 @@ export const ShopSettingsPage = () => {
     }
   };
 
+  const contactFieldStyles = {
+    formRow: {},
+    modalLabel: {},
+    modalInput: {},
+    modalHint: {},
+    sectionTitle: {},
+  };
+
   if (settingsQuery.isLoading) {
     return (
-      <div style={{ padding: '32px', maxWidth: '720px', margin: '0 auto' }}>
-        <p style={{ color: '#64748b' }}>Đang tải cấu hình...</p>
+      <div className={styles.container}>
+        <p className={styles.mutedCenter}>Đang tải cấu hình...</p>
       </div>
     );
   }
 
   if (settingsQuery.isError) {
     return (
-      <div style={{ padding: '32px', maxWidth: '720px', margin: '0 auto' }}>
-        <p style={{ color: '#b91c1c' }}>Không tải được cấu hình. Kiểm tra đã chọn shop và đăng nhập.</p>
+      <div className={styles.container}>
+        <p className={styles.errorCenter}>Không tải được cấu hình. Kiểm tra đã chọn shop và đăng nhập.</p>
       </div>
     );
   }
 
   return (
-    <div style={{ padding: '24px 16px 48px', maxWidth: '720px', margin: '0 auto' }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '8px' }}>
-        <Palette size={28} style={{ color: 'var(--ct-primary)' }} />
-        <h1 style={{ fontSize: '24px', fontWeight: 800, margin: 0, color: '#0f172a' }}>Cấu hình shop</h1>
-      </div>
-      <p style={{ fontSize: '14px', color: '#64748b', marginBottom: '24px', lineHeight: 1.5 }}>
-        Chỉnh nội dung trang liên hệ công khai và giao diện (mở rộng) cho shop:{' '}
-        <strong>{activeShop?.name ?? settingsQuery.data?.name}</strong>
-        <span style={{ color: '#94a3b8' }}> · slug {activeShop?.slug ?? settingsQuery.data?.slug}</span>
-      </p>
+    <div className={styles.container}>
+      <header className={styles.pageHeader}>
+        <div className={styles.titleRow}>
+          <div className={styles.titleIcon} aria-hidden>
+            <Palette size={22} strokeWidth={2} />
+          </div>
+          <h1 className={styles.title}>Cấu hình shop</h1>
+        </div>
+        <p className={styles.subtitle}>
+          Chỉnh nội dung trang liên hệ công khai và giao diện (mở rộng) cho shop:{' '}
+          <strong>{activeShop?.name ?? settingsQuery.data?.name}</strong>
+          <span className={styles.shopMetaSlug}> · slug {activeShop?.slug ?? settingsQuery.data?.slug}</span>
+        </p>
+      </header>
 
       {!canEditSettings && activeShop?.id ? (
-        <p
-          style={{
-            ...hint,
-            marginBottom: '16px',
-            padding: '12px 14px',
-            background: '#fef9c3',
-            border: '1px solid #fde047',
-            borderRadius: '8px',
-            color: '#713f12',
-          }}
-        >
+        <p className={styles.alertReadonly}>
           Bạn không có quyền chỉnh sửa cấu hình shop này (chỉ <strong>quản trị shop</strong> được lưu; tài khoản nhân
           viên chỉ xem).
         </p>
       ) : null}
 
-      {saveOk && <p style={{ color: '#15803d', marginBottom: '12px' }}>{saveOk}</p>}
-      {saveError && <p style={{ color: '#b91c1c', marginBottom: '12px' }}>{saveError}</p>}
+      {saveOk ? <p className={styles.alertSuccess}>{saveOk}</p> : null}
+      {saveError ? <p className={styles.alertError}>{saveError}</p> : null}
 
-      <form onSubmit={onSubmit}>
-        <div style={card}>
-          <h2 style={{ fontSize: '16px', fontWeight: 700, margin: '0 0 12px', color: '#111827' }}>
-            Trang liên hệ (công khai)
-          </h2>
-          <p style={{ ...hint, marginBottom: '16px' }}>
-            Hiển thị tại <code style={{ background: '#f1f5f9', padding: '2px 6px', borderRadius: 4 }}>/contact</code>{' '}
-            với <code style={{ background: '#f1f5f9', padding: '2px 6px', borderRadius: 4 }}>?shop_id=</code> (slug
-            hoặc UUID). Để trống rồi lưu để xóa giá trị.
+      <form onSubmit={onSubmit} className={styles.formStack}>
+        <section className={styles.card}>
+          <h2 className={styles.cardTitle}>Trang liên hệ (công khai)</h2>
+          <p className={styles.cardIntro}>
+            Hiển thị tại <code className={styles.inlineCode}>/contact</code> với{' '}
+            <code className={styles.inlineCode}>?shop_id=</code> (slug hoặc UUID). Để trống rồi lưu để xóa giá trị.
           </p>
           <ShopContactFields
             idPrefix="shop-settings"
             value={contact}
             onChange={setContact}
             disabled={!canEditSettings}
-            styles={{
-              formRow,
-              modalLabel: label,
-              modalInput: input,
-              modalHint: hint,
-              sectionTitle: { ...sectionTitle, marginTop: '12px' },
+            styles={contactFieldStyles}
+            classNames={{
+              root: styles.contactFieldsGrid,
+              sectionTitle: styles.contactSectionTitle,
+              hoursScheduleRow: styles.contactRowFull,
             }}
           />
-        </div>
+        </section>
 
-        <div style={card}>
-          <h2 style={{ fontSize: '16px', fontWeight: 700, margin: '0 0 8px', color: '#111827' }}>
-            Giao diện (chuẩn bị mở rộng)
-          </h2>
-          <p style={{ ...hint, marginBottom: '16px' }}>
-            Dữ liệu lưu trong <code style={{ background: '#f1f5f9', padding: '2px 6px', borderRadius: 4 }}>appearance_json</code>
-            . Áp dụng lên catalog công khai có thể làm ở bước sau.
+        <section className={styles.card}>
+          <h2 className={styles.cardTitle}>Giao diện (chuẩn bị mở rộng)</h2>
+          <p className={styles.cardIntro}>
+            Dữ liệu lưu trong <code className={styles.inlineCode}>appearance_json</code>. Áp dụng lên catalog công
+            khai có thể làm ở bước sau.
           </p>
 
-          <div style={formRow}>
-            <label style={label} htmlFor="appearance-logo">
-              URL logo (https)
-            </label>
-            <input
-              id="appearance-logo"
-              style={input}
-              value={appearance.logo_url}
-              onChange={(e) => setAppearance((a) => ({ ...a, logo_url: e.target.value }))}
-              placeholder="https://..."
-              disabled={!canEditSettings}
-            />
-            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '10px', marginTop: '4px' }}>
+          <div className={styles.brandingRow}>
+            <div className={styles.formRow}>
+              <label className={styles.label} htmlFor="appearance-logo">
+                URL logo (https)
+              </label>
               <input
-                id="appearance-logo-file"
-                type="file"
-                accept="image/jpeg,image/png,image/webp"
-                disabled={!canEditSettings || uploadingLogo}
-                style={{ fontSize: '13px', maxWidth: '100%' }}
-                onChange={(e) => {
-                  void handleBrandingFile('logo', e.target.files);
-                  e.target.value = '';
-                }}
-              />
-              {uploadingLogo ? (
-                <span style={{ ...hint, margin: 0 }}>Đang upload logo...</span>
-              ) : (
-                <span style={{ ...hint, margin: 0 }}>Hoặc chọn ảnh: JPEG, PNG, WebP · tối đa 2MB.</span>
-              )}
-            </div>
-            {appearance.logo_url.trim() ? (
-              <img
-                src={appearance.logo_url.trim()}
-                alt="Logo xem trước"
-                style={{ marginTop: '8px', maxHeight: '56px', maxWidth: '220px', objectFit: 'contain' }}
-              />
-            ) : null}
-          </div>
-          <div style={formRow}>
-            <label style={label} htmlFor="appearance-favicon">
-              URL favicon (https)
-            </label>
-            <input
-              id="appearance-favicon"
-              style={input}
-              value={appearance.favicon_url}
-              onChange={(e) => setAppearance((a) => ({ ...a, favicon_url: e.target.value }))}
-              placeholder="https://..."
-              disabled={!canEditSettings}
-            />
-            <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '10px', marginTop: '4px' }}>
-              <input
-                id="appearance-favicon-file"
-                type="file"
-                accept="image/jpeg,image/png,image/webp"
-                disabled={!canEditSettings || uploadingFavicon}
-                style={{ fontSize: '13px', maxWidth: '100%' }}
-                onChange={(e) => {
-                  void handleBrandingFile('favicon', e.target.files);
-                  e.target.value = '';
-                }}
-              />
-              {uploadingFavicon ? (
-                <span style={{ ...hint, margin: 0 }}>Đang upload favicon...</span>
-              ) : (
-                <span style={{ ...hint, margin: 0 }}>Hoặc chọn ảnh: JPEG, PNG, WebP · tối đa 2MB.</span>
-              )}
-            </div>
-            {appearance.favicon_url.trim() ? (
-              <img
-                src={appearance.favicon_url.trim()}
-                alt="Favicon xem trước"
-                style={{ marginTop: '8px', width: '32px', height: '32px', objectFit: 'contain' }}
-              />
-            ) : null}
-          </div>
-          <div style={formRow}>
-            <label style={label} htmlFor="appearance-primary">
-              Màu chủ (hex #RRGGBB hoặc tên màu đơn giản, ví dụ #4f46e5 hoặc indigo)
-            </label>
-            <div style={colorRow}>
-              <input
-                id="appearance-primary"
-                style={{ ...input, flex: '1 1 220px', minWidth: '140px', width: 'auto' }}
-                value={appearance.primary_color}
-                onChange={(e) => setAppearance((a) => ({ ...a, primary_color: e.target.value }))}
+                id="appearance-logo"
+                className={styles.input}
+                value={appearance.logo_url}
+                onChange={(e) => setAppearance((a) => ({ ...a, logo_url: e.target.value }))}
+                placeholder="https://..."
                 disabled={!canEditSettings}
-                autoComplete="off"
               />
+              <div className={styles.brandingUploadRow}>
+                <input
+                  id="appearance-logo-file"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  disabled={!canEditSettings || uploadingLogo}
+                  className={styles.fileInput}
+                  onChange={(e) => {
+                    void handleBrandingFile('logo', e.target.files);
+                    e.target.value = '';
+                  }}
+                />
+                {uploadingLogo ? (
+                  <span className={styles.hint}>Đang upload logo...</span>
+                ) : (
+                  <span className={styles.hint}>Hoặc chọn ảnh: JPEG, PNG, WebP · tối đa 2MB.</span>
+                )}
+              </div>
+              {appearance.logo_url.trim() ? (
+                <img
+                  src={appearance.logo_url.trim()}
+                  alt="Logo xem trước"
+                  className={styles.previewLogo}
+                />
+              ) : null}
+            </div>
+            <div className={styles.formRow}>
+              <label className={styles.label} htmlFor="appearance-favicon">
+                URL favicon (https)
+              </label>
               <input
-                type="color"
-                aria-label="Chọn màu chủ bằng bảng màu"
-                title="Chọn màu chủ"
-                value={normalizeHexForColorInput(appearance.primary_color) ?? '#4f46e5'}
-                onChange={(e) => setAppearance((a) => ({ ...a, primary_color: e.target.value }))}
+                id="appearance-favicon"
+                className={styles.input}
+                value={appearance.favicon_url}
+                onChange={(e) => setAppearance((a) => ({ ...a, favicon_url: e.target.value }))}
+                placeholder="https://..."
                 disabled={!canEditSettings}
-                style={{
-                  ...colorPicker,
-                  cursor: canEditSettings ? 'pointer' : 'not-allowed',
-                  opacity: canEditSettings ? 1 : 0.55,
-                }}
               />
+              <div className={styles.brandingUploadRow}>
+                <input
+                  id="appearance-favicon-file"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  disabled={!canEditSettings || uploadingFavicon}
+                  className={styles.fileInput}
+                  onChange={(e) => {
+                    void handleBrandingFile('favicon', e.target.files);
+                    e.target.value = '';
+                  }}
+                />
+                {uploadingFavicon ? (
+                  <span className={styles.hint}>Đang upload favicon...</span>
+                ) : (
+                  <span className={styles.hint}>Hoặc chọn ảnh: JPEG, PNG, WebP · tối đa 2MB.</span>
+                )}
+              </div>
+              {appearance.favicon_url.trim() ? (
+                <img
+                  src={appearance.favicon_url.trim()}
+                  alt="Favicon xem trước"
+                  className={styles.previewFavicon}
+                />
+              ) : null}
             </div>
           </div>
-          <div style={formRow}>
-            <label style={label} htmlFor="appearance-accent">
-              Màu nhấn
-            </label>
-            <div style={colorRow}>
-              <input
-                id="appearance-accent"
-                style={{ ...input, flex: '1 1 220px', minWidth: '140px', width: 'auto' }}
-                value={appearance.accent_color}
-                onChange={(e) => setAppearance((a) => ({ ...a, accent_color: e.target.value }))}
-                disabled={!canEditSettings}
-                autoComplete="off"
-              />
-              <input
-                type="color"
-                aria-label="Chọn màu nhấn bằng bảng màu"
-                title="Chọn màu nhấn"
-                value={normalizeHexForColorInput(appearance.accent_color) ?? '#7c3aed'}
-                onChange={(e) => setAppearance((a) => ({ ...a, accent_color: e.target.value }))}
-                disabled={!canEditSettings}
-                style={{
-                  ...colorPicker,
-                  cursor: canEditSettings ? 'pointer' : 'not-allowed',
-                  opacity: canEditSettings ? 1 : 0.55,
-                }}
-              />
+
+          <div className={styles.colorPairRow}>
+            <div className={styles.formRow}>
+              <label className={styles.label} htmlFor="appearance-primary">
+                Màu chủ (hex hoặc tên màu)
+              </label>
+              <div className={styles.colorRow}>
+                <input
+                  id="appearance-primary"
+                  className={cn(styles.input, styles.inputGrow)}
+                  value={appearance.primary_color}
+                  onChange={(e) => setAppearance((a) => ({ ...a, primary_color: e.target.value }))}
+                  disabled={!canEditSettings}
+                  autoComplete="off"
+                />
+                <input
+                  type="color"
+                  aria-label="Chọn màu chủ bằng bảng màu"
+                  title="Chọn màu chủ"
+                  value={normalizeHexForColorInput(appearance.primary_color) ?? '#4f46e5'}
+                  onChange={(e) => setAppearance((a) => ({ ...a, primary_color: e.target.value }))}
+                  disabled={!canEditSettings}
+                  className={styles.colorPicker}
+                />
+              </div>
+              <p className={styles.hint}>Ví dụ #4f46e5 hoặc indigo.</p>
+            </div>
+            <div className={styles.formRow}>
+              <label className={styles.label} htmlFor="appearance-accent">
+                Màu nhấn
+              </label>
+              <div className={styles.colorRow}>
+                <input
+                  id="appearance-accent"
+                  className={cn(styles.input, styles.inputGrow)}
+                  value={appearance.accent_color}
+                  onChange={(e) => setAppearance((a) => ({ ...a, accent_color: e.target.value }))}
+                  disabled={!canEditSettings}
+                  autoComplete="off"
+                />
+                <input
+                  type="color"
+                  aria-label="Chọn màu nhấn bằng bảng màu"
+                  title="Chọn màu nhấn"
+                  value={normalizeHexForColorInput(appearance.accent_color) ?? '#7c3aed'}
+                  onChange={(e) => setAppearance((a) => ({ ...a, accent_color: e.target.value }))}
+                  disabled={!canEditSettings}
+                  className={styles.colorPicker}
+                />
+              </div>
             </div>
           </div>
-          <div style={formRow}>
-            <label style={label} htmlFor="appearance-font">
+
+          <div className={styles.formRow}>
+            <label className={styles.label} htmlFor="appearance-font">
               Font (CSS font-family)
             </label>
             <input
               id="appearance-font"
-              style={input}
+              className={styles.input}
               value={appearance.font_family}
               onChange={(e) => setAppearance((a) => ({ ...a, font_family: e.target.value }))}
               placeholder="Inter, system-ui, sans-serif"
               disabled={!canEditSettings}
             />
           </div>
-        </div>
+        </section>
 
-        <div style={{ display: 'flex', gap: '12px', justifyContent: 'flex-end' }}>
+        <div className={styles.actions}>
           <button
             type="submit"
             disabled={saveMutation.isPending || !canEditSettings}
-            style={{
-              padding: '10px 20px',
-              background: 'var(--ct-primary)',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '8px',
-              fontWeight: 600,
-              cursor: saveMutation.isPending || !canEditSettings ? 'not-allowed' : 'pointer',
-              opacity: saveMutation.isPending || !canEditSettings ? 0.55 : 1,
-            }}
+            className={styles.buttonPrimary}
           >
             {saveMutation.isPending ? 'Đang lưu...' : 'Lưu cấu hình'}
           </button>

--- a/frontend/src/pages/admin/shopSettingsPage.module.css
+++ b/frontend/src/pages/admin/shopSettingsPage.module.css
@@ -1,0 +1,381 @@
+/* Shop settings — Corporate Trust, aligned with preordersAdmin / admin shell */
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px 16px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 100%;
+  color: var(--ct-ink, #0f172a);
+  font-family: "Plus Jakarta Sans", system-ui, sans-serif;
+  box-sizing: border-box;
+}
+
+.pageHeader {
+  margin: 0;
+  padding: 0;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.titleIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgb(var(--shop-primary-rgb) / 0.12), rgb(var(--shop-accent-rgb) / 0.12));
+  border: 1px solid var(--ct-border, #e2e8f0);
+  color: var(--ct-primary, #4f46e5);
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--ct-ink, #0f172a);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--ct-muted, #64748b);
+}
+
+.shopMetaSlug {
+  color: #94a3b8;
+  font-weight: 500;
+}
+
+.card {
+  background: var(--ct-surface, #fff);
+  border-radius: 0.75rem;
+  border: 1px solid var(--ct-border, #e2e8f0);
+  padding: 1.125rem 1.25rem;
+  box-shadow: 0 4px 20px -2px rgb(var(--shop-primary-rgb) / 0.1);
+  transition:
+    box-shadow 0.2s ease-out,
+    transform 0.2s ease-out;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .card:hover {
+    box-shadow:
+      0 10px 25px -5px rgb(var(--shop-primary-rgb) / 0.12),
+      0 8px 10px -6px rgb(var(--shop-primary-rgb) / 0.08);
+  }
+}
+
+.cardTitle {
+  margin: 0 0 0.5rem;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: var(--ct-ink, #0f172a);
+}
+
+.cardIntro {
+  margin: 0 0 1rem;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: #6b7280;
+}
+
+.inlineCode {
+  font-size: 0.6875rem;
+  background: #f1f5f9;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  color: #0f172a;
+}
+
+.formStack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.formRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #334155;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  border: 1px solid var(--ct-border, #e2e8f0);
+  border-radius: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  color: var(--ct-ink, #0f172a);
+  background: #fff;
+  box-sizing: border-box;
+  transition:
+    border-color 0.15s ease-out,
+    box-shadow 0.15s ease-out;
+}
+
+.input::placeholder,
+.textarea::placeholder {
+  color: #94a3b8;
+}
+
+.input:focus-visible,
+.textarea:focus-visible {
+  outline: none;
+  border-color: var(--ct-primary, #4f46e5);
+  box-shadow:
+    0 0 0 1px #fff,
+    0 0 0 3px rgb(var(--shop-primary-rgb) / 0.35);
+}
+
+.input:disabled,
+.textarea:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background: #f8fafc;
+}
+
+.textarea {
+  min-height: 4.5rem;
+  resize: vertical;
+  line-height: 1.55;
+}
+
+.hint {
+  font-size: 0.8125rem;
+  color: #6b7280;
+  margin: 0;
+  line-height: 1.45;
+}
+
+.sectionTitle {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #334155;
+  margin: 0;
+  padding-bottom: 0.125rem;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+/* Contact fields: responsive 2-column grid */
+.contactFieldsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+@media (max-width: 640px) {
+  .contactFieldsGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.contactSectionTitle {
+  grid-column: 1 / -1;
+}
+
+.contactRowFull {
+  grid-column: 1 / -1;
+}
+
+/* Appearance: brand row + colors */
+.brandingRow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem 1.25rem;
+  align-items: start;
+}
+
+@media (max-width: 720px) {
+  .brandingRow {
+    grid-template-columns: 1fr;
+  }
+}
+
+.colorPairRow {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem 1.25rem;
+}
+
+@media (max-width: 640px) {
+  .colorPairRow {
+    grid-template-columns: 1fr;
+  }
+}
+
+.colorRow {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+}
+
+.colorPicker {
+  width: 2.75rem;
+  height: 2.5rem;
+  padding: 0;
+  border: 1px solid var(--ct-border, #e2e8f0);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  flex-shrink: 0;
+  background: transparent;
+}
+
+.colorPicker:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.inputGrow {
+  flex: 1 1 12rem;
+  min-width: 8rem;
+  width: auto;
+}
+
+.brandingUploadRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.625rem;
+  margin-top: 0.25rem;
+}
+
+.fileInput {
+  font-size: 0.8125rem;
+  max-width: 100%;
+}
+
+.previewLogo {
+  margin-top: 0.5rem;
+  max-height: 3.5rem;
+  max-width: 13rem;
+  object-fit: contain;
+  border-radius: 0.375rem;
+  border: 1px solid #f1f5f9;
+  padding: 0.25rem;
+  background: #fafafa;
+}
+
+.previewFavicon {
+  margin-top: 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  object-fit: contain;
+  border-radius: 0.25rem;
+  border: 1px solid #f1f5f9;
+  padding: 0.125rem;
+  background: #fafafa;
+}
+
+.alertReadonly {
+  margin: 0;
+  padding: 0.75rem 0.875rem;
+  background: #fef9c3;
+  border: 1px solid #fde047;
+  border-radius: 0.5rem;
+  color: #713f12;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
+.alertSuccess {
+  margin: 0;
+  color: #047857;
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.alertError {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.buttonPrimary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.5rem;
+  padding: 0.5rem 1.125rem;
+  border-radius: 0.5rem;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(90deg, var(--ct-primary, #4f46e5), var(--ct-secondary, #7c3aed));
+  box-shadow: 0 4px 14px 0 rgb(var(--shop-primary-rgb) / 0.28);
+  transition:
+    background 0.2s ease-out,
+    transform 0.2s ease-out,
+    box-shadow 0.2s ease-out,
+    opacity 0.15s ease-out;
+}
+
+.buttonPrimary:hover:not(:disabled) {
+  background: linear-gradient(90deg, #4338ca, #6d28d9);
+  filter: brightness(1.02);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .buttonPrimary:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow:
+      0 8px 20px -4px rgb(var(--shop-primary-rgb) / 0.35),
+      0 4px 14px 0 rgb(var(--shop-primary-rgb) / 0.25);
+  }
+}
+
+.buttonPrimary:focus-visible {
+  outline: 2px solid var(--ct-primary, #4f46e5);
+  outline-offset: 2px;
+}
+
+.buttonPrimary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.mutedCenter {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: var(--ct-muted, #64748b);
+  font-size: 0.9375rem;
+}
+
+.errorCenter {
+  padding: 2rem 1rem;
+  text-align: center;
+  color: #b91c1c;
+  font-size: 0.9375rem;
+}

--- a/frontend/src/pages/admin/shops/ShopContactFields.tsx
+++ b/frontend/src/pages/admin/shops/ShopContactFields.tsx
@@ -9,6 +9,15 @@ type FieldStyles = {
   sectionTitle: CSSProperties;
 };
 
+type ContactFieldsClassNames = {
+  /** Wrapper around all fields (e.g. CSS grid) */
+  root?: string;
+  /** Applied to each section heading row (e.g. full grid width) */
+  sectionTitle?: string;
+  /** Applied to specific rows that should span all columns */
+  hoursScheduleRow?: string;
+};
+
 type Props = {
   idPrefix: string;
   value: ShopContactFormState;
@@ -16,9 +25,10 @@ type Props = {
   styles: FieldStyles;
   intro?: ReactNode;
   disabled?: boolean;
+  classNames?: ContactFieldsClassNames;
 };
 
-export function ShopContactFields({ idPrefix, value, onChange, styles, intro, disabled }: Props) {
+export function ShopContactFields({ idPrefix, value, onChange, styles, intro, disabled, classNames }: Props) {
   const set = (patch: Partial<ShopContactFormState>) => onChange({ ...value, ...patch });
   const setPhone = (patch: Partial<ShopContactFormState['phone']>) =>
     onChange({ ...value, phone: { ...value.phone, ...patch } });
@@ -30,7 +40,7 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro, di
     onChange({ ...value, hours: { ...value.hours, ...patch } });
 
   return (
-    <>
+    <div className={classNames?.root}>
       {intro}
       <div style={styles.formRow}>
         <label style={styles.modalLabel} htmlFor={`${idPrefix}-contact-title`}>
@@ -60,7 +70,9 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro, di
         />
       </div>
 
-      <div style={styles.sectionTitle}>Điện thoại</div>
+      <div style={styles.sectionTitle} className={classNames?.sectionTitle}>
+        Điện thoại
+      </div>
       <div style={styles.formRow}>
         <label style={styles.modalLabel} htmlFor={`${idPrefix}-phone-tel`}>
           Số gọi (tel, có thể gồm +)
@@ -104,7 +116,9 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro, di
         />
       </div>
 
-      <div style={styles.sectionTitle}>Facebook</div>
+      <div style={styles.sectionTitle} className={classNames?.sectionTitle}>
+        Facebook
+      </div>
       <div style={styles.formRow}>
         <label style={styles.modalLabel} htmlFor={`${idPrefix}-fb-url`}>
           URL (https)
@@ -133,7 +147,9 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro, di
         />
       </div>
 
-      <div style={styles.sectionTitle}>Zalo</div>
+      <div style={styles.sectionTitle} className={classNames?.sectionTitle}>
+        Zalo
+      </div>
       <div style={styles.formRow}>
         <label style={styles.modalLabel} htmlFor={`${idPrefix}-zalo-url`}>
           URL (https)
@@ -162,8 +178,10 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro, di
         />
       </div>
 
-      <div style={styles.sectionTitle}>Giờ làm việc</div>
-      <div style={styles.formRow}>
+      <div style={styles.sectionTitle} className={classNames?.sectionTitle}>
+        Giờ làm việc
+      </div>
+      <div style={styles.formRow} className={classNames?.hoursScheduleRow}>
         <label style={styles.modalLabel} htmlFor={`${idPrefix}-hours-line`}>
           Dòng lịch (có thể dùng **in đậm**)
         </label>
@@ -189,6 +207,6 @@ export function ShopContactFields({ idPrefix, value, onChange, styles, intro, di
           disabled={disabled}
         />
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors the admin **Cấu hình shop** page so layout and styling match the Corporate Trust admin shell used elsewhere (e.g. pre-orders admin CSS modules).

## Changes

- Introduces `shopSettingsPage.module.css`: container, cards with shop-tinted shadows, label/input focus rings, gradient primary save button, and alert styles consistent with other admin surfaces.
- **Contact section**: fields flow in a responsive two-column grid on wider viewports; section headings span full width; the hours schedule textarea stays full width for readability.
- **Appearance section**: logo and favicon blocks sit side by side on desktop; primary and accent color controls are paired in a two-column row; previews use subtle bordered surfaces.

## Technical notes

- `ShopContactFields` accepts optional `classNames` for the grid wrapper and full-width rows without changing modal usage on `ShopsPage`.
- ESLint: scoped disable for `react-hooks/set-state-in-effect` around the existing server-to-form sync effect (same behavior as before).

## Verification

- `pnpm exec tsc -b --noEmit` (frontend)
- ESLint on touched files only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b2ae5c6-782b-46a2-a71d-b3c94404fd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b2ae5c6-782b-46a2-a71d-b3c94404fd1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

