### PR TITLE
feat(storage): Cloudflare R2 IStorageService driver (plan 17-01)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -22,7 +22,7 @@ This roadmap organizes Diecast360 delivery from core product foundations to oper
 - [x] **Phase 14: Multi-Tenant Shop** - Support multiple isolated diecast shops on a single deployment with scoped access.
 - [x] **Phase 15: Admin RBAC & Tenant Authorization** - Separate platform operator permissions from per-shop roles; extend shop roles (e.g. read-only staff) and align API + admin UI.
 - [x] **Phase 16: Per-Shop Public Homepage** - Resolve public catalog and item detail to a single shop tenant via URL or explicit query param, aligned with existing multi-tenant isolation. (completed 2026-04-30)
-- [ ] **Phase 17: Cloudflare R2 upload — migrate backend media from local disk to object storage** - S3-compatible R2 behind `IStorageService`; presigned or proxied media URLs; optional disk→R2 migration.
+- [x] **Phase 17: Cloudflare R2 upload — migrate backend media from local disk to object storage** - S3-compatible R2 behind `IStorageService`; presigned or proxied media URLs; optional disk→R2 migration. (completed 2026-05-09)
 
 ## Phase Details
 
@@ -362,7 +362,7 @@ Gợi ý tài liệu follow-up: cập nhật `docs/API_CONTRACT.md` / `ENV.md` k
 **Goal:** Persist uploaded media in **Cloudflare R2** (S3-compatible) behind `IStorageService`, with **presigned GET** URLs by default and optional **`GET /api/v1/media` proxy** for signed-link compatibility; keep **`STORAGE_DRIVER=local`** for dev/Pi fallback; document cutover from existing `UPLOAD_DIR`.
 **Requirements:** MEDI-01, MEDI-02, MEDI-03, PLAT-01, PLAT-02
 **Depends on:** Phase 16
-**Plans:** 3 plans (2 waves + docs wave)
+**Plans:** 3/3 plans complete
 
 Plans:
 - [ ] 17-01: Backend — `R2StorageService`, `STORAGE_DRIVER` wiring, presigned `getFileUrl`, unit tests with mocked S3

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,6 +2,19 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
+status: unknown
+last_updated: "2026-05-09T03:03:14.681Z"
+progress:
+  total_phases: 17
+  completed_phases: 11
+  total_plans: 39
+  completed_plans: 22
+---
+
+---
+gsd_state_version: 1.0
+milestone: v1.0
+milestone_name: milestone
 status: complete
 last_updated: "2026-05-08T12:00:00.000Z"
 progress:

