### PR TITLE
fix(ci): install devDependencies before Nest build on Pi deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -44,7 +44,12 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
 
+      # NODE_ENV=production (e.g. in shell profile) makes `npm ci` skip devDependencies,
+      # so @nestjs/cli is missing and `nest build` fails — force dev deps for this step.
       - name: Install & build
+        env:
+          NPM_CONFIG_PRODUCTION: "false"
+          NODE_ENV: development
         run: |
           npm ci
           npm run build

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -77,7 +77,8 @@ Lợi ích: không cần mở cổng inbound trên router, không phụ thuộc 
 
   ```bash
   cd /path/to/Diecast360/backend
-  npm ci
+  # Không đặt NODE_ENV=production trước bước này — npm sẽ bỏ qua devDependencies và `nest` không có.
+  NPM_CONFIG_PRODUCTION=false NODE_ENV=development npm ci
   npm run build
   npm ci --omit=dev
   npx prisma generate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the Pi (or any environment where `NODE_ENV=production` is set globally, e.g. in `.bashrc`), `npm ci` omits **devDependencies**, so `@nestjs/cli` is never installed and `npm run build` fails with `sh: 1: nest: not found`.

## Changes

- **`.github/workflows/deploy-backend.yml`**: For the checkout `Install & build` step, set `NPM_CONFIG_PRODUCTION=false` and `NODE_ENV=development` so `npm ci` always installs dev tools needed for `nest build`.
- **`docs/DEPLOYMENT.md`**: Document the same pitfall for manual Pi builds before `npm ci` / `npm run build`.

## Neon `P1001`

That error is separate: the Pi could not open a TCP connection to the Neon host (paused project, wrong URL, outbound firewall/DNS, or typo in `.env`). After fixing the build, verify `DATABASE_URL` / `DIRECT_URL` and that the Neon project is active; test from the Pi with `nc -zv <neon-host> 5432` or the Neon dashboard “Wake”.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-def712f5-455e-4e64-aa0f-556fe685b96b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-def712f5-455e-4e64-aa0f-556fe685b96b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

