### PR TITLE
Add backend `.env.production.example` for Pi/production

### DIFF
--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,0 +1,55 @@
+# Diecast360 backend — production template
+# Sao chép: cp .env.production.example .env  rồi thay mọi giá trị CHANGE_ME / URL mẫu.
+# Không commit file .env lên git. Chi tiết: docs/ENV.md, docs/DEPLOYMENT.md
+
+NODE_ENV=production
+
+# --- PostgreSQL (Neon khuyến nghị trên Pi) ---
+# Runtime: host có -pooler
+DATABASE_URL="postgresql://USER:PASSWORD@ep-xxx-pooler.REGION.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
+# Prisma migrate: host direct (không pooler)
+DIRECT_URL="postgresql://USER:PASSWORD@ep-xxx.REGION.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
+
+PORT=3000
+# Chỉ lắng nghe localhost nếu API chỉ ra ngoài qua Cloudflare Tunnel trỏ tới 127.0.0.1:3000
+HOST=127.0.0.1
+# Nếu cần bind toàn LAN: HOST=0.0.0.0
+
+# Origin UI production (Vercel / Pages / …), đúng scheme + host + port
+FRONTEND_URL="https://CHANGE_ME_YOUR_FRONTEND_HOST"
+# FRONTEND_URLS="https://preview.example.com"
+
+# URL public của API (HTTPS, không dấu / cuối) — dùng ký link /api/v1/media
+BACKEND_URL="https://CHANGE_ME_YOUR_API_HOST"
+
+# Thư mục upload trên server (tuyệt đối, tồn tại và ghi được)
+UPLOAD_DIR="/opt/diecast360-backend/uploads"
+# MAX_UPLOAD_MB=10
+# ALLOWED_MIME="image/jpeg,image/png,image/webp"
+
+# --- Auth (bắt buộc: mỗi secret ≥ 32 ký tự, entropy cao, không tái dùng từ dev) ---
+JWT_SECRET="CHANGE_ME_AT_LEAST_32_CHARACTERS_RANDOM"
+JWT_EXPIRES_IN="15m"
+REFRESH_TOKEN_EXPIRES_IN="7d"
+COOKIE_SECRET="CHANGE_ME_AT_LEAST_32_CHARACTERS_RANDOM"
+
+# Cookie production: HTTPS bắt buộc. Frontend khác subdomain/domain với API → thường dùng none + secure
+COOKIE_SECURE=true
+COOKIE_SAME_SITE=none
+# Cùng site (ít gặp khi API tách host) có thể: COOKIE_SAME_SITE=lax
+
+# Tắt LAN CORS trong production (bắt buộc khi NODE_ENV=production)
+CORS_ALLOW_LAN=false
+
+# Tách khỏi JWT để xoay JWT không làm hỏng URL ảnh đã ký (≥32 ký tự)
+MEDIA_SIGNING_SECRET="CHANGE_ME_AT_LEAST_32_CHARACTERS_RANDOM"
+# MEDIA_URL_TTL_MS=604800000
+
+# --- Tùy chọn: AI / vector / Facebook (bỏ trống hoặc xóa nếu không dùng) ---
+# OPENAI_API_KEY=
+# OPENAI_MODEL=gpt-4o-mini
+# PINECONE_API_KEY=
+# PINECONE_INDEX=
+# FACEBOOK_PAGE_ID=
+# FACEBOOK_PAGE_ACCESS_TOKEN=
+# FACEBOOK_GRAPH_API_VERSION=v21.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a tracked production-oriented environment template under `backend/.env.production.example` so operators can `cp` it to `.env` on a Pi or VPS without guessing required variables (Neon URLs, `NODE_ENV`, cookie hardening, `BACKEND_URL`, absolute `UPLOAD_DIR`, optional integrations).

Does not contain secrets. Full variable reference remains in `docs/ENV.md` and `docs/DEPLOYMENT.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-def712f5-455e-4e64-aa0f-556fe685b96b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-def712f5-455e-4e64-aa0f-556fe685b96b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

