### PR TITLE
CD: chạy Prisma migrate trên GitHub-hosted, Pi chỉ build và restart

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,13 +1,16 @@
-# Deploy backend: build on a self-hosted runner on the Raspberry Pi, then sync into
-# DEPLOY_REMOTE_PATH (default /opt/diecast360-backend), npm ci, migrate, restart.
+# CD: (1) Apply Prisma migrations on GitHub-hosted runner (reaches Neon reliably).
+#     (2) Build on self-hosted Pi, sync to DEPLOY_REMOTE_PATH, generate client, restart.
 #
-# Requires a registered self-hosted runner with labels: self-hosted, diecast360-pi
-# (see docs/BACKEND_SELF_HOSTED_RUNNER.md).
+# Requires: self-hosted runner on the Pi with labels: self-hosted, diecast360-pi
+#           (see docs/BACKEND_SELF_HOSTED_RUNNER.md).
+#
+# GitHub Environment "production" secrets (for migrate job):
+#   PRODUCTION_DATABASE_URL — Neon pooled URL (same meaning as backend DATABASE_URL)
+#   PRODUCTION_DIRECT_URL     — Neon direct URL (for prisma migrate)
+#
+# Optional: workflow_dispatch input `skip_migrate` when Neon/GitHub already applied migrations.
 #
 # Optional secret: DEPLOY_REMOTE_PATH (default /opt/diecast360-backend)
-#
-# Legacy SSH deploy from GitHub-hosted runners is removed — use self-hosted on the Pi
-# or adapt a fork if you still need rsync over SSH.
 
 name: Deploy backend (Pi)
 
@@ -18,13 +21,55 @@ on:
       - "backend/**"
       - ".github/workflows/deploy-backend.yml"
   workflow_dispatch:
