### PR TITLE
feat(frontend): full-page public shop gate overlay + SMIL dual-ring loader

### DIFF
--- a/frontend/src/components/public/PublicShopMainGate.tsx
+++ b/frontend/src/components/public/PublicShopMainGate.tsx
@@ -1,22 +1,24 @@
 import type { FC, ReactNode } from 'react';
+import { useEffect } from 'react';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
 import { publicRouteNeedsCatalogShopContact } from '../../config/routes';
 import { usePublicShopContext } from '../../hooks/usePublicShopContext';
 import { usePublicShopContact } from '../../hooks/usePublicShopContact';
 import type { PublicShopContactResponse } from '../../types/shopContactPublic';
+import { ShopLoadingRingSvg } from './ShopLoadingRingSvg';
 
 function SpinnerBlock({ caption }: { caption: string }) {
   return (
-    <div className="relative min-h-[50vh] px-4 py-16 sm:px-6" role="status" aria-busy="true" aria-live="polite">
-      <div className="mx-auto max-w-7xl">
-        <div className="py-16 text-center">
-          <div
-            className="mx-auto h-10 w-10 animate-spin rounded-full border-2 border-shop/25 border-t-shop"
-            aria-hidden
-          />
-          <p className="mt-4 text-sm font-medium text-slate-500">{caption}</p>
-        </div>
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-[#F8FAFC]/94 px-4 backdrop-blur-[2px] motion-reduce:backdrop-blur-none"
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="max-w-md text-center">
+        <ShopLoadingRingSvg className="mx-auto" />
+        <p className="mt-4 text-sm font-medium text-slate-500">{caption}</p>
       </div>
     </div>
   );
@@ -24,9 +26,9 @@ function SpinnerBlock({ caption }: { caption: string }) {
 
 function MissingShopScopePanel() {
   return (
-    <div className="relative min-h-[50vh] px-4 py-16 sm:px-6">
-      <div className="mx-auto max-w-7xl">
-        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-4 text-amber-900 shadow-corporate-card">
+    <div className="fixed inset-0 z-[200] overflow-y-auto bg-[#F8FAFC]/94 px-4 py-16 backdrop-blur-[2px] motion-reduce:backdrop-blur-none sm:px-6">
+      <div className="mx-auto flex min-h-full max-w-2xl items-center justify-center py-8">
+        <div className="w-full rounded-xl border border-amber-200 bg-amber-50 px-4 py-4 text-amber-900 shadow-corporate-card">
           <p className="font-semibold">Chưa chọn cửa hàng</p>
           <p className="mt-1 text-sm text-amber-800/90">
             Thêm <code className="rounded bg-amber-100/80 px-1">?shop_id=</code> vào URL (UUID hoặc slug cửa hàng), hoặc cấu hình biến build{' '}
@@ -40,9 +42,9 @@ function MissingShopScopePanel() {
 
 function PublicShopContactErrorPanel({ onRetry }: { onRetry: () => void }) {
   return (
-    <div className="relative min-h-[50vh] px-4 py-16 sm:px-6">
-      <div className="mx-auto max-w-7xl">
-        <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-4 text-rose-800 shadow-corporate-card">
+    <div className="fixed inset-0 z-[200] overflow-y-auto bg-[#F8FAFC]/94 px-4 py-16 backdrop-blur-[2px] motion-reduce:backdrop-blur-none sm:px-6">
+      <div className="mx-auto flex min-h-full max-w-2xl items-center justify-center py-8">
+        <div className="w-full rounded-xl border border-rose-200 bg-rose-50 px-4 py-4 text-rose-800 shadow-corporate-card">
           <p className="font-semibold">Không tải được cấu hình cửa hàng</p>
           <p className="mt-1 text-sm text-rose-700/90">Vui lòng thử lại.</p>
           <button
@@ -68,6 +70,21 @@ export const PublicShopMainGate: FC<{ children: ReactNode }> = ({ children }) =>
   const needsCatalogContact = publicRouteNeedsCatalogShopContact(pathname);
   const { shopContextReady, publicApiShopReady } = usePublicShopContext();
   const contactQuery: UseQueryResult<PublicShopContactResponse> = usePublicShopContact(needsCatalogContact);
+
+  const blocksInteraction =
+    needsCatalogContact &&
+    (!shopContextReady || !publicApiShopReady || contactQuery.isPending || contactQuery.isError);
+
+  useEffect(() => {
+    if (!blocksInteraction) {
+      return;
+    }
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [blocksInteraction]);
 
   if (!needsCatalogContact) {
     return <>{children}</>;

--- a/frontend/src/components/public/PublicShopMainGate.tsx
+++ b/frontend/src/components/public/PublicShopMainGate.tsx
@@ -1,5 +1,5 @@
 import type { FC, ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
 import { publicRouteNeedsCatalogShopContact } from '../../config/routes';
@@ -7,6 +7,17 @@ import { usePublicShopContext } from '../../hooks/usePublicShopContext';
 import { usePublicShopContact } from '../../hooks/usePublicShopContact';
 import type { PublicShopContactResponse } from '../../types/shopContactPublic';
 import { ShopLoadingRingSvg } from './ShopLoadingRingSvg';
+
+function formatQueryError(err: unknown): string {
+  if (err instanceof Error && err.message.trim()) {
+    return err.message.trim();
+  }
+  if (err && typeof err === 'object' && 'message' in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === 'string' && m.trim()) return m.trim();
+  }
+  return '';
+}
 
 function SpinnerBlock({ caption }: { caption: string }) {
   return (
@@ -26,10 +37,16 @@ function SpinnerBlock({ caption }: { caption: string }) {
 
 function MissingShopScopePanel() {
   return (
-    <div className="fixed inset-0 z-[200] overflow-y-auto bg-[#F8FAFC]/94 px-4 py-16 backdrop-blur-[2px] motion-reduce:backdrop-blur-none sm:px-6">
+    <div
+      className="fixed inset-0 z-[200] overflow-y-auto bg-[#F8FAFC]/94 px-4 py-16 backdrop-blur-[2px] motion-reduce:backdrop-blur-none sm:px-6"
+      role="region"
+      aria-labelledby="missing-shop-title"
+    >
       <div className="mx-auto flex min-h-full max-w-2xl items-center justify-center py-8">
         <div className="w-full rounded-xl border border-amber-200 bg-amber-50 px-4 py-4 text-amber-900 shadow-corporate-card">
-          <p className="font-semibold">Chưa chọn cửa hàng</p>
+          <p id="missing-shop-title" className="font-semibold">
+            Chưa chọn cửa hàng
+          </p>
           <p className="mt-1 text-sm text-amber-800/90">
             Thêm <code className="rounded bg-amber-100/80 px-1">?shop_id=</code> vào URL (UUID hoặc slug cửa hàng), hoặc cấu hình biến build{' '}
             <code className="rounded bg-amber-100/80 px-1">VITE_PUBLIC_CATALOG_SHOP_ID</code> cho bản triển khai một-cửa-hàng.
@@ -40,13 +57,23 @@ function MissingShopScopePanel() {
   );
 }
 
-function PublicShopContactErrorPanel({ onRetry }: { onRetry: () => void }) {
+function PublicShopContactErrorPanel({ onRetry, errorDetail }: { onRetry: () => void; errorDetail: string }) {
   return (
-    <div className="fixed inset-0 z-[200] overflow-y-auto bg-[#F8FAFC]/94 px-4 py-16 backdrop-blur-[2px] motion-reduce:backdrop-blur-none sm:px-6">
+    <div
+      className="fixed inset-0 z-[200] overflow-y-auto bg-[#F8FAFC]/94 px-4 py-16 backdrop-blur-[2px] motion-reduce:backdrop-blur-none sm:px-6"
+      role="alert"
+      aria-live="assertive"
+      aria-labelledby="shop-contact-error-title"
+    >
       <div className="mx-auto flex min-h-full max-w-2xl items-center justify-center py-8">
         <div className="w-full rounded-xl border border-rose-200 bg-rose-50 px-4 py-4 text-rose-800 shadow-corporate-card">
-          <p className="font-semibold">Không tải được cấu hình cửa hàng</p>
+          <p id="shop-contact-error-title" className="font-semibold">
+            Không tải được cấu hình cửa hàng
+          </p>
           <p className="mt-1 text-sm text-rose-700/90">Vui lòng thử lại.</p>
+          {errorDetail ? (
+            <p className="mt-2 rounded-md bg-rose-100/80 px-2 py-1.5 font-mono text-xs text-rose-900/90">{errorDetail}</p>
+          ) : null}
           <button
             type="button"
             className="mt-4 inline-flex min-h-[44px] items-center justify-center rounded-lg bg-rose-700 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-rose-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2"
@@ -70,13 +97,14 @@ export const PublicShopMainGate: FC<{ children: ReactNode }> = ({ children }) =>
   const needsCatalogContact = publicRouteNeedsCatalogShopContact(pathname);
   const { shopContextReady, publicApiShopReady } = usePublicShopContext();
   const contactQuery: UseQueryResult<PublicShopContactResponse> = usePublicShopContact(needsCatalogContact);
+  const { refetch } = contactQuery;
 
-  const blocksInteraction =
+  const isBlockingInteraction =
     needsCatalogContact &&
     (!shopContextReady || !publicApiShopReady || contactQuery.isPending || contactQuery.isError);
 
   useEffect(() => {
-    if (!blocksInteraction) {
+    if (!isBlockingInteraction) {
       return;
     }
     const previousOverflow = document.body.style.overflow;
@@ -84,7 +112,11 @@ export const PublicShopMainGate: FC<{ children: ReactNode }> = ({ children }) =>
     return () => {
       document.body.style.overflow = previousOverflow;
     };
-  }, [blocksInteraction]);
+  }, [isBlockingInteraction]);
+
+  const refetchContact = useCallback(() => {
+    void refetch();
+  }, [refetch]);
 
   if (!needsCatalogContact) {
     return <>{children}</>;
@@ -103,7 +135,12 @@ export const PublicShopMainGate: FC<{ children: ReactNode }> = ({ children }) =>
   }
 
   if (contactQuery.isError) {
-    return <PublicShopContactErrorPanel onRetry={() => void contactQuery.refetch()} />;
+    return (
+      <PublicShopContactErrorPanel
+        onRetry={refetchContact}
+        errorDetail={formatQueryError(contactQuery.error)}
+      />
+    );
   }
 
   return <>{children}</>;

--- a/frontend/src/components/public/ShopLoadingRingSvg.tsx
+++ b/frontend/src/components/public/ShopLoadingRingSvg.tsx
@@ -1,0 +1,77 @@
+import type { FC } from 'react';
+import { cn } from '../../lib/utils';
+
+/**
+ * Dual expanding-ring loader (SMIL) from loading.io — two stroked circles with r/opacity animation.
+ */
+export const ShopLoadingRingSvg: FC<{ className?: string }> = ({ className }) => {
+  return (
+    <svg
+      className={cn(className)}
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid"
+      width={200}
+      height={200}
+      focusable="false"
+      aria-hidden
+      style={{
+        shapeRendering: 'auto',
+        display: 'block',
+        background: 'rgb(255, 255, 255)',
+        maxWidth: 'min(200px, 92vw)',
+        maxHeight: 'min(200px, 85vh)',
+        width: 'min(200px, 92vw)',
+        height: 'min(200px, 92vw)',
+      }}
+    >
+      <g>
+        <circle strokeWidth="2" stroke="#e90c59" fill="none" r="0" cy="50" cx="50">
+          <animate
+            begin="0s"
+            calcMode="spline"
+            keySplines="0 0.2 0.8 1"
+            keyTimes="0;1"
+            values="0;40"
+            dur="1s"
+            repeatCount="indefinite"
+            attributeName="r"
+          />
+          <animate
+            begin="0s"
+            calcMode="spline"
+            keySplines="0.2 0 0.8 1"
+            keyTimes="0;1"
+            values="1;0"
+            dur="1s"
+            repeatCount="indefinite"
+            attributeName="opacity"
+          />
+        </circle>
+        <circle strokeWidth="2" stroke="#46dff0" fill="none" r="0" cy="50" cx="50">
+          <animate
+            begin="-0.5s"
+            calcMode="spline"
+            keySplines="0 0.2 0.8 1"
+            keyTimes="0;1"
+            values="0;40"
+            dur="1s"
+            repeatCount="indefinite"
+            attributeName="r"
+          />
+          <animate
+            begin="-0.5s"
+            calcMode="spline"
+            keySplines="0.2 0 0.8 1"
+            keyTimes="0;1"
+            values="1;0"
+            dur="1s"
+            repeatCount="indefinite"
+            attributeName="opacity"
+          />
+        </circle>
+      </g>
+    </svg>
+  );
+};

--- a/frontend/src/components/public/ShopLoadingRingSvg.tsx
+++ b/frontend/src/components/public/ShopLoadingRingSvg.tsx
@@ -24,7 +24,7 @@ type ShopLoadingRingSvgProps = {
 };
 
 /**
- * Dual expanding-ring loader (SMIL) from loading.io — two stroked circles with r/opacity animation.
+ * Dual expanding-ring loader (SMIL): two stroked circles with r/opacity animation.
  * When `prefers-reduced-motion: reduce`, shows static rings (no SMIL).
  */
 export const ShopLoadingRingSvg: FC<ShopLoadingRingSvgProps> = ({ className, pixelSize = 200 }) => {

--- a/frontend/src/components/public/ShopLoadingRingSvg.tsx
+++ b/frontend/src/components/public/ShopLoadingRingSvg.tsx
@@ -1,10 +1,37 @@
 import type { FC } from 'react';
+import { useSyncExternalStore } from 'react';
 import { cn } from '../../lib/utils';
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function subscribePrefersReducedMotion(onStoreChange: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return () => {};
+  }
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+  mq.addEventListener('change', onStoreChange);
+  return () => mq.removeEventListener('change', onStoreChange);
+}
+
+type ShopLoadingRingSvgProps = {
+  className?: string;
+  /** Max edge length in CSS px (viewBox stays 0–100). Default 200. */
+  pixelSize?: number;
+};
 
 /**
  * Dual expanding-ring loader (SMIL) from loading.io — two stroked circles with r/opacity animation.
+ * When `prefers-reduced-motion: reduce`, shows static rings (no SMIL).
  */
-export const ShopLoadingRingSvg: FC<{ className?: string }> = ({ className }) => {
+export const ShopLoadingRingSvg: FC<ShopLoadingRingSvgProps> = ({ className, pixelSize = 200 }) => {
+  const reducedMotion = useSyncExternalStore(subscribePrefersReducedMotion, prefersReducedMotion, () => false);
+
+  const size = `min(${pixelSize}px, 92vw)`;
+
   return (
     <svg
       className={cn(className)}
@@ -12,65 +39,74 @@ export const ShopLoadingRingSvg: FC<{ className?: string }> = ({ className }) =>
       xmlnsXlink="http://www.w3.org/1999/xlink"
       viewBox="0 0 100 100"
       preserveAspectRatio="xMidYMid"
-      width={200}
-      height={200}
+      width={pixelSize}
+      height={pixelSize}
       focusable="false"
       aria-hidden
       style={{
         shapeRendering: 'auto',
         display: 'block',
-        background: 'rgb(255, 255, 255)',
-        maxWidth: 'min(200px, 92vw)',
-        maxHeight: 'min(200px, 85vh)',
-        width: 'min(200px, 92vw)',
-        height: 'min(200px, 92vw)',
+        background: 'transparent',
+        maxWidth: size,
+        maxHeight: `min(${pixelSize}px, 85vh)`,
+        width: size,
+        height: size,
       }}
     >
       <g>
-        <circle strokeWidth="2" stroke="#e90c59" fill="none" r="0" cy="50" cx="50">
-          <animate
-            begin="0s"
-            calcMode="spline"
-            keySplines="0 0.2 0.8 1"
-            keyTimes="0;1"
-            values="0;40"
-            dur="1s"
-            repeatCount="indefinite"
-            attributeName="r"
-          />
-          <animate
-            begin="0s"
-            calcMode="spline"
-            keySplines="0.2 0 0.8 1"
-            keyTimes="0;1"
-            values="1;0"
-            dur="1s"
-            repeatCount="indefinite"
-            attributeName="opacity"
-          />
-        </circle>
-        <circle strokeWidth="2" stroke="#46dff0" fill="none" r="0" cy="50" cx="50">
-          <animate
-            begin="-0.5s"
-            calcMode="spline"
-            keySplines="0 0.2 0.8 1"
-            keyTimes="0;1"
-            values="0;40"
-            dur="1s"
-            repeatCount="indefinite"
-            attributeName="r"
-          />
-          <animate
-            begin="-0.5s"
-            calcMode="spline"
-            keySplines="0.2 0 0.8 1"
-            keyTimes="0;1"
-            values="1;0"
-            dur="1s"
-            repeatCount="indefinite"
-            attributeName="opacity"
-          />
-        </circle>
+        {reducedMotion ? (
+          <>
+            <circle strokeWidth="2" stroke="#e90c59" fill="none" r="28" cy="50" cx="50" opacity={0.45} />
+            <circle strokeWidth="2" stroke="#46dff0" fill="none" r="18" cy="50" cx="50" opacity={0.55} />
+          </>
+        ) : (
+          <>
+            <circle strokeWidth="2" stroke="#e90c59" fill="none" r="0" cy="50" cx="50">
+              <animate
+                begin="0s"
+                calcMode="spline"
+                keySplines="0 0.2 0.8 1"
+                keyTimes="0;1"
+                values="0;40"
+                dur="1s"
+                repeatCount="indefinite"
+                attributeName="r"
+              />
+              <animate
+                begin="0s"
+                calcMode="spline"
+                keySplines="0.2 0 0.8 1"
+                keyTimes="0;1"
+                values="1;0"
+                dur="1s"
+                repeatCount="indefinite"
+                attributeName="opacity"
+              />
+            </circle>
+            <circle strokeWidth="2" stroke="#46dff0" fill="none" r="0" cy="50" cx="50">
+              <animate
+                begin="-0.5s"
+                calcMode="spline"
+                keySplines="0 0.2 0.8 1"
+                keyTimes="0;1"
+                values="0;40"
+                dur="1s"
+                repeatCount="indefinite"
+                attributeName="r"
+              />
+              <animate
+                begin="-0.5s"
+                calcMode="spline"
+                keySplines="0.2 0 0.8 1"
+                keyTimes="0;1"
+                values="1;0"
+                dur="1s"
+                repeatCount="indefinite"
+                attributeName="opacity"
+              />
+            </circle>
+          </>
+        )}
       </g>
     </svg>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Public catalog gate: **full-viewport** loading / missing-shop / error scrim (`fixed inset-0 z-[200]`), **SMIL dual-ring loader** in `ShopLoadingRingSvg`, and `body` scroll lock while blocking.

Merged latest `main` and resolved **add/add** conflict on `PublicShopMainGate.tsx` (kept full-page + SVG + `useEffect` path).

## Verification

- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend exec vitest run tests/unit/PublicShopMainGate.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97c7355b-a144-40db-bcaf-d6afc8efd1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97c7355b-a144-40db-bcaf-d6afc8efd1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

