### PR TITLE
build(backend): nest output dist/main.js (fix Pi systemd entrypoint)

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -3,7 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "tsConfigPath": "tsconfig.build.json"
   }
 }
 

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.security.spec.ts"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Vấn đề

`nest build` cũ dùng `tsconfig.json` không giới hạn `rootDir` nên TypeScript gom cả cây ngoài `src` → output thành **`dist/src/main.js`**, trong khi `package.json`, systemd và Docker trỏ **`dist/main.js`**.

## Cách xử lý

- Thêm **`backend/tsconfig.build.json`**: `rootDir: ./src`, `include: ["src/**/*"]`, exclude `*.spec.ts`.
- **`nest-cli.json`**: `compilerOptions.tsConfigPath`: `tsconfig.build.json`.

Sau build: **`dist/main.js`** như tài liệu deploy.

## Kiểm tra

- `npm run build` trong `backend/` → có `dist/main.js`.
- `pnpm --filter ./backend test` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8134a735-0051-4bfb-8684-47230b8c4de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8134a735-0051-4bfb-8684-47230b8c4de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

