### PR TITLE
fix(frontend): solid white full-page public shop gate overlay

### DIFF
--- a/frontend/src/components/public/PublicShopMainGate.tsx
+++ b/frontend/src/components/public/PublicShopMainGate.tsx
@@ -22,7 +22,7 @@ function formatQueryError(err: unknown): string {
 function SpinnerBlock({ caption }: { caption: string }) {
   return (
     <div
-      className="fixed inset-0 z-[200] flex items-center justify-center bg-[#F8FAFC]/94 px-4 backdrop-blur-[2px] motion-reduce:backdrop-blur-none"
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-white px-4"
       role="status"
       aria-busy="true"
       aria-live="polite"
@@ -38,7 +38,7 @@ function SpinnerBlock({ caption }: { caption: string }) {
 function MissingShopScopePanel() {
   return (
     <div
-      className="fixed inset-0 z-[200] overflow-y-auto bg-[#F8FAFC]/94 px-4 py-16 backdrop-blur-[2px] motion-reduce:backdrop-blur-none sm:px-6"
+      className="fixed inset-0 z-[200] overflow-y-auto bg-white px-4 py-16 sm:px-6"
       role="region"
       aria-labelledby="missing-shop-title"
     >
@@ -60,7 +60,7 @@ function MissingShopScopePanel() {
 function PublicShopContactErrorPanel({ onRetry, errorDetail }: { onRetry: () => void; errorDetail: string }) {
   return (
     <div
-      className="fixed inset-0 z-[200] overflow-y-auto bg-[#F8FAFC]/94 px-4 py-16 backdrop-blur-[2px] motion-reduce:backdrop-blur-none sm:px-6"
+      className="fixed inset-0 z-[200] overflow-y-auto bg-white px-4 py-16 sm:px-6"
       role="alert"
       aria-live="assertive"
       aria-labelledby="shop-contact-error-title"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the translucent public shop gate scrim (`bg-[#F8FAFC]/94` + backdrop blur) with a **solid white** full-viewport overlay (`bg-white`) for loading, missing-shop, and error states.

## Note

`main` is branch-protected; this PR is the path to land the change.

## Verification

- `pnpm --filter ./frontend exec vitest run tests/unit/PublicShopMainGate.test.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97c7355b-a144-40db-bcaf-d6afc8efd1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97c7355b-a144-40db-bcaf-d6afc8efd1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