+    inputs:
+      skip_migrate:
+        description: "Skip prisma migrate (use if Neon/GitHub already migrated)"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: deploy-backend-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  migrate:
+    name: Prisma migrate (production)
+    runs-on: ubuntu-latest
+    environment: production
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Prisma generate & migrate deploy
+        if: ${{ github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && !fromJSON(github.event.inputs.skip_migrate || 'false')) }}
+        env:
+          DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.PRODUCTION_DIRECT_URL }}
+        run: |
+          npx prisma generate
+          npx prisma migrate deploy
+
+      - name: Skip migrate (manual dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' && fromJSON(github.event.inputs.skip_migrate || 'false') }}
+        run: echo "::notice::Skipped prisma migrate deploy — using Neon/GitHub or manual migration."
+
   deploy:
+    name: Build & deploy on Pi
+    needs: migrate
     runs-on: [self-hosted, diecast360-pi]
     environment: production
     env:
@@ -63,7 +108,7 @@ jobs:
           rsync -a ./package.json ./package-lock.json "${REDIR}/"
           rsync -a --delete ./prisma/ "${REDIR}/prisma/"
 
-      - name: Install prod deps, migrate, restart
+      - name: Install prod deps, generate, restart
         run: |
           set -euo pipefail
           REDIR="${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
@@ -75,7 +120,6 @@ jobs:
           PORT="${PORT:-3000}"
           npm ci --omit=dev
           npx prisma generate
-          npx prisma migrate deploy
           sudo systemctl restart diecast360-api
           systemctl is-active --quiet diecast360-api
           # Post-restart probe: Pi/Node may need several seconds before accepting IPv4.

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -1,6 +1,6 @@
 # Backend trên Raspberry Pi + Cloudflare Tunnel + GitHub Actions
 
-Luồng hiện tại: **self-hosted GitHub Actions runner chạy trực tiếp trên Pi** → `checkout` → build NestJS trên ARM → `rsync` `dist/`, `package.json`, `package-lock.json`, `prisma/` vào `DEPLOY_REMOTE_PATH` → `npm ci --omit=dev` → `prisma generate` → `prisma migrate deploy` → `systemctl restart` → probe `GET /api/v1/health`.
+Luồng hiện tại: job **migrate** trên **GitHub-hosted** (`prisma migrate deploy` với secret Neon) → job trên **Pi**: `checkout` → build NestJS trên ARM → `rsync` `dist/`, `package.json`, `package-lock.json`, `prisma/` vào `DEPLOY_REMOTE_PATH` → `npm ci --omit=dev` → `prisma generate` → `systemctl restart` → probe `GET /api/v1/health`.
 
 API ra ngoài qua **Cloudflare Tunnel** trỏ tới `http://127.0.0.1:3000` (hoặc cổng `PORT` trong `.env`).
 

--- a/docs/BACKEND_SELF_HOSTED_RUNNER.md
+++ b/docs/BACKEND_SELF_HOSTED_RUNNER.md
@@ -1,6 +1,6 @@
 # GitHub Actions self-hosted runner trên Raspberry Pi (deploy backend)
 
-Khi runner chạy **trực tiếp trên Pi**, workflow **không** SSH từ internet vào nhà: chỉ `checkout` → `build` trên ARM → `rsync` nội bộ vào thư mục deploy → `npm ci` → migrate → `systemctl restart`.
+Khi runner chạy **trực tiếp trên Pi**, workflow **không** SSH từ internet vào nhà: job **`migrate`** chạy trước trên **GitHub-hosted** (`prisma migrate deploy` với secret Neon); job deploy trên Pi chỉ `checkout` → `build` trên ARM → `rsync` nội bộ → `npm ci` → `prisma generate` → `systemctl restart`.
 
 **Nhãn runner bắt buộc:** workflow dùng `runs-on: [self-hosted, diecast360-pi]`. Khi đăng ký runner, thêm nhãn tùy chọn **`diecast360-pi`** (Settings → Actions → Runners → runner của bạn → labels), hoặc thêm lúc cấu hình lần đầu.
 
@@ -85,11 +85,15 @@ sudo chmod 440 /etc/sudoers.d/diecast360-api
 
 ---
 
-## Bước 4 — GitHub Secrets (tuỳ chọn)
+## Bước 4 — GitHub Secrets / Environment **production**
 
 | Secret | Mô tả |
 |--------|--------|
+| `PRODUCTION_DATABASE_URL` | **Bắt buộc cho CD** (trừ khi luôn deploy với *Skip prisma migrate*): Neon pooled — cùng giá trị `DATABASE_URL` trong `.env` Pi. |
+| `PRODUCTION_DIRECT_URL` | **Bắt buộc** cùng điều kiện trên: Neon direct — cùng giá trị `DIRECT_URL` trong `.env` Pi. |
 | `DEPLOY_REMOTE_PATH` | (Tuỳ chọn) Đường dẫn deploy; nếu **không** set → mặc định `/opt/diecast360-backend`. Ví dụ bạn dùng `/opt/diecast360-api` → đặt secret này thành **`/opt/diecast360-api`** (đúng dấu `/` đầu). |
+
+Đặt các secret trên trong **Settings → Environments → production** (workflow deploy gắn `environment: production`).
 
 ### Thư mục deploy là `/opt/diecast360-api` (không phải `-backend`)
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -129,19 +129,31 @@ Chi tiết Facebook, OpenAI, Pinecone: tùy tính năng bật — vẫn trong [`
 
 ## 5. Thứ tự triển khai đề xuất
 
-1. Neon: tạo project, gán `DATABASE_URL` / `DIRECT_URL`, chạy `prisma migrate deploy`.
+1. Neon: tạo project, gán `DATABASE_URL` / `DIRECT_URL`, chạy `prisma migrate deploy` (lần đầu có thể từ máy dev).
 2. Pi: cài Node, clone repo, tạo `backend/.env`, build, chạy thử local trên `127.0.0.1:3000`.
-3. Cloudflare Tunnel: public HTTPS → port 3000 trên Pi.
-4. Cập nhật `VITE_API_BASE_URL` trên host frontend, deploy lại frontend.
-5. Kiểm tra đăng nhập, upload nhỏ, catalog; đọc [`COOKIE_AUTH.md`](COOKIE_AUTH.md) nếu cookie cross-site lỗi.
+3. GitHub Environment **production**: thêm secret `PRODUCTION_DATABASE_URL` và `PRODUCTION_DIRECT_URL` (cùng giá trị như trên Pi — xem mục 6).
+4. Cloudflare Tunnel: public HTTPS → port 3000 trên Pi.
+5. Cập nhật `VITE_API_BASE_URL` trên host frontend, deploy lại frontend.
+6. Kiểm tra đăng nhập, upload nhỏ, catalog; đọc [`COOKIE_AUTH.md`](COOKIE_AUTH.md) nếu cookie cross-site lỗi.
 
-Tự động deploy backend khi merge `main`: cài [GitHub self-hosted runner trên Pi](BACKEND_SELF_HOSTED_RUNNER.md) và dùng workflow [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml). Workflow checkout/build trực tiếp trên Pi, sync `dist/`, `prisma/`, `package.json`, `package-lock.json` vào `DEPLOY_REMOTE_PATH` (mặc định `/opt/diecast360-backend`), chạy `npm ci --omit=dev`, `npx prisma generate`, `npx prisma migrate deploy`, restart `diecast360-api`, rồi probe `GET /api/v1/health`.
+Tự động deploy backend khi merge `main`: cài [GitHub self-hosted runner trên Pi](BACKEND_SELF_HOSTED_RUNNER.md) và dùng workflow [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml). Job đầu chạy trên **GitHub-hosted** (`ubuntu-latest`): `prisma migrate deploy` với secret Neon (không phụ thuộc mạng Pi). Job tiếp theo checkout/build trên Pi, sync `dist/`, `prisma/`, `package.json`, `package-lock.json` vào `DEPLOY_REMOTE_PATH`, chạy `npm ci --omit=dev`, `npx prisma generate`, restart `diecast360-api`, rồi probe `GET /api/v1/health`.
 
 ---
 
 ## 6. CI và migration
 
-Workflow CI mặc định: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). Deploy backend lên Pi (self-hosted runner): [`BACKEND_SELF_HOSTED_RUNNER.md`](BACKEND_SELF_HOSTED_RUNNER.md) và [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml). Migration production hiện chạy trong deploy job bằng `DIRECT_URL` từ `.env` trên Pi; không cần secret SSH cho workflow hiện tại.
+Workflow CI mặc định: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). Deploy backend: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml) và [`BACKEND_SELF_HOSTED_RUNNER.md`](BACKEND_SELF_HOSTED_RUNNER.md).
+
+**Migration production** chạy **trước** bước Pi, trên runner `ubuntu-latest`, biến lấy từ GitHub Environment **production**:
+
+| Secret | Ý nghĩa |
+|--------|---------|
+| `PRODUCTION_DATABASE_URL` | Neon pooled — giống `DATABASE_URL` trong `.env` Pi |
+| `PRODUCTION_DIRECT_URL` | Neon direct — giống `DIRECT_URL` trong `.env` Pi |
+
+Nếu bạn chỉ áp migration qua **Neon GitHub integration**, có thể chạy deploy thủ công với tùy chọn **Skip prisma migrate** (`workflow_dispatch`), hoặc vẫn đặt hai secret ở trên: `prisma migrate deploy` là lệnh idempotent (đã apply thì bỏ qua).
+
+Pi không cần mở outbound tới Neon chỉ để migrate trong CD (runtime API vẫn cần `DATABASE_URL` trong `.env` Pi).
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Thay đổi

- **Job `migrate`** (`ubuntu-latest`): `prisma generate` + `prisma migrate deploy` với secret Neon trong GitHub Environment **production** (`PRODUCTION_DATABASE_URL`, `PRODUCTION_DIRECT_URL`).
- **Job `deploy`** (self-hosted Pi): bỏ `prisma migrate deploy` khỏi bước cài đặt — Pi chỉ `npm ci --omit=dev`, `prisma generate`, restart service. Giảm rủi ro `P1001` khi Pi/mạng nhà không kết nối ổn tới Neon.
- **`workflow_dispatch`**: tùy chọn **Skip prisma migrate** khi migration đã được áp bởi Neon GitHub integration (hoặc thủ công).

## Việc cần làm trên GitHub (sau khi merge)

Trong **Settings → Environments → production → Environment secrets**, thêm:

- `PRODUCTION_DATABASE_URL` — cùng giá trị `DATABASE_URL` trong `.env` Pi (Neon pooled).
- `PRODUCTION_DIRECT_URL` — cùng giá trị `DIRECT_URL` trong `.env` Pi (Neon direct).

Nếu không đặt hai secret này, job migrate trên push `main` sẽ fail cho đến khi cấu hình xong.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8134a735-0051-4bfb-8684-47230b8c4de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8134a735-0051-4bfb-8684-47230b8c4de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

