### PR TITLE
fix(frontend): auto-append /api/v1 when VITE_API_BASE_URL is origin-only

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
+# Backend uses Nest prefix /api/v1 — you may set only the origin (e.g. https://api.example.com); it is normalized.
 VITE_API_BASE_URL=http://localhost:3000/api/v1
 VITE_ADMIN_SEMANTIC_SEARCH_ENABLED=false
 # Optional: default shop for public /preorders when visitor has no ?shop_id= and is not logged in

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -8,10 +8,40 @@ function resolveDefaultApiBaseUrl(): string {
   return '/api/v1';
 }
 
+/**
+ * Ensures absolute production URLs include `/api/v1` (Nest global prefix).
+ * Without this, setting `VITE_API_BASE_URL=https://api.example.com` makes Axios
+ * call `https://api.example.com/auth/me` → 404 instead of `/api/v1/auth/me`.
+ */
+export function normalizeConfiguredApiBaseUrl(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'auto') {
+    return trimmed;
+  }
+  if (trimmed.startsWith('/')) {
+    const noTrail = trimmed.replace(/\/+$/, '');
+    return noTrail || '/api/v1';
+  }
+  try {
+    const u = new URL(trimmed);
+    const path = u.pathname.replace(/\/+$/, '') || '';
+    if (path === '' || path === '/') {
+      return `${u.origin}/api/v1`;
+    }
+    if (path === '/api/v1' || path.endsWith('/api/v1')) {
+      return `${u.origin}${path}`;
+    }
+    return trimmed.replace(/\/+$/, '');
+  } catch {
+    return trimmed;
+  }
+}
+
 const configuredBaseUrl = (import.meta.env.VITE_API_BASE_URL || '').trim();
-const baseUrl = !configuredBaseUrl || configuredBaseUrl.toLowerCase() === 'auto'
-  ? resolveDefaultApiBaseUrl()
-  : configuredBaseUrl;
+const baseUrl =
+  !configuredBaseUrl || configuredBaseUrl.toLowerCase() === 'auto'
+    ? resolveDefaultApiBaseUrl()
+    : normalizeConfiguredApiBaseUrl(configuredBaseUrl);
 
 export const API_CONFIG = {
   BASE_URL: baseUrl,

--- a/frontend/tests/unit/api-config.test.ts
+++ b/frontend/tests/unit/api-config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeConfiguredApiBaseUrl } from '../../src/config/api';
+
+describe('normalizeConfiguredApiBaseUrl', () => {
+  it('appends /api/v1 when only origin is set (production footgun)', () => {
+    expect(normalizeConfiguredApiBaseUrl('https://api.nhtin.name.vn')).toBe(
+      'https://api.nhtin.name.vn/api/v1',
+    );
+    expect(normalizeConfiguredApiBaseUrl('https://api.nhtin.name.vn/')).toBe(
+      'https://api.nhtin.name.vn/api/v1',
+    );
+  });
+
+  it('leaves full API base unchanged', () => {
+    expect(normalizeConfiguredApiBaseUrl('https://api.example.com/api/v1')).toBe(
+      'https://api.example.com/api/v1',
+    );
+    expect(normalizeConfiguredApiBaseUrl('http://localhost:3000/api/v1')).toBe(
+      'http://localhost:3000/api/v1',
+    );
+  });
+
+  it('normalizes relative base paths', () => {
+    expect(normalizeConfiguredApiBaseUrl('/api/v1')).toBe('/api/v1');
+    expect(normalizeConfiguredApiBaseUrl('/api/v1/')).toBe('/api/v1');
+  });
+
+  it('does not rewrite uncommon path prefixes', () => {
+    expect(normalizeConfiguredApiBaseUrl('https://api.example.com/staging')).toBe(
+      'https://api.example.com/staging',
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Public frontend builds that set `VITE_API_BASE_URL` to only the API origin (e.g. `https://api.nhtin.name.vn`) caused Axios to request `/auth/me`, `/public/items`, etc. at the **host root**. Nest mounts everything under `/api/v1`, so the browser saw **404** for those URLs.

## Solution

- Normalize configured absolute URLs: if the path is empty or `/`, append `/api/v1`.
- Keep existing behavior for relative bases (`/api/v1`), full bases (`.../api/v1`), and unusual non-root paths (unchanged).
- Add Vitest coverage and a short note in `frontend/.env.example`.

## User follow-up

After merge, **rebuild and redeploy the static frontend** (no backend or tunnel change required for this fix). Existing env may stay as `https://api...` without `/api/v1` and will work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e6024dd-387b-40be-a8a9-5cf6e85df217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e6024dd-387b-40be-a8a9-5cf6e85df217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