--- a/.planning/phases/17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage/17-01-SUMMARY.md
+++ b/.planning/phases/17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage/17-01-SUMMARY.md
@@ -1,0 +1,103 @@
+---
+phase: 17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage
+plan: 01
+subsystem: infra
+tags: [cloudflare, r2, s3, nestjs, aws-sdk, presigned-url]
+
+requires: []
+provides:
+  - R2StorageService implementing IStorageService with PutObject, CopyObject+DeleteObject move, presigned GetObject URLs
+  - StorageModule factory selecting LocalStorageService vs R2StorageService from STORAGE_DRIVER
+affects:
+  - 17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage
+
+tech-stack:
+  added: ["@aws-sdk/client-s3", "@aws-sdk/s3-request-presigner"]
+  patterns:
+    - "Config-driven storage provider via useFactory + assertR2Env for r2 driver"
+    - "Relative object keys match local layout (e.g. spinner/frame.jpg)"
+
+key-files:
+  created:
+    - backend/src/storage/r2-storage.service.ts
+    - backend/src/storage/r2-storage.service.spec.ts
+  modified:
+    - backend/src/storage/storage.module.ts
+    - backend/src/storage/storage.interface.ts
+    - backend/src/storage/local-storage.service.ts
+    - backend/package.json
+    - backend/.env.example
+
+key-decisions:
+  - "Presigned GET URLs use getSignedUrl; IStorageService.getFileUrl is async (Promise<string>) so TTL aligns with MEDIA_URL_TTL_MS without blocking the event loop."
+  - "R2 S3 client uses region auto, forcePathStyle, endpoint https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com"
+
+patterns-established:
+  - "Consumers resolve media URLs with await Promise.all when mapping lists."
+
+requirements-completed: [MEDI-01, MEDI-02, PLAT-02]
+
+duration: unknown
+completed: 2026-05-09
+---
+
+# Phase 17 plan 01: R2 storage provider summary
+
+**Conditional Cloudflare R2-backed `IStorageService` with S3 API, presigned read URLs, and Jest-mocked unit tests; local disk remains the default driver.**
+
+## Performance
+
+- **Duration:** (not recorded)
+- **Tasks:** 3 (per plan)
+- **Files modified:** 20+ (including consumer await updates for async `getFileUrl`)
+
+## Accomplishments
+
+- Added `R2StorageService` with `saveFile`, `deleteFile`, `moveFile` (copy + delete), and presigned `getFileUrl` using `MEDIA_URL_TTL_MS` (default 7d).
+- `StorageModule` wires `IStorageService` from `STORAGE_DRIVER` (`local` default, `r2` with required env validation).
+- Documented `STORAGE_DRIVER` and `R2_*` variables in `backend/.env.example`.
+
+## Task commits
+
+Single integration commit: feat(storage): add R2 driver and async getFileUrl
+
+## Files created/modified
+
+- `backend/src/storage/r2-storage.service.ts` — R2 / S3 implementation
+- `backend/src/storage/r2-storage.service.spec.ts` — mocked S3 `send` + presigner
+- `backend/src/storage/storage.module.ts` — factory provider
+- `backend/src/storage/storage.interface.ts` — `getFileUrl` → `Promise<string>`
+- `backend/src/storage/local-storage.service.ts` — async `getFileUrl`
+- Consumer services/specs — `await` / `Promise.all` for URL resolution
+
+## Decisions made
+
+- `getFileUrl` is asynchronous across the stack because `@aws-sdk/s3-request-presigner` `getSignedUrl` is async; local implementation returns the same signed API URLs via `Promise` for a uniform contract.
+
+## Deviations from plan
+
+### Documented deviation
+
+**Async `getFileUrl` on `IStorageService`**
+
+- **Issue:** Plan text assumed a synchronous `getFileUrl`; AWS presigned URL generation is async.
+- **Fix:** Changed the interface to `Promise<string>` and updated all call sites to `await` (often via `Promise.all` in list mappings).
+- **Verification:** `pnpm --filter ./backend test` (479 tests) green.
+
+Otherwise the plan was followed: dependencies, R2 service, module switch, `.env.example`, and unit tests without live R2.
+
+## Issues encountered
+
+- None blocking; Jest 30 uses `--testPathPatterns` instead of `--testPathPattern` when running filtered suites from CLI.
+
+## User setup required
+
+For `STORAGE_DRIVER=r2`, configure `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and `R2_BUCKET` in `backend/.env` (see `backend/.env.example`). No secrets committed.
+
+## Next phase readiness
+
+- Plan 17-02 can focus on `MediaController` and delivery edge cases while uploads already use `IStorageService` keys compatible with R2.
+
+---
+*Phase: 17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage*
+*Completed: 2026-05-09*

--- a/.planning/phases/17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage/17-02-SUMMARY.md
+++ b/.planning/phases/17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage/17-02-SUMMARY.md
@@ -1,0 +1,61 @@
+---
+phase: 17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage
+plan: 02
+subsystem: api
+tags: [r2, s3, media, nestjs, proxy]
+
+requires:
+  - phase: 17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage
+    provides: R2StorageService, presigned getFileUrl
+provides:
+  - MediaController R2 proxy branch (GetObject stream after signed /api/v1/media)
+  - Shared R2 S3 client factory (r2-s3.factory.ts) used by R2StorageService
+affects: []
+
+tech-stack:
+  added: []
+  patterns:
+    - "Lazy-cached R2 client on MediaController for proxy path"
+    - "Segment-based key safety check for R2 (no ..)"
+
+key-files:
+  created:
+    - backend/src/storage/r2-s3.factory.ts
+  modified:
+    - backend/src/common/media/media.controller.ts
+    - backend/src/common/media/media.controller.spec.ts
+    - backend/src/storage/r2-storage.service.ts
+    - docs/API_CONTRACT.md
+
+key-decisions:
+  - "Implemented R2 proxy for legacy signed /api/v1/media links; local driver unchanged and still reads UPLOAD_DIR."
+
+patterns-established: []
+
+requirements-completed: [MEDI-01, MEDI-02, MEDI-03]
+
+duration: unknown
+completed: 2026-05-09
+---
+
+# Phase 17 plan 02 summary
+
+**Signed `GET /api/v1/media` now streams from Cloudflare R2 when `STORAGE_DRIVER=r2`, with no disk read of `UPLOAD_DIR`; local behavior unchanged.**
+
+## Accomplishments
+
+- Extracted `createR2S3ClientAndBucket`, `isR2StorageDriver`, and `normalizeR2ObjectKey` into `backend/src/storage/r2-s3.factory.ts`; `R2StorageService` reuses the factory.
+- `MediaController.serveSigned` branches: R2 uses `GetObject` + pipe; local keeps `createReadStream`.
+- Tests cover R2 happy path, `NoSuchKey` → 404, and misconfigured R2 env → 403.
+- `docs/API_CONTRACT.md` documents URL semantics per `STORAGE_DRIVER`.
+
+## Manual smoke (plan)
+
+Not run in agent session: start backend with `STORAGE_DRIVER=r2` + real bucket, upload one asset, open presigned and `/media` URLs in browser.
+
+## Deviations
+
+None material.
+
+---
+*Phase: 17 — plan 02*

--- a/.planning/phases/17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage/17-03-SUMMARY.md
+++ b/.planning/phases/17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage/17-03-SUMMARY.md
@@ -1,0 +1,64 @@
+---
+phase: 17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage
+plan: 03
+subsystem: infra
+tags: [r2, deployment, documentation, runbook]
+
+requires:
+  - phase: 17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage
+    provides: Media R2 proxy + storage driver
+provides:
+  - ENV / deployment / Pi docs for R2 and cutover
+  - Cutover runbook in cloudflare migration plan
+  - backend/scripts/README.md migration outline
+affects: []
+
+tech-stack:
+  added: []
+  patterns:
+    - "Document rclone sync as primary migration path"
+
+key-files:
+  created:
+    - backend/scripts/README.md
+  modified:
+    - docs/ENV.md
+    - docs/DEPLOYMENT.md
+    - docs/BACKEND_PI_CLOUDFLARE.md
+    - docs/plans/cloudflare-r2-upload-migration.md
+    - AGENTS.md
+
+key-decisions:
+  - "Staging bucket human smoke left to operator; recorded as not executed in-session below."
+
+patterns-established: []
+
+requirements-completed: [PLAT-01, PLAT-02]
+
+duration: unknown
+completed: 2026-05-09
+---
+
+# Phase 17 plan 03 summary
+
+**Operator docs for `STORAGE_DRIVER` / R2, Pi uploads optionally, deployment cutover section, and a Cutover runbook with rclone example.**
+
+## Staging bucket smoke (human checkpoint)
+
+- [ ] **Not run** in this agent session (2026-05-09). Operator should create dev bucket + token, run backend with `STORAGE_DRIVER=r2`, upload branding + one spinner frame, confirm DB paths unchanged and images render.
+
+## Accomplishments
+
+- `docs/ENV.md`: table rows + **Object storage (Cloudflare R2)** subsection.
+- `docs/DEPLOYMENT.md`: Pi note for R2 vs local uploads; env table rows; **§8 Cutover**.
+- `docs/BACKEND_PI_CLOUDFLARE.md`: `mkdir uploads` only when `STORAGE_DRIVER=local`.
+- `docs/plans/cloudflare-r2-upload-migration.md`: **Cutover runbook** (prerequisites, rclone example, validation, flag order, links to 17-01..03).
+- `backend/scripts/README.md`: points to runbook and optional future Node sync outline.
+- `AGENTS.md`: one-line cross-link to ENV R2 section.
+
+## Deviations
+
+None.
+
+---
+*Phase: 17 — plan 03*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Diecast360 is a pnpm monorepo (`backend/` + `frontend/`) for a diecast model car
 ### Key gotchas
 
 - **COOKIE_SECRET** must be at least 32 characters in `backend/.env` or the app will throw at startup.
+- **Object storage (Cloudflare R2):** optional `STORAGE_DRIVER=r2` and `R2_*` variables — see [`docs/ENV.md`](docs/ENV.md) section **Object storage (Cloudflare R2)** and cutover notes in [`docs/plans/cloudflare-r2-upload-migration.md`](docs/plans/cloudflare-r2-upload-migration.md).
 - **pnpm.onlyBuiltDependencies** in root `package.json` is required so that native modules (`sharp`, `bcrypt`, `prisma`, `esbuild`) build during `pnpm install`. Without it, pnpm v10+ silently skips their build scripts.
 - After `pnpm install`, the backend `postinstall` runs `prisma generate` automatically.
 - `prisma migrate dev` prompts interactively for a migration name if the schema drifts; use `prisma migrate deploy` (non-interactive) when only applying existing migrations.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,16 @@ FRONTEND_URL="http://localhost:5173"
 # Vite --host (LAN): set true in dev, keep false in production unless you need it.
 # CORS_ALLOW_LAN=true
 UPLOAD_DIR="./uploads"
+# Media storage backend: local (default) or r2 (Cloudflare R2 via S3 API).
+# STORAGE_DRIVER=local
+# When STORAGE_DRIVER=r2, set all R2_* variables below (see Cloudflare dashboard).
+# R2_ACCOUNT_ID=""
+# R2_ACCESS_KEY_ID=""
+# R2_SECRET_ACCESS_KEY=""
+# R2_BUCKET=""
+# Optional: public CDN base for R2 (not used when serving via presigned URLs).
+# R2_PUBLIC_BASE_URL=""
+
 # Public base URL of this API (no trailing slash). Used to sign GET /api/v1/media links.
 # In production set to your HTTPS API origin (e.g. https://nhtin.name.vn). If unset, defaults to http://localhost:3000 (breaks images from a public HTTPS frontend).
 # BACKEND_URL="https://nhtin.name.vn"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,8 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1045.0",
+        "@aws-sdk/s3-request-presigner": "^3.1045.0",
         "@nestjs/common": "^11.1.10",
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.1.10",
@@ -194,6 +196,894 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1045.0.tgz",
+      "integrity": "sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.16",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.16.tgz",
+      "integrity": "sha512-6ru8doI0/XzszqLIPXf0E/V7HhAw1Pu94010XCKYtBUfD0LxF0BuOzrUf8OQGR6j2o6wgKTHUniOmndQycHwCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1045.0.tgz",
+      "integrity": "sha512-VDRF8GIuUPX+K4DUYrvcODj/h54LOmdJ7DhpLQ0wrYrdxzIiJEpi0n9jZ1bbjT2UxhwTbOorse5EGo+gnOK2aA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2869,6 +3759,18 @@
         "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
@@ -3022,6 +3924,725 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -4577,6 +6198,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -6040,6 +7667,43 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -8771,6 +10435,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -9726,6 +11405,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "10.3.5",
@@ -10796,6 +12487,21 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1045.0",
+    "@aws-sdk/s3-request-presigner": "^3.1045.0",
     "@nestjs/common": "^11.1.10",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.10",
@@ -49,6 +51,7 @@
     "class-validator": "^0.14.3",
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.2.3",
+    "ms": "^2.1.3",
     "multer": "^2.0.2",
     "openai": "^6.16.0",
     "passport": "^0.7.0",
@@ -57,8 +60,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "sharp": "^0.34.5",
-    "uuid": "^9.0.1",
-    "ms": "^2.1.3"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
@@ -87,7 +89,6 @@
     "seed": "ts-node prisma/seed-categories.ts"
   },
   "overrides": {
-
     "qs": "^6.14.3",
     "whatwg-url": "^14.0.0",
     "@isaacs/brace-expansion": "5.0.1",

--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -1,0 +1,13 @@
+# Backend scripts
+
+Các script TypeScript trong thư mục này chạy bằng `ts-node` hoặc qua `package.json` của `backend/`. Không commit secret.
+
+## Đồng bộ upload local → Cloudflare R2 (cutover)
+
+Khi chuyển `STORAGE_DRIVER=r2`, object trên R2 phải dùng **cùng key** với đường dẫn tương đối trong DB (`images/...`, `spinner/...`, …).
+
+**Khuyến nghị:** dùng [rclone](https://rclone.org/) `sync` từ thư mục `UPLOAD_DIR` lên bucket — xem phần **Cutover runbook** trong [`docs/plans/cloudflare-r2-upload-migration.md`](../../docs/plans/cloudflare-r2-upload-migration.md).
+
+**Gợi ý Node (outline, không bắt buộc):** có thể thêm script sau này dùng `@aws-sdk/client-s3` `ListObjectsV2` + đọc file local + `PutObject` theo từng key; trên dataset lớn ưu tiên `rclone` vì resume/checksum tích hợp.
+
+Các script khác (`create-admin`, `index-items`, …) xem từng file hoặc `package.json` scripts.

--- a/backend/src/common/media/media-mime.util.ts
+++ b/backend/src/common/media/media-mime.util.ts
@@ -1,0 +1,19 @@
+/**
+ * Maps common image extensions to MIME types. Uses the last path segment
+ * (e.g. `spinner/thumbnails/x.jpg` → extension `jpg`).
+ */
+export function imageMimeAndExtForPath(fileNameOrPath: string): { mime: string; ext: string } {
+  const base = fileNameOrPath.split(/[/\\]/).pop() || fileNameOrPath;
+  const ext = base.toLowerCase().split('.').pop() || '';
+  const mime =
+    ext === 'jpg' || ext === 'jpeg'
+      ? 'image/jpeg'
+      : ext === 'png'
+        ? 'image/png'
+        : ext === 'webp'
+          ? 'image/webp'
+          : ext === 'gif'
+            ? 'image/gif'
+            : 'application/octet-stream';
+  return { mime, ext };
+}

--- a/backend/src/common/media/media-url-ttl.util.ts
+++ b/backend/src/common/media/media-url-ttl.util.ts
@@ -1,0 +1,15 @@
+import { ConfigService } from '@nestjs/config';
+
+export const DEFAULT_MEDIA_URL_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function parseMediaUrlTtlMs(config: ConfigService): number {
+  const raw = config.get<string | number>('MEDIA_URL_TTL_MS');
+  if (raw === undefined || raw === null || raw === '') {
+    return DEFAULT_MEDIA_URL_TTL_MS;
+  }
+  const n = typeof raw === 'number' ? raw : Number(String(raw).trim());
+  if (!Number.isFinite(n) || n <= 0) {
+    return DEFAULT_MEDIA_URL_TTL_MS;
+  }
+  return n;
+}

--- a/backend/src/common/media/media.controller.spec.ts
+++ b/backend/src/common/media/media.controller.spec.ts
@@ -4,9 +4,21 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { finished } from 'node:stream/promises';
+import { Readable } from 'stream';
 import { Writable } from 'stream';
+import { S3ServiceException } from '@aws-sdk/client-s3';
 import { MediaController } from './media.controller';
 import { signMediaPayload } from './signed-media.util';
+
+const mockR2Send = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const actual = jest.requireActual('@aws-sdk/client-s3') as Record<string, unknown>;
+  return {
+    ...actual,
+    S3Client: jest.fn().mockImplementation(() => ({ send: (...a: unknown[]) => mockR2Send(...a) })),
+  };
+});
 
 class CollectingResponse extends Writable {
   chunks: Buffer[] = [];
@@ -35,6 +47,7 @@ describe('MediaController', () => {
     uploadsRoot = path.join(tmpRoot, 'uploads');
     await fs.mkdir(path.join(uploadsRoot, 'images'), { recursive: true });
     await fs.writeFile(path.join(uploadsRoot, 'images', 'pic.png'), 'png-bytes');
+    mockR2Send.mockReset();
   });
 
   afterEach(async () => {
@@ -60,6 +73,7 @@ describe('MediaController', () => {
     expect(Buffer.concat(res.chunks).toString()).toBe('png-bytes');
     expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/png');
     expect(res.setHeader).toHaveBeenCalledWith('Content-Disposition', 'inline');
+    expect(mockR2Send).not.toHaveBeenCalled();
   });
 
   it('returns 404 when file is missing', async () => {
@@ -83,6 +97,7 @@ describe('MediaController', () => {
     await controller.serveSigned(d, s, res as never);
     expect(status).toHaveBeenCalledWith(404);
     expect(end).toHaveBeenCalled();
+    expect(mockR2Send).not.toHaveBeenCalled();
   });
 
   it('rejects invalid signature', async () => {
@@ -103,5 +118,86 @@ describe('MediaController', () => {
     await expect(controller.serveSigned('x', 'y', res as never)).rejects.toBeInstanceOf(
       ForbiddenException,
     );
+  });
+
+  describe('STORAGE_DRIVER=r2', () => {
+    function r2ControllerFromConfig(
+      get: (key: string) => string | undefined,
+    ): MediaController {
+      return new MediaController({ get } as ConfigService);
+    }
+
+    it('streams object from R2 when signature is valid', async () => {
+      mockR2Send.mockResolvedValueOnce({ Body: Readable.from([Buffer.from('r2-bytes')]) });
+      const controller = r2ControllerFromConfig((key) => {
+        if (key === 'JWT_SECRET') return secret;
+        if (key === 'STORAGE_DRIVER') return 'r2';
+        if (key === 'R2_ACCOUNT_ID') return 'acct';
+        if (key === 'R2_ACCESS_KEY_ID') return 'ak';
+        if (key === 'R2_SECRET_ACCESS_KEY') return 'sk';
+        if (key === 'R2_BUCKET') return 'bucket';
+        return undefined;
+      });
+      const rel = 'images/pic.png';
+      const { d, s } = signMediaPayload({ p: rel, exp: Date.now() + 60_000 }, secret);
+
+      const res = new CollectingResponse();
+      await controller.serveSigned(d, s, res as never);
+      await finished(res);
+      expect(mockR2Send).toHaveBeenCalledTimes(1);
+      expect(Buffer.concat(res.chunks).toString()).toBe('r2-bytes');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/png');
+    });
+
+    it('returns 404 when R2 object is missing', async () => {
+      mockR2Send.mockRejectedValueOnce(
+        new S3ServiceException({
+          name: 'NoSuchKey',
+          message: 'Not Found',
+          $metadata: { httpStatusCode: 404 },
+        } as ConstructorParameters<typeof S3ServiceException>[0]),
+      );
+      const controller = r2ControllerFromConfig((key) => {
+        if (key === 'JWT_SECRET') return secret;
+        if (key === 'STORAGE_DRIVER') return 'r2';
+        if (key === 'R2_ACCOUNT_ID') return 'acct';
+        if (key === 'R2_ACCESS_KEY_ID') return 'ak';
+        if (key === 'R2_SECRET_ACCESS_KEY') return 'sk';
+        if (key === 'R2_BUCKET') return 'bucket';
+        return undefined;
+      });
+      const { d, s } = signMediaPayload(
+        { p: 'images/missing.png', exp: Date.now() + 60_000 },
+        secret,
+      );
+      const end = jest.fn();
+      const status = jest.fn().mockReturnValue({ end });
+      const res = {
+        headersSent: false,
+        status,
+        setHeader: jest.fn(),
+        pipe: jest.fn(),
+      };
+      await controller.serveSigned(d, s, res as never);
+      expect(status).toHaveBeenCalledWith(404);
+      expect(end).toHaveBeenCalled();
+    });
+
+    it('throws when R2 env is incomplete', async () => {
+      const controller = r2ControllerFromConfig((key) => {
+        if (key === 'JWT_SECRET') return secret;
+        if (key === 'STORAGE_DRIVER') return 'r2';
+        if (key === 'R2_ACCOUNT_ID') return 'acct';
+        return undefined;
+      });
+      const { d, s } = signMediaPayload(
+        { p: 'images/pic.png', exp: Date.now() + 60_000 },
+        secret,
+      );
+      const res = new CollectingResponse();
+      await expect(controller.serveSigned(d, s, res as never)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+    });
   });
 });

--- a/backend/src/common/media/media.controller.spec.ts
+++ b/backend/src/common/media/media.controller.spec.ts
@@ -128,7 +128,10 @@ describe('MediaController', () => {
     }
 
     it('streams object from R2 when signature is valid', async () => {
-      mockR2Send.mockResolvedValueOnce({ Body: Readable.from([Buffer.from('r2-bytes')]) });
+      mockR2Send.mockResolvedValueOnce({
+        Body: Readable.from([Buffer.from('r2-bytes')]),
+        ContentLength: 8,
+      });
       const controller = r2ControllerFromConfig((key) => {
         if (key === 'JWT_SECRET') return secret;
         if (key === 'STORAGE_DRIVER') return 'r2';
@@ -147,6 +150,7 @@ describe('MediaController', () => {
       expect(mockR2Send).toHaveBeenCalledTimes(1);
       expect(Buffer.concat(res.chunks).toString()).toBe('r2-bytes');
       expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/png');
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Length', '8');
     });
 
     it('returns 404 when R2 object is missing', async () => {

--- a/backend/src/common/media/media.controller.ts
+++ b/backend/src/common/media/media.controller.ts
@@ -20,21 +20,7 @@ import {
   isR2StorageDriver,
   normalizeR2ObjectKey,
 } from '../../storage/r2-s3.factory';
-
-function mimeFromMediaRelativePath(relPath: string): { mime: string; ext: string } {
-  const ext = relPath.toLowerCase().split('.').pop() || '';
-  const mime =
-    ext === 'jpg' || ext === 'jpeg'
-      ? 'image/jpeg'
-      : ext === 'png'
-        ? 'image/png'
-        : ext === 'webp'
-          ? 'image/webp'
-          : ext === 'gif'
-            ? 'image/gif'
-            : 'application/octet-stream';
-  return { mime, ext };
-}
+import { imageMimeAndExtForPath } from './media-mime.util';
 
 function isS3NoSuchKey(err: unknown): boolean {
   if (err instanceof S3ServiceException) {
@@ -89,7 +75,7 @@ export class MediaController {
       throw new BadRequestException('Invalid or expired media link');
     }
 
-    const { mime, ext } = mimeFromMediaRelativePath(payload.p);
+    const { mime, ext } = imageMimeAndExtForPath(payload.p);
 
     if (isR2StorageDriver(this.config)) {
       assertSafeR2ObjectKeyFromPayload(payload.p);

--- a/backend/src/common/media/media.controller.ts
+++ b/backend/src/common/media/media.controller.ts
@@ -102,6 +102,9 @@ export class MediaController {
 
         res.setHeader('Content-Type', mime);
         res.setHeader('Cache-Control', 'private, max-age=3600');
+        if (out.ContentLength != null && Number.isFinite(out.ContentLength)) {
+          res.setHeader('Content-Length', String(out.ContentLength));
+        }
         if (['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(ext)) {
           res.setHeader('Content-Disposition', 'inline');
         }

--- a/backend/src/common/media/media.controller.ts
+++ b/backend/src/common/media/media.controller.ts
@@ -12,8 +12,46 @@ import * as fs from 'fs/promises';
 import { createReadStream } from 'fs';
 import * as path from 'path';
 import { ConfigService } from '@nestjs/config';
+import { GetObjectCommand, S3ServiceException } from '@aws-sdk/client-s3';
 import { verifySignedMediaParams } from './signed-media.util';
 import { resolveMediaSigningSecret } from './media-signing-secret';
+import {
+  createR2S3ClientAndBucket,
+  isR2StorageDriver,
+  normalizeR2ObjectKey,
+} from '../../storage/r2-s3.factory';
+
+function mimeFromMediaRelativePath(relPath: string): { mime: string; ext: string } {
+  const ext = relPath.toLowerCase().split('.').pop() || '';
+  const mime =
+    ext === 'jpg' || ext === 'jpeg'
+      ? 'image/jpeg'
+      : ext === 'png'
+        ? 'image/png'
+        : ext === 'webp'
+          ? 'image/webp'
+          : ext === 'gif'
+            ? 'image/gif'
+            : 'application/octet-stream';
+  return { mime, ext };
+}
+
+function isS3NoSuchKey(err: unknown): boolean {
+  if (err instanceof S3ServiceException) {
+    return err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404;
+  }
+  return err instanceof Error && err.name === 'NoSuchKey';
+}
+
+function assertSafeR2ObjectKeyFromPayload(p: string): void {
+  const key = normalizeR2ObjectKey(p);
+  const segments = key.split('/');
+  for (const seg of segments) {
+    if (seg === '' || seg === '.' || seg === '..' || seg.includes('\\')) {
+      throw new ForbiddenException('Invalid media path');
+    }
+  }
+}
 
 /**
  * Endpoint binary thô: không bọc {@link ResponseInterceptor} ({ ok, data }).
@@ -22,8 +60,16 @@ import { resolveMediaSigningSecret } from './media-signing-secret';
 @Controller('media')
 export class MediaController {
   private readonly logger = new Logger(MediaController.name);
+  private r2MediaCtx: ReturnType<typeof createR2S3ClientAndBucket> | null = null;
 
   constructor(private readonly config: ConfigService) {}
+
+  private getR2MediaContext(): ReturnType<typeof createR2S3ClientAndBucket> {
+    if (!this.r2MediaCtx) {
+      this.r2MediaCtx = createR2S3ClientAndBucket(this.config);
+    }
+    return this.r2MediaCtx;
+  }
 
   @Get()
   async serveSigned(
@@ -43,6 +89,62 @@ export class MediaController {
       throw new BadRequestException('Invalid or expired media link');
     }
 
+    const { mime, ext } = mimeFromMediaRelativePath(payload.p);
+
+    if (isR2StorageDriver(this.config)) {
+      assertSafeR2ObjectKeyFromPayload(payload.p);
+      const key = normalizeR2ObjectKey(payload.p);
+
+      let r2: ReturnType<typeof createR2S3ClientAndBucket>;
+      try {
+        r2 = this.getR2MediaContext();
+      } catch (e) {
+        this.logger.error(
+          `R2 media proxy misconfigured: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        throw new ForbiddenException('Object storage is not configured');
+      }
+
+      try {
+        const out = await r2.client.send(
+          new GetObjectCommand({ Bucket: r2.bucket, Key: key }),
+        );
+        if (!out.Body) {
+          res.status(404).end();
+          return;
+        }
+
+        res.setHeader('Content-Type', mime);
+        res.setHeader('Cache-Control', 'private, max-age=3600');
+        if (['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(ext)) {
+          res.setHeader('Content-Disposition', 'inline');
+        }
+
+        const stream = out.Body as NodeJS.ReadableStream;
+        stream.on('error', (err) => {
+          this.logger.warn(
+            `R2 media stream failed: ${err instanceof Error ? err.name : 'Error'}`,
+          );
+          if (!res.headersSent) {
+            res.status(500).end();
+          }
+        });
+        stream.pipe(res);
+      } catch (err) {
+        if (isS3NoSuchKey(err)) {
+          res.status(404).end();
+          return;
+        }
+        this.logger.warn(
+          `R2 GetObject failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        if (!res.headersSent) {
+          res.status(502).end();
+        }
+      }
+      return;
+    }
+
     const uploadDir = this.config.get<string>('UPLOAD_DIR') || './uploads';
     const root = path.resolve(process.cwd(), uploadDir);
     const absolute = path.resolve(root, payload.p);
@@ -57,18 +159,6 @@ export class MediaController {
       res.status(404).end();
       return;
     }
-
-    const ext = payload.p.toLowerCase().split('.').pop() || '';
-    const mime =
-      ext === 'jpg' || ext === 'jpeg'
-        ? 'image/jpeg'
-        : ext === 'png'
-          ? 'image/png'
-          : ext === 'webp'
-            ? 'image/webp'
-            : ext === 'gif'
-              ? 'image/gif'
-              : 'application/octet-stream';
 
     res.setHeader('Content-Type', mime);
     res.setHeader('Cache-Control', 'private, max-age=3600');

--- a/backend/src/images/images.service.spec.ts
+++ b/backend/src/images/images.service.spec.ts
@@ -73,7 +73,7 @@ describe('ImagesService', () => {
     storage = {
       saveFile: jest.fn().mockResolvedValue('images/generated_name.jpg'),
       deleteFile: jest.fn().mockResolvedValue(undefined),
-      getFileUrl: jest.fn((path: string) => `http://localhost/uploads/${path}`),
+      getFileUrl: jest.fn(async (path: string) => `http://localhost/uploads/${path}`),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/backend/src/images/images.service.ts
+++ b/backend/src/images/images.service.ts
@@ -90,7 +90,7 @@ export class ImagesService {
         Boolean(isCover),
       );
 
-      return { image: this.mapImage(image) };
+      return { image: await this.mapImage(image) };
     } catch (error) {
       await this.cleanupSavedFiles(savedPaths, `uploadImage:itemId=${itemId}`);
       throw error;
@@ -236,7 +236,7 @@ export class ImagesService {
       return nextImage;
     });
 
-    return { image: this.mapImage(updated) };
+    return { image: await this.mapImage(updated) };
   }
 
   async reorderImages(itemId: string, reorderDto: ReorderImagesDto, tenantId: string) {
@@ -299,7 +299,7 @@ export class ImagesService {
         );
 
         return {
-          images: updatedImages.map((img) => this.mapImage(img)),
+          images: await Promise.all(updatedImages.map((img) => this.mapImage(img))),
         };
       } catch (error) {
         const shouldRetry =
@@ -391,12 +391,14 @@ export class ImagesService {
     await this.uploadSupport.validateFile(file, this.allowedMimeTypes, this.maxUploadBytes);
   }
 
-  private mapImage(image: ItemImage) {
+  private async mapImage(image: ItemImage) {
     return {
       id: image.id,
       item_id: image.item_id,
-      url: this.storage.getFileUrl(image.file_path),
-      thumbnail_url: image.thumbnail_path ? this.storage.getFileUrl(image.thumbnail_path) : null,
+      url: await this.storage.getFileUrl(image.file_path),
+      thumbnail_url: image.thumbnail_path
+        ? await this.storage.getFileUrl(image.thumbnail_path)
+        : null,
       is_cover: image.is_cover,
       display_order: image.display_order,
       created_at: image.created_at,

--- a/backend/src/items/ai-draft.controller.spec.ts
+++ b/backend/src/items/ai-draft.controller.spec.ts
@@ -42,7 +42,7 @@ describe('AiDraftController', () => {
     storage = {
       saveFile: jest.fn().mockResolvedValue('drafts/test.jpg'),
       deleteFile: jest.fn().mockResolvedValue(undefined),
-      getFileUrl: jest.fn((path: string) => `http://localhost/uploads/${path}`),
+      getFileUrl: jest.fn(async (path: string) => `http://localhost/uploads/${path}`),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/backend/src/items/ai-draft.controller.ts
+++ b/backend/src/items/ai-draft.controller.ts
@@ -59,7 +59,7 @@ export class AiDraftController {
         const filename = this.buildDraftFilename(file.originalname, index, tenantId);
         const path = await this.storage.saveFile(file.buffer, filename, 'drafts');
         savedPaths.push(path);
-        imageUrls.push(this.storage.getFileUrl(path));
+        imageUrls.push(await this.storage.getFileUrl(path));
       }
 
       // 3. Save Draft to DB

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -69,7 +69,7 @@ describe('ItemsService', () => {
   beforeEach(async () => {
     storage = {
       moveFile: jest.fn(),
-      getFileUrl: jest.fn((path: string) => `http://localhost/uploads/${path}`),
+      getFileUrl: jest.fn(async (path: string) => `http://localhost/uploads/${path}`),
       saveFile: jest.fn(),
       deleteFile: jest.fn(),
     };

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -166,18 +166,20 @@ Condition: ${item.condition || ''}`;
         .map(id => idMap.get(id))
         .filter(item => item !== undefined);
 
-      const itemsWithCover = sortedItems.map((item) => {
-        const itemWithImages = item as ItemWithCoverImage;
-        return {
-          ...itemWithImages,
-          price: toNumber(itemWithImages.price),
-          original_price: toNumber(itemWithImages.original_price),
-          cover_image_url: itemWithImages.item_images[0]
-            ? this.getImageUrl(itemWithImages.item_images[0].file_path)
-            : null,
-          item_images: undefined,
-        };
-      });
+      const itemsWithCover = await Promise.all(
+        sortedItems.map(async (item) => {
+          const itemWithImages = item as ItemWithCoverImage;
+          return {
+            ...itemWithImages,
+            price: toNumber(itemWithImages.price),
+            original_price: toNumber(itemWithImages.original_price),
+            cover_image_url: itemWithImages.item_images[0]
+              ? await this.getImageUrl(itemWithImages.item_images[0].file_path)
+              : null,
+            item_images: undefined,
+          };
+        }),
+      );
 
       return {
         items: itemsWithCover,
@@ -274,22 +276,24 @@ Condition: ${item.condition || ''}`;
       this.prisma.item.count({ where }),
     ]);
 
-    const itemsWithCover = items.map((item) => ({
-      ...item,
-      price: toNumber(item.price),
-      original_price: toNumber(item.original_price),
-      cover_image_url: item.item_images[0]
-        ? this.getImageUrl(item.item_images[0].file_path)
-        : null,
-      has_default_spin_set: item.spin_sets.length > 0,
-      fb_post_url: item.facebook_posts[0]?.post_url || null,
-      fb_posted_at: item.facebook_posts[0]?.posted_at || null,
-      fb_posts_count: item._count.facebook_posts,
-      item_images: undefined,
-      spin_sets: undefined,
-      facebook_posts: undefined,
-      _count: undefined,
-    }));
+    const itemsWithCover = await Promise.all(
+      items.map(async (item) => ({
+        ...item,
+        price: toNumber(item.price),
+        original_price: toNumber(item.original_price),
+        cover_image_url: item.item_images[0]
+          ? await this.getImageUrl(item.item_images[0].file_path)
+          : null,
+        has_default_spin_set: item.spin_sets.length > 0,
+        fb_post_url: item.facebook_posts[0]?.post_url || null,
+        fb_posted_at: item.facebook_posts[0]?.posted_at || null,
+        fb_posts_count: item._count.facebook_posts,
+        item_images: undefined,
+        spin_sets: undefined,
+        facebook_posts: undefined,
+        _count: undefined,
+      })),
+    );
 
     return {
       items: itemsWithCover,
@@ -331,10 +335,45 @@ Condition: ${item.condition || ''}`;
       throw new AppException(ErrorCode.NOT_FOUND, 'Item not found');
     }
 
-    const { item_images, spin_sets, facebook_posts, ...itemData } = item;
+    const { item_images, spin_sets: spinSetsFromDb, facebook_posts, ...itemData } = item;
 
     const priceValue = itemData.price as unknown as { toNumber?: () => number } | number | null;
     const originalPriceValue = itemData.original_price as unknown as { toNumber?: () => number } | number | null;
+
+    const images = await Promise.all(
+      item_images.map(async (img) => ({
+        id: img.id,
+        item_id: img.item_id,
+        url: await this.getImageUrl(img.file_path),
+        thumbnail_url: img.thumbnail_path ? await this.getImageUrl(img.thumbnail_path) : null,
+        is_cover: img.is_cover,
+        display_order: img.display_order,
+        created_at: img.created_at,
+      })),
+    );
+
+    const spin_sets = await Promise.all(
+      spinSetsFromDb.map(async (set) => ({
+        id: set.id,
+        item_id: set.item_id,
+        label: set.label,
+        is_default: set.is_default,
+        frames: await Promise.all(
+          set.frames.map(async (frame) => ({
+            id: frame.id,
+            spin_set_id: frame.spin_set_id,
+            frame_index: frame.frame_index,
+            image_url: await this.getImageUrl(frame.file_path),
+            thumbnail_url: frame.thumbnail_path
+              ? await this.getImageUrl(frame.thumbnail_path)
+              : null,
+            created_at: frame.created_at,
+          })),
+        ),
+        created_at: set.created_at,
+        updated_at: set.updated_at,
+      })),
+    );
 
     return {
       item: {
@@ -342,31 +381,8 @@ Condition: ${item.condition || ''}`;
         price: priceValue != null ? (typeof (priceValue as { toNumber?: () => number }).toNumber === 'function' ? (priceValue as { toNumber: () => number }).toNumber() : Number(priceValue)) : null,
         original_price: originalPriceValue != null ? (typeof (originalPriceValue as { toNumber?: () => number }).toNumber === 'function' ? (originalPriceValue as { toNumber: () => number }).toNumber() : Number(originalPriceValue)) : null,
       },
-      images: item_images.map((img) => ({
-        id: img.id,
-        item_id: img.item_id,
-        url: this.getImageUrl(img.file_path),
-        thumbnail_url: img.thumbnail_path ? this.getImageUrl(img.thumbnail_path) : null,
-        is_cover: img.is_cover,
-        display_order: img.display_order,
-        created_at: img.created_at,
-      })),
-      spin_sets: spin_sets.map((set) => ({
-        id: set.id,
-        item_id: set.item_id,
-        label: set.label,
-        is_default: set.is_default,
-        frames: set.frames.map((frame) => ({
-          id: frame.id,
-          spin_set_id: frame.spin_set_id,
-          frame_index: frame.frame_index,
-          image_url: this.getImageUrl(frame.file_path),
-          thumbnail_url: frame.thumbnail_path ? this.getImageUrl(frame.thumbnail_path) : null,
-          created_at: frame.created_at,
-        })),
-        created_at: set.created_at,
-        updated_at: set.updated_at,
-      })),
+      images,
+      spin_sets,
       facebook_posts,
     };
   }
@@ -762,7 +778,7 @@ Condition: ${item.condition || ''}`;
     await this.prisma.vectorSyncTask.deleteMany({ where: { item_id: itemId } });
   }
 
-  private getImageUrl(filePath: string): string {
+  private async getImageUrl(filePath: string): Promise<string> {
     // Use storage service to get consistent URL format
     return this.storage.getFileUrl(filePath);
   }

--- a/backend/src/preorders/preorders.service.spec.ts
+++ b/backend/src/preorders/preorders.service.spec.ts
@@ -19,7 +19,7 @@ describe('PreordersService', () => {
       groupBy: jest.fn(),
     },
   };
-  const storage = { getFileUrl: jest.fn((path: string) => `http://localhost/${path}`) };
+  const storage = { getFileUrl: jest.fn(async (path: string) => `http://localhost/${path}`) };
 
   const tenantId = '00000000-0000-0000-0000-000000000001';
 

--- a/backend/src/preorders/preorders.service.ts
+++ b/backend/src/preorders/preorders.service.ts
@@ -81,7 +81,7 @@ export class PreordersService {
     }
   }
 
-  private toCard(data: {
+  private async toCard(data: {
     id: string;
     status: PreOrderStatus;
     quantity: number;
@@ -111,7 +111,7 @@ export class PreordersService {
         .filter(Boolean)
         .join(' | '),
       cover_image_url: data.item.item_images[0]
-        ? this.storage.getFileUrl(data.item.item_images[0].file_path)
+        ? await this.storage.getFileUrl(data.item.item_images[0].file_path)
         : null,
     };
   }
@@ -357,7 +357,7 @@ export class PreordersService {
     });
 
     return {
-      cards: rows.map((row) => this.toCard(row)),
+      cards: await Promise.all(rows.map((row) => this.toCard(row))),
       pagination: {
         page,
         page_size: pageSize,
@@ -396,7 +396,7 @@ export class PreordersService {
     ]);
 
     return {
-      cards: rows.map((row) => this.toCard(row)),
+      cards: await Promise.all(rows.map((row) => this.toCard(row))),
       pagination: {
         page,
         page_size: pageSize,

--- a/backend/src/public/public.service.spec.ts
+++ b/backend/src/public/public.service.spec.ts
@@ -44,7 +44,7 @@ describe('PublicService', () => {
     };
 
     storage = {
-      getFileUrl: jest.fn((path: string) => `http://localhost/uploads/${path}`),
+      getFileUrl: jest.fn(async (path: string) => `http://localhost/uploads/${path}`),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/backend/src/public/public.service.ts
+++ b/backend/src/public/public.service.ts
@@ -190,31 +190,33 @@ export class PublicService {
       this.getCachedTotal(where),
     ]);
 
-    const itemsWithMeta = items.map((item) => {
-      const coverImage = item.item_images[0] ?? null;
-      const defaultSpinSet = item.spin_sets[0] ?? null;
+    const itemsWithMeta = await Promise.all(
+      items.map(async (item) => {
+        const coverImage = item.item_images[0] ?? null;
+        const defaultSpinSet = item.spin_sets[0] ?? null;
 
-      return {
-        id: item.id,
-        name: item.name,
-        description: item.description,
-        scale: item.scale,
-        brand: item.brand,
-        car_brand: item.car_brand || null,
-        model_brand: item.model_brand || null,
-        condition: item.condition || null,
-        price: toNumber(item.price),
-        original_price: toNumber(item.original_price),
-        status: item.status,
-        is_public: item.is_public,
-        cover_image_url: coverImage
-          ? this.storage.getFileUrl(coverImage.file_path)
-          : null,
-        has_spinner: Boolean(defaultSpinSet && defaultSpinSet.frames.length > 0),
-        created_at: item.created_at,
-        updated_at: item.updated_at,
-      };
-    });
+        return {
+          id: item.id,
+          name: item.name,
+          description: item.description,
+          scale: item.scale,
+          brand: item.brand,
+          car_brand: item.car_brand || null,
+          model_brand: item.model_brand || null,
+          condition: item.condition || null,
+          price: toNumber(item.price),
+          original_price: toNumber(item.original_price),
+          status: item.status,
+          is_public: item.is_public,
+          cover_image_url: coverImage
+            ? await this.storage.getFileUrl(coverImage.file_path)
+            : null,
+          has_spinner: Boolean(defaultSpinSet && defaultSpinSet.frames.length > 0),
+          created_at: item.created_at,
+          updated_at: item.updated_at,
+        };
+      }),
+    );
 
     return {
       items: itemsWithMeta,
@@ -263,39 +265,50 @@ export class PublicService {
       Boolean(frame.file_path?.trim()),
     );
 
+    const images = await Promise.all(
+      normalizedImages.map(async (img) => ({
+        id: img.id,
+        item_id: img.item_id,
+        url: await this.storage.getFileUrl(img.file_path),
+        thumbnail_url: img.thumbnail_path
+          ? await this.storage.getFileUrl(img.thumbnail_path)
+          : null,
+        is_cover: img.is_cover,
+        display_order: img.display_order,
+        created_at: img.created_at,
+      })),
+    );
+
+    const frames =
+      defaultSpinSet != null
+        ? await Promise.all(
+            normalizedFrames.map(async (frame) => ({
+              id: frame.id,
+              spin_set_id: frame.spin_set_id,
+              frame_index: frame.frame_index,
+              image_url: await this.storage.getFileUrl(frame.file_path),
+              thumbnail_url: frame.thumbnail_path
+                ? await this.storage.getFileUrl(frame.thumbnail_path)
+                : null,
+              created_at: frame.created_at,
+            })),
+          )
+        : [];
+
     return {
       item: {
         ...itemData,
         price: toNumber(itemData.price),
         original_price: toNumber(itemData.original_price),
       },
-      images: normalizedImages.map((img) => ({
-        id: img.id,
-        item_id: img.item_id,
-        url: this.storage.getFileUrl(img.file_path),
-        thumbnail_url: img.thumbnail_path
-          ? this.storage.getFileUrl(img.thumbnail_path)
-          : null,
-        is_cover: img.is_cover,
-        display_order: img.display_order,
-        created_at: img.created_at,
-      })),
+      images,
       spinner: defaultSpinSet
         ? {
             id: defaultSpinSet.id,
             item_id: defaultSpinSet.item_id,
             label: defaultSpinSet.label,
             is_default: defaultSpinSet.is_default,
-            frames: normalizedFrames.map((frame) => ({
-              id: frame.id,
-              spin_set_id: frame.spin_set_id,
-              frame_index: frame.frame_index,
-              image_url: this.storage.getFileUrl(frame.file_path),
-              thumbnail_url: frame.thumbnail_path
-                ? this.storage.getFileUrl(frame.thumbnail_path)
-                : null,
-              created_at: frame.created_at,
-            })),
+            frames,
             created_at: defaultSpinSet.created_at,
             updated_at: defaultSpinSet.updated_at,
           }

--- a/backend/src/shops/shops.service.spec.ts
+++ b/backend/src/shops/shops.service.spec.ts
@@ -75,7 +75,7 @@ describe('ShopsService', () => {
 
     storage = {
       saveFile: jest.fn().mockResolvedValue('shop-branding/x.png'),
-      getFileUrl: jest.fn((p: string) => `https://signed.example/${p}`),
+      getFileUrl: jest.fn(async (p: string) => `https://signed.example/${p}`),
       deleteFile: jest.fn().mockResolvedValue(undefined),
     };
     uploadSupport = {

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -466,7 +466,7 @@ export class ShopsService {
     }
     const filename = `${tenantId}_${kind}_${uuidv4()}${ext}`;
     const relativePath = await this.storage.saveFile(payloadBuffer, filename, 'shop-branding');
-    const publicUrl = this.storage.getFileUrl(relativePath);
+    const publicUrl = await this.storage.getFileUrl(relativePath);
 
     const patch: ShopAppearancePatchDto =
       kind === 'logo' ? { logo_url: publicUrl } : { favicon_url: publicUrl };
@@ -600,15 +600,17 @@ export class ShopsService {
     ]);
 
     return {
-      items: items.map((item) => ({
-        id: item.id,
-        name: item.name,
-        price: toNumber(item.price),
-        created_at: item.created_at,
-        cover_image_url: item.item_images[0]
-          ? this.storage.getFileUrl(item.item_images[0].file_path)
-          : null,
-      })),
+      items: await Promise.all(
+        items.map(async (item) => ({
+          id: item.id,
+          name: item.name,
+          price: toNumber(item.price),
+          created_at: item.created_at,
+          cover_image_url: item.item_images[0]
+            ? await this.storage.getFileUrl(item.item_images[0].file_path)
+            : null,
+        })),
+      ),
       pagination: {
         page,
         page_size: pageSize,

--- a/backend/src/spinner/spinner.service.spec.ts
+++ b/backend/src/spinner/spinner.service.spec.ts
@@ -85,7 +85,7 @@ describe('SpinnerService', () => {
     storage = {
       saveFile: jest.fn().mockResolvedValue('spinner/generated.jpg'),
       deleteFile: jest.fn().mockResolvedValue(undefined),
-      getFileUrl: jest.fn((path: string) => `http://localhost/uploads/${path}`),
+      getFileUrl: jest.fn(async (path: string) => `http://localhost/uploads/${path}`),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/backend/src/spinner/spinner.service.ts
+++ b/backend/src/spinner/spinner.service.ts
@@ -49,24 +49,17 @@ export class SpinnerService {
     });
 
     return {
-      spin_sets: spinSets.map((set) => ({
-        id: set.id,
-        item_id: set.item_id,
-        label: set.label,
-        is_default: set.is_default,
-        frames: set.frames.map((frame) => ({
-          id: frame.id,
-          spin_set_id: frame.spin_set_id,
-          frame_index: frame.frame_index,
-          image_url: this.storage.getFileUrl(frame.file_path),
-          thumbnail_url: frame.thumbnail_path
-            ? this.storage.getFileUrl(frame.thumbnail_path)
-            : null,
-          created_at: frame.created_at,
+      spin_sets: await Promise.all(
+        spinSets.map(async (set) => ({
+          id: set.id,
+          item_id: set.item_id,
+          label: set.label,
+          is_default: set.is_default,
+          frames: await Promise.all(set.frames.map((frame) => this.mapFrame(frame))),
+          created_at: set.created_at,
+          updated_at: set.updated_at,
         })),
-        created_at: set.created_at,
-        updated_at: set.updated_at,
-      })),
+      ),
     };
   }
 
@@ -160,16 +153,7 @@ export class SpinnerService {
         item_id: updated.item_id,
         label: updated.label,
         is_default: updated.is_default,
-        frames: updated.frames.map((frame) => ({
-          id: frame.id,
-          spin_set_id: frame.spin_set_id,
-          frame_index: frame.frame_index,
-          image_url: this.storage.getFileUrl(frame.file_path),
-          thumbnail_url: frame.thumbnail_path
-            ? this.storage.getFileUrl(frame.thumbnail_path)
-            : null,
-          created_at: frame.created_at,
-        })),
+        frames: await Promise.all(updated.frames.map((frame) => this.mapFrame(frame))),
         created_at: updated.created_at,
         updated_at: updated.updated_at,
       },
@@ -235,7 +219,7 @@ export class SpinnerService {
         uploadDto.frame_index,
       );
 
-      return { frame: this.mapFrame(frame) };
+      return { frame: await this.mapFrame(frame) };
     } catch (error) {
       await this.cleanupSavedFiles(savedPaths, `uploadFrame:spinSetId=${spinSetId}`);
       throw error;
@@ -321,13 +305,15 @@ export class SpinnerService {
     );
   }
 
-  private mapFrame(frame: SpinFrame) {
+  private async mapFrame(frame: SpinFrame) {
     return {
       id: frame.id,
       spin_set_id: frame.spin_set_id,
       frame_index: frame.frame_index,
-      image_url: this.storage.getFileUrl(frame.file_path),
-      thumbnail_url: frame.thumbnail_path ? this.storage.getFileUrl(frame.thumbnail_path) : null,
+      image_url: await this.storage.getFileUrl(frame.file_path),
+      thumbnail_url: frame.thumbnail_path
+        ? await this.storage.getFileUrl(frame.thumbnail_path)
+        : null,
       created_at: frame.created_at,
     };
   }
@@ -390,16 +376,9 @@ export class SpinnerService {
         );
 
         return {
-          frames: updatedFrames.map((frame) => ({
-            id: frame.id,
-            spin_set_id: frame.spin_set_id,
-            frame_index: frame.frame_index,
-            image_url: this.storage.getFileUrl(frame.file_path),
-            thumbnail_url: frame.thumbnail_path
-              ? this.storage.getFileUrl(frame.thumbnail_path)
-              : null,
-            created_at: frame.created_at,
-          })),
+          frames: await Promise.all(
+            updatedFrames.map((frame) => this.mapFrame(frame)),
+          ),
         };
       } catch (error) {
         const shouldRetry =

--- a/backend/src/storage/local-storage.service.spec.ts
+++ b/backend/src/storage/local-storage.service.spec.ts
@@ -88,10 +88,16 @@ describe('LocalStorageService', () => {
     });
 
     it('should silently handle file-not-found errors', async () => {
-      mockedFs.unlink.mockRejectedValue(new Error('ENOENT'));
+      mockedFs.unlink.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' as const }));
 
       // Should not throw
       await service.deleteFile('nonexistent.jpg');
+    });
+
+    it('should propagate other unlink errors', async () => {
+      mockedFs.unlink.mockRejectedValue(Object.assign(new Error('permission'), { code: 'EACCES' as const }));
+
+      await expect(service.deleteFile('images/locked.jpg')).rejects.toMatchObject({ code: 'EACCES' });
     });
   });
 

--- a/backend/src/storage/local-storage.service.spec.ts
+++ b/backend/src/storage/local-storage.service.spec.ts
@@ -129,8 +129,8 @@ describe('LocalStorageService', () => {
   // getFileUrl
   // ============================================================
   describe('getFileUrl', () => {
-    it('should return signed media URL', () => {
-      const href = service.getFileUrl('images/test.jpg');
+    it('should return signed media URL', async () => {
+      const href = await service.getFileUrl('images/test.jpg');
       const u = new URL(href);
       expect(u.pathname).toBe('/api/v1/media');
       const d = u.searchParams.get('d');
@@ -141,15 +141,15 @@ describe('LocalStorageService', () => {
       expect(payload?.p).toBe('images/test.jpg');
     });
 
-    it('should strip leading ./ from path', () => {
-      const href = service.getFileUrl('./images/test.jpg');
+    it('should strip leading ./ from path', async () => {
+      const href = await service.getFileUrl('./images/test.jpg');
       const u = new URL(href);
       const payload = verifySignedMediaParams(u.searchParams.get('d')!, u.searchParams.get('s')!, mediaSigningSecret);
       expect(payload?.p).toBe('images/test.jpg');
     });
 
-    it('should strip leading / from path', () => {
-      const href = service.getFileUrl('/images/test.jpg');
+    it('should strip leading / from path', async () => {
+      const href = await service.getFileUrl('/images/test.jpg');
       const u = new URL(href);
       const payload = verifySignedMediaParams(u.searchParams.get('d')!, u.searchParams.get('s')!, mediaSigningSecret);
       expect(payload?.p).toBe('images/test.jpg');

--- a/backend/src/storage/local-storage.service.ts
+++ b/backend/src/storage/local-storage.service.ts
@@ -41,10 +41,13 @@ export class LocalStorageService implements IStorageService {
     const fullPath = path.join(this.uploadDir, filePath);
     try {
       await fs.unlink(fullPath);
-    } catch {
-      // File may not exist, ignore
+    } catch (err) {
+      const code = err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+      if (code !== 'ENOENT') {
+        throw err;
+      }
     }
-    }
+  }
 
 
   async moveFile(currentPath: string, newFilename: string, destinationSubfolder: string): Promise<string> {

--- a/backend/src/storage/local-storage.service.ts
+++ b/backend/src/storage/local-storage.service.ts
@@ -66,7 +66,7 @@ export class LocalStorageService implements IStorageService {
     }
   }
 
-  getFileUrl(filePath: string): string {
+  async getFileUrl(filePath: string): Promise<string> {
     const backend = (this.config.get<string>('BACKEND_URL') || 'http://localhost:3000').replace(/\/$/, '');
     const apiBase = `${backend}/api/v1`;
     const secret = resolveMediaSigningSecret(this.config);

--- a/backend/src/storage/local-storage.service.ts
+++ b/backend/src/storage/local-storage.service.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { buildSignedMediaFileUrl } from '../common/media/signed-media.util';
 import { resolveMediaSigningSecret } from '../common/media/media-signing-secret';
+import { parseMediaUrlTtlMs } from '../common/media/media-url-ttl.util';
 import { IStorageService } from './storage.interface';
 
 @Injectable()
@@ -70,7 +71,7 @@ export class LocalStorageService implements IStorageService {
     const backend = (this.config.get<string>('BACKEND_URL') || 'http://localhost:3000').replace(/\/$/, '');
     const apiBase = `${backend}/api/v1`;
     const secret = resolveMediaSigningSecret(this.config);
-    const ttlMs = Number(this.config.get('MEDIA_URL_TTL_MS')) || 7 * 24 * 60 * 60 * 1000;
+    const ttlMs = parseMediaUrlTtlMs(this.config);
     const cleanPath = filePath.replace(/^\.\//, '').replace(/^\//, '');
     return buildSignedMediaFileUrl(apiBase, cleanPath, secret, ttlMs);
   }

--- a/backend/src/storage/local-storage.service.ts
+++ b/backend/src/storage/local-storage.service.ts
@@ -41,7 +41,7 @@ export class LocalStorageService implements IStorageService {
     const fullPath = path.join(this.uploadDir, filePath);
     try {
       await fs.unlink(fullPath);
-    } catch (error) {
+    } catch {
       // File may not exist, ignore
     }
     }
@@ -59,7 +59,7 @@ export class LocalStorageService implements IStorageService {
     try {
       await fs.rename(fullCurrentPath, destPath);
       return relativeDestPath;
-    } catch (error) {
+    } catch {
       // If rename fails (e.g. cross-device), try copy + unlink
       await fs.copyFile(fullCurrentPath, destPath);
       await fs.unlink(fullCurrentPath);

--- a/backend/src/storage/r2-s3.factory.ts
+++ b/backend/src/storage/r2-s3.factory.ts
@@ -1,0 +1,32 @@
+import { ConfigService } from '@nestjs/config';
+import { S3Client } from '@aws-sdk/client-s3';
+
+export type R2S3ClientAndBucket = { client: S3Client; bucket: string };
+
+export function isR2StorageDriver(config: ConfigService): boolean {
+  return (config.get<string>('STORAGE_DRIVER') || 'local').trim().toLowerCase() === 'r2';
+}
+
+/** Normalize DB-relative media path to an R2 object key (forward slashes, no leading slash). */
+export function normalizeR2ObjectKey(filePath: string): string {
+  return filePath.replace(/^\.\//, '').replace(/^\//, '');
+}
+
+export function createR2S3ClientAndBucket(config: ConfigService): R2S3ClientAndBucket {
+  const accountId = config.get<string>('R2_ACCOUNT_ID')?.trim();
+  const accessKeyId = config.get<string>('R2_ACCESS_KEY_ID')?.trim();
+  const secretAccessKey = config.get<string>('R2_SECRET_ACCESS_KEY')?.trim();
+  const bucket = config.get<string>('R2_BUCKET')?.trim();
+  if (!accountId || !accessKeyId || !secretAccessKey || !bucket) {
+    throw new Error(
+      'STORAGE_DRIVER=r2 requires R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and R2_BUCKET. See backend/.env.example.',
+    );
+  }
+  const client = new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId, secretAccessKey },
+    forcePathStyle: true,
+  });
+  return { client, bucket };
+}

--- a/backend/src/storage/r2-storage.service.spec.ts
+++ b/backend/src/storage/r2-storage.service.spec.ts
@@ -99,6 +99,25 @@ describe('R2StorageService', () => {
 
       expect(result).toBe('images/new.jpg');
     });
+
+    it('retries DeleteObject when first attempt fails after successful copy', async () => {
+      mockSend
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('throttle'))
+        .mockResolvedValueOnce({});
+
+      const result = await service.moveFile('drafts/old.jpg', 'new.jpg', 'images');
+
+      expect(mockSend).toHaveBeenCalledTimes(3);
+      expect(result).toBe('images/new.jpg');
+    });
+
+    it('throws after delete retries exhausted', async () => {
+      mockSend.mockResolvedValueOnce({}).mockRejectedValue(new Error('network'));
+
+      await expect(service.moveFile('drafts/old.jpg', 'new.jpg', 'images')).rejects.toThrow('network');
+      expect(mockSend).toHaveBeenCalledTimes(5);
+    });
   });
 
   describe('deleteFile', () => {
@@ -109,9 +128,9 @@ describe('R2StorageService', () => {
       expect(cmd.input.Key).toBe('images/x.jpg');
     });
 
-    it('should swallow errors', async () => {
+    it('propagates DeleteObject errors', async () => {
       mockSend.mockRejectedValueOnce(new Error('network'));
-      await expect(service.deleteFile('images/x.jpg')).resolves.toBeUndefined();
+      await expect(service.deleteFile('images/x.jpg')).rejects.toThrow('network');
     });
   });
 
@@ -122,6 +141,26 @@ describe('R2StorageService', () => {
       expect(mockedGetSignedUrl).toHaveBeenCalled();
       expect(url).toContain('X-Amz-');
       expect(url).toContain('r2.cloudflarestorage.com');
+    });
+
+    it('uses default TTL when MEDIA_URL_TTL_MS is invalid', async () => {
+      const cfg = {
+        get: jest.fn((key: string) => {
+          if (key === 'R2_ACCOUNT_ID') return 'test-account';
+          if (key === 'R2_ACCESS_KEY_ID') return 'test-access-key';
+          if (key === 'R2_SECRET_ACCESS_KEY') return 'test-secret-key';
+          if (key === 'R2_BUCKET') return 'test-bucket';
+          if (key === 'MEDIA_URL_TTL_MS') return 'not-a-number';
+          return undefined;
+        }),
+      } as unknown as ConfigService;
+      const s = new R2StorageService(cfg);
+      await s.getFileUrl('a.jpg');
+      expect(mockedGetSignedUrl).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ expiresIn: 604800 }),
+      );
     });
 
     it('should pass expiresIn derived from MEDIA_URL_TTL_MS', async () => {

--- a/backend/src/storage/r2-storage.service.spec.ts
+++ b/backend/src/storage/r2-storage.service.spec.ts
@@ -1,0 +1,136 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  CopyObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { R2StorageService } from './r2-storage.service';
+
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({ send: mockSend })),
+  PutObjectCommand: jest.fn().mockImplementation((input: object) => ({ input })),
+  GetObjectCommand: jest.fn().mockImplementation((input: object) => ({ input })),
+  CopyObjectCommand: jest.fn().mockImplementation((input: object) => ({ input })),
+  DeleteObjectCommand: jest.fn().mockImplementation((input: object) => ({ input })),
+}));
+
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn().mockResolvedValue(
+    'https://test-account.r2.cloudflarestorage.com/test-bucket/spinner/frame.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test',
+  ),
+}));
+
+const mockedGetSignedUrl = jest.mocked(getSignedUrl);
+const MockedS3Client = jest.mocked(S3Client);
+
+describe('R2StorageService', () => {
+  let service: R2StorageService;
+
+  const mockConfig = (): ConfigService =>
+    ({
+      get: jest.fn((key: string) => {
+        if (key === 'R2_ACCOUNT_ID') return 'test-account';
+        if (key === 'R2_ACCESS_KEY_ID') return 'test-access-key';
+        if (key === 'R2_SECRET_ACCESS_KEY') return 'test-secret-key';
+        if (key === 'R2_BUCKET') return 'test-bucket';
+        if (key === 'MEDIA_URL_TTL_MS') return 3600_000;
+        return undefined;
+      }),
+    }) as unknown as ConfigService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSend.mockResolvedValue({});
+    service = new R2StorageService(mockConfig());
+  });
+
+  it('should configure S3 client for R2 endpoint', () => {
+    expect(MockedS3Client).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: 'auto',
+        endpoint: 'https://test-account.r2.cloudflarestorage.com',
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: 'test-access-key',
+          secretAccessKey: 'test-secret-key',
+        },
+      }),
+    );
+  });
+
+  describe('saveFile', () => {
+    it('should PutObject and return spinner/frame.jpg style path', async () => {
+      const buffer = Buffer.from('img');
+      const result = await service.saveFile(buffer, 'frame.jpg', 'spinner');
+
+      expect(PutObjectCommand).toHaveBeenCalled();
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const cmd = mockSend.mock.calls[0][0] as { input: Record<string, unknown> };
+      expect(cmd.input.Bucket).toBe('test-bucket');
+      expect(cmd.input.Key).toBe('spinner/frame.jpg');
+      expect(cmd.input.Body).toBe(buffer);
+      expect(cmd.input.ContentType).toBe('image/jpeg');
+      expect(result).toBe('spinner/frame.jpg');
+    });
+  });
+
+  describe('moveFile', () => {
+    it('should CopyObject then DeleteObject and return destination path', async () => {
+      const result = await service.moveFile('drafts/old.jpg', 'new.jpg', 'images');
+
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(CopyObjectCommand).toHaveBeenCalled();
+      expect(DeleteObjectCommand).toHaveBeenCalled();
+
+      const copyCmd = mockSend.mock.calls[0][0] as { input: Record<string, unknown> };
+      expect(copyCmd.input.Bucket).toBe('test-bucket');
+      expect(copyCmd.input.Key).toBe('images/new.jpg');
+      expect(copyCmd.input.CopySource).toBe('test-bucket/drafts/old.jpg');
+      expect(copyCmd.input.ContentType).toBe('image/jpeg');
+      expect(copyCmd.input.MetadataDirective).toBe('REPLACE');
+
+      const deleteCmd = mockSend.mock.calls[1][0] as { input: Record<string, unknown> };
+      expect(deleteCmd.input.Key).toBe('drafts/old.jpg');
+
+      expect(result).toBe('images/new.jpg');
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('should DeleteObject', async () => {
+      await service.deleteFile('images/x.jpg');
+      expect(DeleteObjectCommand).toHaveBeenCalled();
+      const cmd = mockSend.mock.calls[0][0] as { input: Record<string, unknown> };
+      expect(cmd.input.Key).toBe('images/x.jpg');
+    });
+
+    it('should swallow errors', async () => {
+      mockSend.mockRejectedValueOnce(new Error('network'));
+      await expect(service.deleteFile('images/x.jpg')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getFileUrl', () => {
+    it('should return presigned URL from getSignedUrl', async () => {
+      const url = await service.getFileUrl('spinner/frame.jpg');
+      expect(GetObjectCommand).toHaveBeenCalled();
+      expect(mockedGetSignedUrl).toHaveBeenCalled();
+      expect(url).toContain('X-Amz-');
+      expect(url).toContain('r2.cloudflarestorage.com');
+    });
+
+    it('should pass expiresIn derived from MEDIA_URL_TTL_MS', async () => {
+      await service.getFileUrl('a.jpg');
+      expect(mockedGetSignedUrl).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ expiresIn: 3600 }),
+      );
+    });
+  });
+});

--- a/backend/src/storage/r2-storage.service.ts
+++ b/backend/src/storage/r2-storage.service.ts
@@ -1,25 +1,26 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PutObjectCommand, GetObjectCommand, CopyObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { imageMimeAndExtForPath } from '../common/media/media-mime.util';
+import { parseMediaUrlTtlMs } from '../common/media/media-url-ttl.util';
 import { IStorageService } from './storage.interface';
 import { createR2S3ClientAndBucket, normalizeR2ObjectKey } from './r2-s3.factory';
-
-function contentTypeForFilename(filename: string): string {
-  const ext = filename.toLowerCase().split('.').pop() || '';
-  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg';
-  if (ext === 'png') return 'image/png';
-  if (ext === 'webp') return 'image/webp';
-  if (ext === 'gif') return 'image/gif';
-  return 'application/octet-stream';
-}
 
 function copySourceHeader(bucket: string, sourceKey: string): string {
   return `${bucket}/${sourceKey.split('/').map(encodeURIComponent).join('/')}`;
 }
 
+function moveDeleteBackoffMs(attemptIndex: number): number {
+  if (typeof process.env.JEST_WORKER_ID === 'string') {
+    return 0;
+  }
+  return Math.min(2000, 100 * 2 ** attemptIndex);
+}
+
 @Injectable()
 export class R2StorageService implements IStorageService {
+  private readonly logger = new Logger(R2StorageService.name);
   private readonly client: ReturnType<typeof createR2S3ClientAndBucket>['client'];
   private readonly bucket: string;
   private readonly urlTtlMs: number;
@@ -28,18 +29,19 @@ export class R2StorageService implements IStorageService {
     const { client, bucket } = createR2S3ClientAndBucket(config);
     this.client = client;
     this.bucket = bucket;
-    this.urlTtlMs = Number(this.config.get('MEDIA_URL_TTL_MS')) || 7 * 24 * 60 * 60 * 1000;
+    this.urlTtlMs = parseMediaUrlTtlMs(config);
   }
 
   async saveFile(file: Buffer, filename: string, subfolder?: string): Promise<string> {
     const relativePath = subfolder ? `${subfolder}/${filename}` : filename;
     const key = normalizeR2ObjectKey(relativePath);
+    const { mime } = imageMimeAndExtForPath(filename);
     await this.client.send(
       new PutObjectCommand({
         Bucket: this.bucket,
         Key: key,
         Body: file,
-        ContentType: contentTypeForFilename(filename),
+        ContentType: mime,
       }),
     );
     return relativePath;
@@ -47,11 +49,7 @@ export class R2StorageService implements IStorageService {
 
   async deleteFile(filePath: string): Promise<void> {
     const key = normalizeR2ObjectKey(filePath);
-    try {
-      await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
-    } catch {
-      // Best-effort; mirror LocalStorageService ignoring missing files
-    }
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
   }
 
   async moveFile(
@@ -62,19 +60,46 @@ export class R2StorageService implements IStorageService {
     const sourceKey = normalizeR2ObjectKey(currentPath);
     const destRelative = `${destinationSubfolder}/${newFilename}`;
     const destKey = normalizeR2ObjectKey(destRelative);
+    const { mime } = imageMimeAndExtForPath(newFilename);
 
     await this.client.send(
       new CopyObjectCommand({
         Bucket: this.bucket,
         CopySource: copySourceHeader(this.bucket, sourceKey),
         Key: destKey,
-        ContentType: contentTypeForFilename(newFilename),
+        ContentType: mime,
         MetadataDirective: 'REPLACE',
       }),
     );
 
-    await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: sourceKey }));
+    await this.deleteSourceAfterCopyWithRetry(sourceKey, destKey);
     return destRelative;
+  }
+
+  private async deleteSourceAfterCopyWithRetry(sourceKey: string, destKey: string): Promise<void> {
+    const maxAttempts = 4;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: sourceKey }));
+        return;
+      } catch (err) {
+        lastErr = err;
+        this.logger.warn(
+          `DeleteObject after CopyObject failed (attempt ${attempt + 1}/${maxAttempts}) sourceKey=${sourceKey}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        if (attempt < maxAttempts - 1) {
+          const ms = moveDeleteBackoffMs(attempt);
+          if (ms > 0) {
+            await new Promise((r) => setTimeout(r, ms));
+          }
+        }
+      }
+    }
+    this.logger.error(
+      `moveFile left duplicate objects after successful copy: sourceKey=${sourceKey} destKey=${destKey} — manual cleanup of source may be required`,
+    );
+    throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
   }
 
   async getFileUrl(filePath: string): Promise<string> {

--- a/backend/src/storage/r2-storage.service.ts
+++ b/backend/src/storage/r2-storage.service.ts
@@ -1,0 +1,108 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  CopyObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { IStorageService } from './storage.interface';
+
+function normalizeObjectKey(filePath: string): string {
+  return filePath.replace(/^\.\//, '').replace(/^\//, '');
+}
+
+function contentTypeForFilename(filename: string): string {
+  const ext = filename.toLowerCase().split('.').pop() || '';
+  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg';
+  if (ext === 'png') return 'image/png';
+  if (ext === 'webp') return 'image/webp';
+  if (ext === 'gif') return 'image/gif';
+  return 'application/octet-stream';
+}
+
+function copySourceHeader(bucket: string, sourceKey: string): string {
+  return `${bucket}/${sourceKey.split('/').map(encodeURIComponent).join('/')}`;
+}
+
+@Injectable()
+export class R2StorageService implements IStorageService {
+  private readonly client: S3Client;
+  private readonly bucket: string;
+  private readonly urlTtlMs: number;
+
+  constructor(private readonly config: ConfigService) {
+    const accountId = this.config.get<string>('R2_ACCOUNT_ID')?.trim();
+    const accessKeyId = this.config.get<string>('R2_ACCESS_KEY_ID')?.trim();
+    const secretAccessKey = this.config.get<string>('R2_SECRET_ACCESS_KEY')?.trim();
+    const bucket = this.config.get<string>('R2_BUCKET')?.trim();
+    if (!accountId || !accessKeyId || !secretAccessKey || !bucket) {
+      throw new Error(
+        'STORAGE_DRIVER=r2 requires R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and R2_BUCKET. See backend/.env.example.',
+      );
+    }
+    this.bucket = bucket;
+    this.urlTtlMs = Number(this.config.get('MEDIA_URL_TTL_MS')) || 7 * 24 * 60 * 60 * 1000;
+    this.client = new S3Client({
+      region: 'auto',
+      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+      credentials: { accessKeyId, secretAccessKey },
+      forcePathStyle: true,
+    });
+  }
+
+  async saveFile(file: Buffer, filename: string, subfolder?: string): Promise<string> {
+    const relativePath = subfolder ? `${subfolder}/${filename}` : filename;
+    const key = normalizeObjectKey(relativePath);
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: file,
+        ContentType: contentTypeForFilename(filename),
+      }),
+    );
+    return relativePath;
+  }
+
+  async deleteFile(filePath: string): Promise<void> {
+    const key = normalizeObjectKey(filePath);
+    try {
+      await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+    } catch {
+      // Best-effort; mirror LocalStorageService ignoring missing files
+    }
+  }
+
+  async moveFile(
+    currentPath: string,
+    newFilename: string,
+    destinationSubfolder: string,
+  ): Promise<string> {
+    const sourceKey = normalizeObjectKey(currentPath);
+    const destRelative = `${destinationSubfolder}/${newFilename}`;
+    const destKey = normalizeObjectKey(destRelative);
+
+    await this.client.send(
+      new CopyObjectCommand({
+        Bucket: this.bucket,
+        CopySource: copySourceHeader(this.bucket, sourceKey),
+        Key: destKey,
+        ContentType: contentTypeForFilename(newFilename),
+        MetadataDirective: 'REPLACE',
+      }),
+    );
+
+    await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: sourceKey }));
+    return destRelative;
+  }
+
+  async getFileUrl(filePath: string): Promise<string> {
+    const key = normalizeObjectKey(filePath);
+    const cmd = new GetObjectCommand({ Bucket: this.bucket, Key: key });
+    const expiresIn = Math.max(1, Math.floor(this.urlTtlMs / 1000));
+    return getSignedUrl(this.client, cmd, { expiresIn });
+  }
+}

--- a/backend/src/storage/r2-storage.service.ts
+++ b/backend/src/storage/r2-storage.service.ts
@@ -1,18 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import {
-  S3Client,
-  PutObjectCommand,
-  GetObjectCommand,
-  CopyObjectCommand,
-  DeleteObjectCommand,
-} from '@aws-sdk/client-s3';
+import { PutObjectCommand, GetObjectCommand, CopyObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { IStorageService } from './storage.interface';
-
-function normalizeObjectKey(filePath: string): string {
-  return filePath.replace(/^\.\//, '').replace(/^\//, '');
-}
+import { createR2S3ClientAndBucket, normalizeR2ObjectKey } from './r2-s3.factory';
 
 function contentTypeForFilename(filename: string): string {
   const ext = filename.toLowerCase().split('.').pop() || '';
@@ -29,33 +20,20 @@ function copySourceHeader(bucket: string, sourceKey: string): string {
 
 @Injectable()
 export class R2StorageService implements IStorageService {
-  private readonly client: S3Client;
+  private readonly client: ReturnType<typeof createR2S3ClientAndBucket>['client'];
   private readonly bucket: string;
   private readonly urlTtlMs: number;
 
   constructor(private readonly config: ConfigService) {
-    const accountId = this.config.get<string>('R2_ACCOUNT_ID')?.trim();
-    const accessKeyId = this.config.get<string>('R2_ACCESS_KEY_ID')?.trim();
-    const secretAccessKey = this.config.get<string>('R2_SECRET_ACCESS_KEY')?.trim();
-    const bucket = this.config.get<string>('R2_BUCKET')?.trim();
-    if (!accountId || !accessKeyId || !secretAccessKey || !bucket) {
-      throw new Error(
-        'STORAGE_DRIVER=r2 requires R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and R2_BUCKET. See backend/.env.example.',
-      );
-    }
+    const { client, bucket } = createR2S3ClientAndBucket(config);
+    this.client = client;
     this.bucket = bucket;
     this.urlTtlMs = Number(this.config.get('MEDIA_URL_TTL_MS')) || 7 * 24 * 60 * 60 * 1000;
-    this.client = new S3Client({
-      region: 'auto',
-      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-      credentials: { accessKeyId, secretAccessKey },
-      forcePathStyle: true,
-    });
   }
 
   async saveFile(file: Buffer, filename: string, subfolder?: string): Promise<string> {
     const relativePath = subfolder ? `${subfolder}/${filename}` : filename;
-    const key = normalizeObjectKey(relativePath);
+    const key = normalizeR2ObjectKey(relativePath);
     await this.client.send(
       new PutObjectCommand({
         Bucket: this.bucket,
@@ -68,7 +46,7 @@ export class R2StorageService implements IStorageService {
   }
 
   async deleteFile(filePath: string): Promise<void> {
-    const key = normalizeObjectKey(filePath);
+    const key = normalizeR2ObjectKey(filePath);
     try {
       await this.client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
     } catch {
@@ -81,9 +59,9 @@ export class R2StorageService implements IStorageService {
     newFilename: string,
     destinationSubfolder: string,
   ): Promise<string> {
-    const sourceKey = normalizeObjectKey(currentPath);
+    const sourceKey = normalizeR2ObjectKey(currentPath);
     const destRelative = `${destinationSubfolder}/${newFilename}`;
-    const destKey = normalizeObjectKey(destRelative);
+    const destKey = normalizeR2ObjectKey(destRelative);
 
     await this.client.send(
       new CopyObjectCommand({
@@ -100,7 +78,7 @@ export class R2StorageService implements IStorageService {
   }
 
   async getFileUrl(filePath: string): Promise<string> {
-    const key = normalizeObjectKey(filePath);
+    const key = normalizeR2ObjectKey(filePath);
     const cmd = new GetObjectCommand({ Bucket: this.bucket, Key: key });
     const expiresIn = Math.max(1, Math.floor(this.urlTtlMs / 1000));
     return getSignedUrl(this.client, cmd, { expiresIn });

--- a/backend/src/storage/storage.interface.ts
+++ b/backend/src/storage/storage.interface.ts
@@ -2,6 +2,6 @@ export interface IStorageService {
   saveFile(file: Buffer, filename: string, subfolder?: string): Promise<string>;
   deleteFile(filePath: string): Promise<void>;
   moveFile(currentPath: string, newFilename: string, destinationSubfolder: string): Promise<string>;
-  getFileUrl(filePath: string): string;
+  getFileUrl(filePath: string): Promise<string>;
 }
 

--- a/backend/src/storage/storage.module.ts
+++ b/backend/src/storage/storage.module.ts
@@ -1,17 +1,35 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { LocalStorageService } from './local-storage.service';
+import { R2StorageService } from './r2-storage.service';
 import { IStorageService } from './storage.interface';
 
-const StorageServiceProvider = {
+function assertR2Env(config: ConfigService): void {
+  const keys = ['R2_ACCOUNT_ID', 'R2_ACCESS_KEY_ID', 'R2_SECRET_ACCESS_KEY', 'R2_BUCKET'] as const;
+  const missing = keys.filter((k) => !config.get<string>(k)?.trim());
+  if (missing.length > 0) {
+    throw new Error(
+      `STORAGE_DRIVER=r2 requires these environment variables: ${missing.join(', ')}. See backend/.env.example.`,
+    );
+  }
+}
+
+const storageServiceProvider = {
   provide: 'IStorageService',
-  useClass: LocalStorageService,
+  useFactory: (config: ConfigService): IStorageService => {
+    const driver = (config.get<string>('STORAGE_DRIVER') || 'local').trim().toLowerCase();
+    if (driver === 'r2') {
+      assertR2Env(config);
+      return new R2StorageService(config);
+    }
+    return new LocalStorageService(config);
+  },
+  inject: [ConfigService],
 };
 
 @Module({
   imports: [ConfigModule],
-  providers: [StorageServiceProvider, LocalStorageService],
+  providers: [storageServiceProvider, LocalStorageService],
   exports: ['IStorageService', LocalStorageService],
 })
 export class StorageModule {}
-

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -476,6 +476,8 @@ Ghi chu: nhom endpoint nay la ke hoach de trien khai MVP pre-order, chua mac din
 - Spinner: `frame_index` phải trong khoảng 0..n và không trùng; order phải đủ tất cả `frame_ids` hiện có.
 
 ## Lưu ý response
-- URL trả về cho ảnh/frame là signed media URL dạng `GET /api/v1/media?d=...&s=...`; backend ghép từ `BACKEND_URL` + `/api/v1` và ký bằng `MEDIA_SIGNING_SECRET` (fallback `JWT_SECRET`).
+- **Lưu trữ media (`STORAGE_DRIVER`):**
+  - `local` (mặc định): URL ảnh/frame trong JSON thường là signed media URL dạng `GET /api/v1/media?d=...&s=...` (backend ghép từ `BACKEND_URL` + `/api/v1`, ký bằng `MEDIA_SIGNING_SECRET` hoặc fallback `JWT_SECRET`). TTL mặc định 7 ngày (`MEDIA_URL_TTL_MS`).
+  - `r2`: Cùng payload DB (đường dẫn tương đối như `images/...`). API thường trả **presigned GET** trỏ thẳng R2; TTL căn `MEDIA_URL_TTL_MS`. Endpoint `GET /api/v1/media?d=&s=` vẫn được hỗ trợ: sau khi xác thực chữ ký, backend **proxy** object từ R2 (không đọc `UPLOAD_DIR`) để tương thích link cũ trong cache/CDN.
 - Không trả password_hash/token_hash.
 - Khi thay đổi API/DB, phải cập nhật docs trước rồi mới code.

--- a/docs/BACKEND_PI_CLOUDFLARE.md
+++ b/docs/BACKEND_PI_CLOUDFLARE.md
@@ -10,9 +10,12 @@ API ra ngoài qua **Cloudflare Tunnel** trỏ tới `http://127.0.0.1:3000` (ho�
 - Thư mục deploy (mặc định): `/opt/diecast360-backend`. Clone repo hoặc tạo thư mục và `git init` + remote — workflow **không** tự clone lần đầu; rsync tạo/tệp tin trong thư mục đó.
 
 ```bash
+# Chỉ cần khi STORAGE_DRIVER=local — volume ghi ảnh trên Pi
 sudo mkdir -p /opt/diecast360-backend/uploads
 sudo chown -R "$USER:$USER" /opt/diecast360-backend
 ```
+
+Khi `STORAGE_DRIVER=r2`, bước `mkdir uploads` **không bắt buộc** cho media (object nằm trên R2). Vẫn cần `backend/.env` đầy đủ `R2_*` và bucket đã đồng bộ nếu đang cutover từ disk — xem [`ENV.md`](ENV.md) và [`docs/plans/cloudflare-r2-upload-migration.md`](../docs/plans/cloudflare-r2-upload-migration.md).
 
 - Copy **`.env`** production trên Pi (Neon `DATABASE_URL` / `DIRECT_URL`, `JWT_SECRET`, `COOKIE_SECRET`, `FRONTEND_URL` = origin frontend hosting, v.v.). Xem [`ENV.md`](ENV.md).
 - **`BACKEND_URL`**: đặt URL public của API (vd `https://api.example.com`) để ký và trả link ảnh qua `GET /api/v1/media`.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -74,7 +74,8 @@ Lợi ích: không cần mở cổng inbound trên router, không phụ thuộc 
 
 - Dùng OS 64-bit; Node 20 (khớp workflow deploy hiện tại).
 - **Chỉ chạy backend trên Pi**; database để trên Neon để tránh Postgres + Nest tranh RAM.
-- Tạo thư mục `UPLOAD_DIR` trên ổ đủ dung lượng (USB nếu cần); giới hạn `MAX_UPLOAD_MB` hợp lý — xử lý ảnh (Sharp) có thể tốn RAM khi upload đồng thời.
+- **`UPLOAD_DIR` / thư mục uploads:** Cần khi `STORAGE_DRIVER=local` (đủ dung lượng, có thể USB). Khi `STORAGE_DRIVER=r2`, có thể **không** cần volume lớn trên Pi cho media; vẫn cần bucket R2 + biến `R2_*` — xem [`ENV.md`](ENV.md) mục Object storage và [`docs/plans/cloudflare-r2-upload-migration.md`](plans/cloudflare-r2-upload-migration.md) phần Cutover runbook.
+- Giới hạn `MAX_UPLOAD_MB` hợp lý — xử lý ảnh (Sharp) có thể tốn RAM khi upload đồng thời.
 - Nếu deploy thủ công, cài dependency, build, migrate rồi restart:
 
   ```bash
@@ -123,7 +124,8 @@ WantedBy=multi-user.target
 | **Pi** | `BACKEND_URL` | URL public của API (HTTPS), dùng làm base cho signed media URL `/api/v1/media` |
 | **Pi** | `MEDIA_SIGNING_SECRET`, `MEDIA_URL_TTL_MS` | Tùy chọn cho signed media URL; nếu không set secret riêng, backend fallback sang `JWT_SECRET` |
 | **Pi** | `COOKIE_SECURE=true`, `COOKIE_SAME_SITE` | Production HTTPS — xem [`ENV.md`](ENV.md) |
-| **Pi** | `UPLOAD_DIR` | Đường dẫn tuyệt đối trên Pi, thư mục tồn tại và ghi được |
+| **Pi** | `UPLOAD_DIR` | Bắt buộc khi `STORAGE_DRIVER=local` — đường dẫn ghi được. Với `STORAGE_DRIVER=r2` có thể giữ mặc định hoặc bỏ qua nhu cầu volume lớn cho media |
+| **Pi** | `STORAGE_DRIVER`, `R2_*` | Khi dùng Cloudflare R2 — xem [`ENV.md`](ENV.md) |
 | **Vercel / Pages** (build) | `VITE_API_BASE_URL` | `https://<api-host>/api/v1` |
 
 Chi tiết Facebook, OpenAI, Pinecone: tùy tính năng bật — vẫn trong [`ENV.md`](ENV.md).
@@ -166,3 +168,17 @@ Pi không cần mở outbound tới Neon chỉ để migrate trong CD (runtime A
 - Sao lưu định kỳ thư mục upload trên Pi; Neon có backup theo gói dịch vụ.
 - Sau deploy: kiểm tra `sudo systemctl status diecast360-api`, `journalctl -u diecast360-api -n 100 --no-pager`, và `curl -sfS http://127.0.0.1:$PORT/api/v1/health`.
 - Cập nhật code: merge `main` (workflow self-hosted trên Pi) hoặc tay: build theo mục Pi ở trên rồi `systemctl restart …`.
+
+---
+
+## 8. Cutover: local disk → Cloudflare R2
+
+Thứ tự gợi ý (staging trước production):
+
+1. Tạo bucket R2 + API token; ghi `STORAGE_DRIVER=r2` và đủ `R2_*` trên **staging** (xem [`ENV.md`](ENV.md)).
+2. **Đồng bộ object** từ thư mục `UPLOAD_DIR` hiện tại lên R2 với **cùng key** (đường dẫn tương đối trong DB). Có thể dùng `rclone sync` — ví dụ trong [`docs/plans/cloudflare-r2-upload-migration.md`](plans/cloudflare-r2-upload-migration.md) (Cutover runbook) và [`backend/scripts/README.md`](../backend/scripts/README.md).
+3. Khởi động lại backend; spot-check: upload mới, mở ảnh catalog, `GET /api/v1/media?...` với link đã ký cũ (proxy R2).
+4. **Production:** lặp lại sync → đổi env → restart; theo dõi log và egress.
+5. **Rollback:** đặt lại `STORAGE_DRIVER=local`, khôi phục tree file dưới `UPLOAD_DIR` từ backup nếu đã xoá; hoặc trỏ lại disk snapshot.
+
+Chi tiết và lệnh mẫu: [`docs/plans/cloudflare-r2-upload-migration.md`](plans/cloudflare-r2-upload-migration.md).

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -20,7 +20,7 @@ Diecast360 dùng PostgreSQL làm chuẩn cho runtime và Prisma CLI:
 | JWT_SECRET | Secret ký access token | `super-secret` | Bắt buộc, đủ entropy |
 | JWT_EXPIRES_IN | TTL access token | `15m` | Chuỗi thời gian (ms, s, m, h...) |
 | REFRESH_TOKEN_EXPIRES_IN | TTL refresh token | `7d` | Dùng để tính `expires_at` |
-| UPLOAD_DIR | Thư mục lưu file local | `./uploads` | Phải tồn tại/ghi được |
+| UPLOAD_DIR | Thư mục lưu file local | `./uploads` | Khi `STORAGE_DRIVER=local` phải tồn tại/ghi được. Khi `STORAGE_DRIVER=r2`, thư mục không dùng cho đọc media (upload qua S3 API); vẫn có thể để mặc định cho dev. |
 | MAX_UPLOAD_MB | Giới hạn kích thước upload | `10` | Áp dụng cho ảnh thường và frame spinner |
 | ALLOWED_MIME | MIME type cho upload | `image/jpeg,image/png` | Server validate trước khi lưu |
 | BACKEND_URL | Base public URL của backend | `http://localhost:3000` | Dùng để ghép signed media URL (`/api/v1/media?...`); production nên đặt URL public của API. |
@@ -33,8 +33,22 @@ Diecast360 dùng PostgreSQL làm chuẩn cho runtime và Prisma CLI:
 | CORS_ALLOW_LAN | Cho phép origin LAN private trong dev | `true` (dev LAN) / `false` (prod) | Chỉ dùng khi test UI qua Vite `--host`; production boot sẽ reject nếu `true`. |
 | MEDIA_SIGNING_SECRET | Secret ký URL media | random 32+ chars | Tùy chọn nhưng khuyến nghị; nếu bỏ trống dùng `JWT_SECRET`, làm xoay JWT có thể vô hiệu link ảnh cũ. |
 | MEDIA_URL_TTL_MS | TTL signed media URL | `604800000` | Tùy chọn; mặc định 7 ngày. |
+| STORAGE_DRIVER | Backend lưu object: `local` hoặc `r2` | `local` | Với `r2` cần đủ biến `R2_*` (xem mục Object storage). |
+| R2_ACCOUNT_ID | Cloudflare account id (segment endpoint S3) | `abc123...` | Bắt buộc khi `STORAGE_DRIVER=r2` |
+| R2_ACCESS_KEY_ID | R2 S3 API access key | `...` | Bắt buộc khi `STORAGE_DRIVER=r2`; rotate định kỳ |
+| R2_SECRET_ACCESS_KEY | R2 S3 API secret | `...` | **Không** commit; chỉ env/secret manager |
+| R2_BUCKET | Tên bucket R2 | `diecast360-media` | Bắt buộc khi `STORAGE_DRIVER=r2` |
+| R2_PUBLIC_BASE_URL | (Tuỳ chọn) CDN/public base nếu không dùng presigned | — | Thường để trống; app ưu tiên presigned GET |
 | FACEBOOK_PAGE_ID | Facebook Page ID cho publish | `123456789` | Tùy chọn (bắt buộc cho FB publish) |
 | FACEBOOK_PAGE_ACCESS_TOKEN | Long-lived Page Access Token | `EAA...` | Tùy chọn (bắt buộc cho FB publish) |
+
+## Object storage (Cloudflare R2)
+
+Khi `STORAGE_DRIVER=r2`, backend dùng S3-compatible API (`@aws-sdk/client-s3`) với endpoint `https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com`, `region: auto`, `forcePathStyle: true`. Object key trùng đường dẫn tương đối trong DB (`images/...`, `spinner/...`, v.v.).
+
+- **Bảo mật:** Tạo R2 API token tối thiểu quyền (read/write trên một bucket). Không bật public bucket list nếu không cần. Rotate key khi nghi ngờ lộ; cập nhật env trên mọi replica trước khi revoke key cũ.
+- **Presigned URL:** `getFileUrl` trả link có thời hạn; client nên refetch JSON khi ảnh hết hạn (TTL `MEDIA_URL_TTL_MS`).
+- **Proxy `/api/v1/media`:** Vẫn xác thực `d`/`s` rồi stream object từ R2 — hữu ích cho link đã lưu/cache; không đọc file từ `UPLOAD_DIR` ở chế độ R2.
 
 ## DATABASE_URL / DIRECT_URL Format
 

--- a/docs/plans/cloudflare-r2-upload-migration.md
+++ b/docs/plans/cloudflare-r2-upload-migration.md
@@ -201,4 +201,42 @@ Issue 1.
 
 ---
 
+## Cutover runbook
+
+**Mục tiêu:** Đưa object từ `UPLOAD_DIR` lên Cloudflare R2 **giữ nguyên key** (trùng `file_path` trong DB), rồi bật `STORAGE_DRIVER=r2`.
+
+**Prerequisites**
+
+- Bucket R2 + API token (S3-compatible); biến `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` trên môi trường đích.
+- Backup tree `UPLOAD_DIR` (hoặc snapshot disk) trước khi xoá local sau cutover.
+- Code đã gồm plans **17-01** (`R2StorageService` + driver), **17-02** (`MediaController` proxy R2), **17-03** (docs này).
+
+**Đồng bộ object (ví dụ rclone)**
+
+1. Cài [rclone](https://rclone.org/) và cấu hình remote R2 (S3 provider, endpoint `https://<R2_ACCOUNT_ID>.r2.cloudflarestorage.com`, `region` = `auto`, access key + secret).
+2. Sync một chiều từ local lên bucket (điều chỉnh đường dẫn local và tên remote/bucket):
+
+```bash
+# Ví dụ — KHÔNG chạy copy-paste: thay LOCAL_UPLOADS, r2remote, bucket
+rclone sync /path/to/LOCAL_UPLOADS r2remote:diecast360-media --progress
+```
+
+Đảm bảo **cấu trúc key** trong bucket là `images/...`, `spinner/...`, v.v. (không thêm prefix không có trong DB).
+
+**Sau sync**
+
+- Restart backend với `STORAGE_DRIVER=r2`.
+- Spot-check: vài `file_path` ngẫu nhiên từ DB mở được qua presigned URL hoặc `GET /api/v1/media?d=&s=`.
+- (Tuỳ chọn) So sánh số file local vs object count trên bucket (rclone `size` / dashboard R2).
+
+**Thứ tự feature flag**
+
+1. Sync dữ liệu → verify key.
+2. Bật `STORAGE_DRIVER=r2` trên staging → kiểm thử upload + đọc ảnh.
+3. Production: maintenance ngắn nếu cần → sync cuối → đổi env → restart.
+
+**Implementers:** Chi tiết code và hợp đồng API trong `.planning/phases/17-cloudflare-r2-upload-migrate-backend-media-from-local-disk-to-object-storage/17-01-PLAN.md`, `17-02-PLAN.md`, `17-03-PLAN.md`.
+
+---
+
 *Tài liệu kế hoạch; triển khai code theo các issue trên.*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
 
   backend:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1045.0
+        version: 3.1045.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1045.0
+        version: 3.1045.0
       '@nestjs/common':
         specifier: ^11.1.10
         version: 11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -271,6 +277,173 @@ packages:
   '@angular-devkit/schematics@19.2.24':
     resolution: {integrity: sha512-lnw+ZM1Io+cJAkReC0NPDjqObL8NtKzKIkdgEEKC8CUmkhurYhedbicN8Y8NYHgG1uLd2GozW3+/QqPRZaN+Lw==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1045.0':
+    resolution: {integrity: sha512-fsuO3Y6t+3Ro9Bsg41DKj4Sfy53CGSrhnMldNplWmG8Tx0UbYk+YDa4RD1hVlJpERw4JBmPkl0+J9qlxMh1pcA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.8':
+    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.7':
+    resolution: {integrity: sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    resolution: {integrity: sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    resolution: {integrity: sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.16':
+    resolution: {integrity: sha512-6ru8doI0/XzszqLIPXf0E/V7HhAw1Pu94010XCKYtBUfD0LxF0BuOzrUf8OQGR6j2o6wgKTHUniOmndQycHwCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    resolution: {integrity: sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    resolution: {integrity: sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1045.0':
+    resolution: {integrity: sha512-VDRF8GIuUPX+K4DUYrvcODj/h54LOmdJ7DhpLQ0wrYrdxzIiJEpi0n9jZ1bbjT2UxhwTbOorse5EGo+gnOK2aA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.10':
+    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1198,6 +1371,9 @@ packages:
       '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
       reflect-metadata: ^0.1.13 || ^0.2.0
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1429,6 +1605,218 @@ packages:
 
   '@sinonjs/fake-timers@15.3.2':
     resolution: {integrity: sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==}
+
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.15':
+    resolution: {integrity: sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.14':
+    resolution: {integrity: sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.14':
+    resolution: {integrity: sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.8':
+    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.3.0':
+    resolution: {integrity: sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2066,6 +2454,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
@@ -2661,6 +3052,13 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3563,6 +3961,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -4037,6 +4439,9 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
 
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
@@ -4518,6 +4923,10 @@ packages:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -4593,6 +5002,471 @@ snapshots:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1045.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.10
+      '@aws-sdk/middleware-expect-continue': 3.972.10
+      '@aws-sdk/middleware-flexible-checksums': 3.974.16
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-location-constraint': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/middleware-ssec': 3.972.10
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/eventstream-serde-config-resolver': 4.3.14
+      '@smithy/eventstream-serde-node': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-blob-browser': 4.2.15
+      '@smithy/hash-node': 4.2.14
+      '@smithy/hash-stream-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/md5-js': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.7':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.39':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.16':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/crc64-nvme': 3.972.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.8
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.6':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1045.0':
+    dependencies:
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-format-url': 3.972.10
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5542,6 +6416,8 @@ snapshots:
       '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5703,6 +6579,339 @@ snapshots:
   '@sinonjs/fake-timers@15.3.2':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    dependencies:
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.15':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.32':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.7':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.20':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.6.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.3.1':
+    dependencies:
+      '@smithy/types': 4.14.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.13':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.3.0':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -6472,6 +7681,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bowser@2.14.1: {}
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -7125,6 +8336,18 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fastq@1.20.1:
     dependencies:
@@ -8188,6 +9411,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -8676,6 +9901,8 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@2.3.0: {}
 
   strtok3@10.3.5:
     dependencies:
@@ -9184,6 +10411,8 @@ snapshots:
   ws@8.20.0: {}
 
   xml-name-validator@4.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Phase 17 (GSD execute-phase) — complete

This PR now includes **all three plans** for Cloudflare R2 media storage:

| Plan | Summary |
|------|---------|
| **17-01** | `R2StorageService`, `STORAGE_DRIVER`, presigned `getFileUrl`, async interface |
| **17-02** | `GET /api/v1/media` **proxies from R2** when `STORAGE_DRIVER=r2` (no `UPLOAD_DIR` read); shared `r2-s3.factory.ts` |
| **17-03** | `ENV.md` / `DEPLOYMENT.md` / Pi doc / cutover runbook + `backend/scripts/README.md` |

### Follow-up (PR review — Cursor automation)
- **moveFile:** `DeleteObject` on source retried up to 4× with exponential backoff (0ms delay under Jest); final failure logs `error` and rethrows so callers do not assume a clean move; warns on each retry.
- **deleteFile (R2):** no longer swallows all errors — real S3/network failures propagate (S3 delete is still idempotent for missing keys).
- **MEDIA_URL_TTL_MS:** `parseMediaUrlTtlMs` — non-finite or ≤0 falls back to 7d default (used by `R2StorageService` and `LocalStorageService.getFileUrl`).
- **MIME mapping:** shared `media-mime.util.ts` for `MediaController` + R2 `PutObject`/`CopyObject` content types.

### CI backend fix
- **`backend/package-lock.json` regenerated** with `npm install` so `npm ci` in `.github/workflows/ci.yml` and `deploy-backend.yml` stays in sync with `package.json` (AWS SDK deps were missing from the lockfile after pnpm-only updates).
- **`LocalStorageService`:** optional `catch` binding to clear `@typescript-eslint/no-unused-vars` warnings.

### Verification
- `npm ci` + `npm run lint` + `npm run build` + `npx jest --runInBand` in `backend/` (matches CI)
- `pnpm --filter ./backend test` (485 tests)

### Human follow-up (17-03 checkpoint)
- Staging smoke with real R2 bucket (recorded unchecked in `17-03-SUMMARY.md`).

### Planning
- `node .codex/get-shit-done/bin/gsd-tools.cjs phase complete 17` applied (ROADMAP + STATE).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-564074ec-84b6-4ad7-8983-85e13f681379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-564074ec-84b6-4ad7-8983-85e13f681379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

