### PR TITLE
feat(catalog): gom bộ lọc & sort (issue #154)

### DIFF
--- a/frontend/src/components/catalog/CatalogFilters.tsx
+++ b/frontend/src/components/catalog/CatalogFilters.tsx
@@ -15,12 +15,17 @@ interface CatalogFiltersProps {
 }
 
 const chipBase =
-  'min-h-[44px] rounded-full border px-4 py-2 text-sm font-semibold transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2';
+  'min-h-[44px] shrink-0 rounded-full border px-3 py-2 text-sm font-semibold transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2';
 
 const chipInactive =
   'border-slate-200 bg-white text-slate-700 shadow-sm hover:border-shop/25 hover:bg-shop/5 active:bg-shop/10 hover:text-shop';
 const chipActive =
   'border-transparent bg-gradient-to-r from-shop to-shopAccent text-white shadow-corporate-btn hover:-translate-y-0.5 hover:shadow-corporate-card-hover active:translate-y-0 active:brightness-95';
+
+const scrollRowClass =
+  'flex gap-2 overflow-x-auto pb-1 pt-0.5 [-webkit-overflow-scrolling:touch]';
+
+const sectionTitleClass = 'mb-2 text-xs font-bold uppercase tracking-wide text-slate-500';
 
 export const CatalogFilters = ({
   shopId,
@@ -78,7 +83,7 @@ export const CatalogFilters = ({
   };
 
   return (
-    <div className="mb-2 space-y-8">
+    <div className="space-y-4">
       {isCategoriesError && (
         <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-medium text-amber-900">
           Không thể tải bộ lọc lúc này.
@@ -90,8 +95,8 @@ export const CatalogFilters = ({
       )}
       {carBrands.length > 0 && (
         <div>
-          <h3 className="mb-3 text-sm font-bold uppercase tracking-wide text-slate-500">Hãng xe</h3>
-          <div className="flex flex-wrap gap-2">
+          <h3 className={sectionTitleClass}>Hãng xe</h3>
+          <div className={scrollRowClass}>
             {carBrands.map((brand) => (
               <button
                 key={brand}
@@ -108,8 +113,8 @@ export const CatalogFilters = ({
 
       {modelBrands.length > 0 && (
         <div>
-          <h3 className="mb-3 text-sm font-bold uppercase tracking-wide text-slate-500">Hãng mô hình</h3>
-          <div className="flex flex-wrap gap-2">
+          <h3 className={sectionTitleClass}>Hãng mô hình</h3>
+          <div className={scrollRowClass}>
             {modelBrands.map((brand) => (
               <button
                 key={brand}
@@ -125,8 +130,8 @@ export const CatalogFilters = ({
       )}
 
       <div>
-        <h3 className="mb-3 text-sm font-bold uppercase tracking-wide text-slate-500">Tình trạng</h3>
-        <div className="flex flex-wrap gap-2">
+        <h3 className={sectionTitleClass}>Tình trạng</h3>
+        <div className={scrollRowClass}>
           <button
             type="button"
             onClick={() => handleConditionClick('new')}

--- a/frontend/src/components/catalog/CatalogSort.tsx
+++ b/frontend/src/components/catalog/CatalogSort.tsx
@@ -1,46 +1,66 @@
 import { cn } from '../../lib/utils';
+import type { CatalogSortBy, CatalogSortOrder } from '../../pages/publicCatalogUrlState';
 
 interface CatalogSortProps {
-  sortBy: 'name' | 'price' | 'created_at';
-  sortOrder: 'asc' | 'desc';
-  onSortChange: (sortBy: 'name' | 'price' | 'created_at', sortOrder: 'asc' | 'desc') => void;
+  sortBy: CatalogSortBy;
+  sortOrder: CatalogSortOrder;
+  onSortChange: (sortBy: CatalogSortBy, sortOrder: CatalogSortOrder) => void;
+  id?: string;
+  className?: string;
 }
 
-const btn =
-  'min-h-[44px] rounded-lg border px-4 py-2 text-sm font-semibold transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2';
+const SORT_OPTIONS: { value: `${CatalogSortBy}:${CatalogSortOrder}`; label: string }[] = [
+  { value: 'created_at:desc', label: 'Mới nhất' },
+  { value: 'created_at:asc', label: 'Cũ nhất (theo ngày)' },
+  { value: 'price:desc', label: 'Giá giảm dần' },
+  { value: 'price:asc', label: 'Giá tăng dần' },
+  { value: 'name:asc', label: 'Tên A → Z' },
+  { value: 'name:desc', label: 'Tên Z → A' },
+];
 
-const btnOff =
-  'border-slate-200 bg-white text-slate-700 shadow-sm hover:border-shop/25 hover:bg-slate-50 active:bg-slate-100';
-const btnOn =
-  'border-transparent bg-shop/10 text-shop ring-1 ring-shop/20 hover:bg-shop/15 active:bg-shop/15';
+function parseSortValue(value: string): { sortBy: CatalogSortBy; sortOrder: CatalogSortOrder } | null {
+  const colon = value.indexOf(':');
+  if (colon <= 0) {
+    return null;
+  }
+  const sortBy = value.slice(0, colon);
+  const sortOrder = value.slice(colon + 1);
+  if (sortBy !== 'name' && sortBy !== 'price' && sortBy !== 'created_at') {
+    return null;
+  }
+  if (sortOrder !== 'asc' && sortOrder !== 'desc') {
+    return null;
+  }
+  return { sortBy, sortOrder };
+}
 
-export const CatalogSort = ({ sortBy, sortOrder, onSortChange }: CatalogSortProps) => {
-  const handleSortClick = (field: 'name' | 'price' | 'created_at') => {
-    if (sortBy === field) {
-      onSortChange(field, sortOrder === 'asc' ? 'desc' : 'asc');
-    } else {
-      onSortChange(field, 'desc');
-    }
-  };
+export const CatalogSort = ({
+  sortBy,
+  sortOrder,
+  onSortChange,
+  id = 'catalog-sort',
+  className,
+}: CatalogSortProps) => {
+  const currentValue = `${sortBy}:${sortOrder}`;
 
   return (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-      <span className="text-sm font-bold uppercase tracking-wide text-slate-500">Sắp xếp</span>
-      <div className="flex flex-wrap gap-2">
-        <button type="button" onClick={() => handleSortClick('name')} className={cn(btn, sortBy === 'name' ? btnOn : btnOff)}>
-          Tên {sortBy === 'name' && (sortOrder === 'asc' ? '↑' : '↓')}
-        </button>
-        <button type="button" onClick={() => handleSortClick('price')} className={cn(btn, sortBy === 'price' ? btnOn : btnOff)}>
-          Giá {sortBy === 'price' && (sortOrder === 'asc' ? '↑' : '↓')}
-        </button>
-        <button
-          type="button"
-          onClick={() => handleSortClick('created_at')}
-          className={cn(btn, sortBy === 'created_at' ? btnOn : btnOff)}
-        >
-          Mới nhất {sortBy === 'created_at' && (sortOrder === 'asc' ? '↑' : '↓')}
-        </button>
-      </div>
-    </div>
+    <select
+      id={id}
+      aria-label="Sắp xếp kết quả"
+      className={cn('select-trust min-h-[44px] max-w-full sm:min-w-[220px]', className)}
+      value={SORT_OPTIONS.some((o) => o.value === currentValue) ? currentValue : SORT_OPTIONS[0].value}
+      onChange={(e) => {
+        const parsed = parseSortValue(e.target.value);
+        if (parsed) {
+          onSortChange(parsed.sortBy, parsed.sortOrder);
+        }
+      }}
+    >
+      {SORT_OPTIONS.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
   );
 };

--- a/frontend/src/pages/PublicCatalogPage.tsx
+++ b/frontend/src/pages/PublicCatalogPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useMemo, useEffect, useCallback, useId } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
 import { apiClient } from '../api/client';
@@ -145,6 +145,57 @@ export const PublicCatalogPage = () => {
     });
   };
 
+  const [filterPanelOpen, setFilterPanelOpen] = useState(false);
+  const sortFieldId = useId();
+  const filterPanelId = useId();
+  const filterPanelTitleId = useId();
+
+  const activeFilterCount = useMemo(() => {
+    let n = 0;
+    if (urlState.carBrand) {
+      n += 1;
+    }
+    if (urlState.modelBrand) {
+      n += 1;
+    }
+    if (urlState.condition) {
+      n += 1;
+    }
+    return n;
+  }, [urlState.carBrand, urlState.modelBrand, urlState.condition]);
+
+  const clearCatalogFilters = useCallback(() => {
+    updateUrlState({ carBrand: null, modelBrand: null, condition: null });
+  }, [updateUrlState]);
+
+  const closeFilterPanel = useCallback(() => {
+    setFilterPanelOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!filterPanelOpen) {
+      return;
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setFilterPanelOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [filterPanelOpen]);
+
+  useEffect(() => {
+    if (!filterPanelOpen) {
+      return;
+    }
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [filterPanelOpen]);
+
   const waitingForShopContext = !shopContextReady;
   const missingShopScope = shopContextReady && !publicApiShopReady;
 
@@ -226,23 +277,131 @@ export const PublicCatalogPage = () => {
         </section>
 
         <div className="rounded-2xl border border-slate-100 bg-white p-5 shadow-corporate-card sm:p-6 lg:p-8">
-          <CatalogFilters
-            shopId={effectiveShopId}
-            carBrand={urlState.carBrand}
-            modelBrand={urlState.modelBrand}
-            condition={urlState.condition}
-            onCarBrandChange={(nextCarBrand) => updateUrlState({ carBrand: nextCarBrand })}
-            onModelBrandChange={(nextModelBrand) => updateUrlState({ modelBrand: nextModelBrand })}
-            onConditionChange={(nextCondition) => updateUrlState({ condition: nextCondition })}
-          />
+          <div className="mb-6 flex flex-col gap-4">
+            {activeFilterCount > 0 && (
+              <div className="flex flex-wrap items-center gap-2" aria-live="polite">
+                <span className="text-xs font-bold uppercase tracking-wide text-slate-400">Đang lọc</span>
+                {urlState.carBrand && (
+                  <button
+                    type="button"
+                    className="inline-flex max-w-[min(100%,14rem)] items-center gap-1 rounded-full bg-shop/10 py-1 pl-3 pr-2 text-sm font-medium text-shop ring-1 ring-shop/15 hover:bg-shop/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2"
+                    onClick={() => updateUrlState({ carBrand: null })}
+                  >
+                    <span className="truncate">{urlState.carBrand}</span>
+                    <span className="text-base leading-none opacity-70" aria-hidden>
+                      ×
+                    </span>
+                    <span className="sr-only">Gỡ lọc hãng xe</span>
+                  </button>
+                )}
+                {urlState.modelBrand && (
+                  <button
+                    type="button"
+                    className="inline-flex max-w-[min(100%,14rem)] items-center gap-1 rounded-full bg-shop/10 py-1 pl-3 pr-2 text-sm font-medium text-shop ring-1 ring-shop/15 hover:bg-shop/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2"
+                    onClick={() => updateUrlState({ modelBrand: null })}
+                  >
+                    <span className="truncate">{urlState.modelBrand}</span>
+                    <span className="text-base leading-none opacity-70" aria-hidden>
+                      ×
+                    </span>
+                    <span className="sr-only">Gỡ lọc hãng mô hình</span>
+                  </button>
+                )}
+                {urlState.condition && (
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 rounded-full bg-shop/10 py-1 pl-3 pr-2 text-sm font-medium text-shop ring-1 ring-shop/15 hover:bg-shop/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2"
+                    onClick={() => updateUrlState({ condition: null })}
+                  >
+                    {urlState.condition === 'new' ? 'Mới' : 'Cũ'}
+                    <span className="text-base leading-none opacity-70" aria-hidden>
+                      ×
+                    </span>
+                    <span className="sr-only">Gỡ lọc tình trạng</span>
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="ml-1 text-sm font-semibold text-shop underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2"
+                  onClick={clearCatalogFilters}
+                >
+                  Xóa lọc
+                </button>
+              </div>
+            )}
 
-          <div className="mt-6 border-t border-slate-100 pt-6">
-            <CatalogSort
-              sortBy={urlState.sortBy}
-              sortOrder={urlState.sortOrder}
-              onSortChange={handleSortChange}
-            />
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+              <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-3">
+                <label htmlFor={sortFieldId} className="text-sm font-semibold text-slate-600">
+                  Sắp xếp
+                </label>
+                <CatalogSort
+                  id={sortFieldId}
+                  sortBy={urlState.sortBy}
+                  sortOrder={urlState.sortOrder}
+                  onSortChange={handleSortChange}
+                  className="min-w-0 flex-1 sm:max-w-xs"
+                />
+              </div>
+              <button
+                type="button"
+                className="inline-flex min-h-[44px] shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white px-5 py-2 text-sm font-semibold text-slate-800 shadow-sm transition-all hover:border-shop/30 hover:bg-shop/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2 active:bg-shop/10"
+                aria-expanded={filterPanelOpen}
+                aria-controls={filterPanelId}
+                onClick={() => setFilterPanelOpen(true)}
+              >
+                <span>Bộ lọc</span>
+                {activeFilterCount > 0 ? (
+                  <span className="ml-2 rounded-full bg-shop px-2 py-0.5 text-xs font-bold tabular-nums text-white">
+                    {activeFilterCount}
+                  </span>
+                ) : null}
+              </button>
+            </div>
           </div>
+
+          {filterPanelOpen ? (
+            <div className="fixed inset-0 z-50 flex items-end justify-center lg:items-center lg:p-4">
+              <button
+                type="button"
+                className="absolute inset-0 bg-slate-900/40 backdrop-blur-[1px]"
+                aria-label="Đóng bộ lọc"
+                onClick={closeFilterPanel}
+              />
+              <div
+                id={filterPanelId}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={filterPanelTitleId}
+                className="relative z-10 flex max-h-[min(92vh,840px)] w-full max-w-lg flex-col rounded-t-2xl border border-slate-100 bg-white shadow-corporate-card lg:max-h-[min(85vh,720px)] lg:rounded-2xl"
+              >
+                <div className="flex shrink-0 items-center justify-between border-b border-slate-100 px-4 py-3 sm:px-5">
+                  <h2 id={filterPanelTitleId} className="text-lg font-bold text-slate-900">
+                    Bộ lọc
+                  </h2>
+                  <button
+                    type="button"
+                    className="flex h-10 min-w-[44px] items-center justify-center rounded-lg text-2xl leading-none text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-shop focus-visible:ring-offset-2"
+                    onClick={closeFilterPanel}
+                    aria-label="Đóng"
+                  >
+                    ×
+                  </button>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-5">
+                  <CatalogFilters
+                    shopId={effectiveShopId}
+                    carBrand={urlState.carBrand}
+                    modelBrand={urlState.modelBrand}
+                    condition={urlState.condition}
+                    onCarBrandChange={(nextCarBrand) => updateUrlState({ carBrand: nextCarBrand })}
+                    onModelBrandChange={(nextModelBrand) => updateUrlState({ modelBrand: nextModelBrand })}
+                    onConditionChange={(nextCondition) => updateUrlState({ condition: nextCondition })}
+                  />
+                </div>
+              </div>
+            </div>
+          ) : null}
 
           {isLoading && items.length === 0 && (
             <div className="py-16 text-center">

--- a/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
+++ b/frontend/tests/unit/PublicCatalogPage.url-sync.test.tsx
@@ -120,6 +120,7 @@ describe('PublicCatalogPage URL sync', () => {
 
     render(<PublicCatalogPage />);
 
+    fireEvent.click(screen.getByRole('button', { name: /Bộ lọc/i }));
     fireEvent.click(screen.getByText('change-brand'));
     fireEvent.click(screen.getByText('change-sort'));
     fireEvent.change(screen.getByPlaceholderText('Tìm kiếm theo tên...'), {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements the public catalog filter UX from issue #154: a single toolbar with sort (dropdown), a **Bộ lọc** button that opens a modal/bottom sheet containing chip filters, compact chip rows with horizontal scroll, and active-filter pills with clear controls.

## Changes
- **`CatalogSort`**: Replaced three toggle buttons with a native `<select>` (six presets: newest/oldest by date, price asc/desc, name A–Z / Z–A) using `select-trust`.
- **`CatalogFilters`**: Reduced vertical spacing; chip rows scroll horizontally on narrow viewports.
- **`PublicCatalogPage`**: Toolbar row (sort + **Bộ lọc** with badge count); overlay panel (`role="dialog"`) with backdrop, Escape/scroll lock; “Đang lọc” removable pills + **Xóa lọc**.

## Tests
- Updated `PublicCatalogPage.url-sync` to open the filter panel before interacting with the mocked filter control.
- `pnpm --filter ./frontend run build` passes.

Closes #154
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e680f2a6-3c47-445b-aadf-4b8e68eaae6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e680f2a6-3c47-445b-aadf-4b8e68eaae6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

