### PR TITLE
Reduce React hooks ESLint bypasses; URL-driven item wizard step

### DIFF
--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef, type KeyboardEvent } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback, type KeyboardEvent } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient, uploadFile } from '../../api/client';
@@ -10,7 +10,12 @@ import type { CategoryItem, ApiResponse } from '../../types/category';
 import { showToast } from '../../utils/toast';
 import type { FacebookPost } from '../../types/item.types';
 import { jumpToStepWithAutoSave, navigateStepWithAutoSave, type ProductStep } from './itemStepNavigation';
-import { buildStepUrlAfterCreate, evaluateFinishDecision, shouldBlockEnterSubmit } from './itemWorkflow';
+import {
+  buildStepUrlAfterCreate,
+  evaluateFinishDecision,
+  parseProductStepFromSearchParams,
+  shouldBlockEnterSubmit,
+} from './itemWorkflow';
 import { MAX_SPINNER_FRAMES } from '../../constants/spinner';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { useOptionalActiveShopId } from '../../hooks/useOptionalActiveShopId';
@@ -359,8 +364,23 @@ export const ItemDetailPage = () => {
   const socialSellingRef = useRef<HTMLDivElement>(null);
   const stepNavInFlightRef = useRef(false);
   const imagePreviewUrlsRef = useRef<string[]>([]);
-  const [searchParams] = useSearchParams();
-  const [currentStep, setCurrentStep] = useState<ProductStep>(1);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlStep = useMemo(() => parseProductStepFromSearchParams(searchParams), [searchParams]);
+  /** Wizard step is driven by `?step=` so URL and UI stay aligned without effect-driven sync. */
+  const currentStep: ProductStep = urlStep ?? 1;
+  const setCurrentStep = useCallback(
+    (step: ProductStep) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('step', String(step));
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
   const isMobile = useIsMobile();
   const activeShopId = useOptionalActiveShopId();
 
@@ -474,16 +494,7 @@ export const ItemDetailPage = () => {
         socialSellingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
       }, 300);
     }
-  }, [searchParams, data]);
-
-  useEffect(() => {
-    const stepFromQuery = searchParams.get('step');
-    if (!stepFromQuery) return;
-    const parsed = Number(stepFromQuery);
-    if ([1, 2, 3, 4].includes(parsed)) {
-      queueMicrotask(() => setCurrentStep(parsed as ProductStep)); // defer to avoid sync setState in effect body
-    }
-  }, [searchParams]);
+  }, [searchParams, data, setCurrentStep]);
 
   const extractItemIdFromResponse = (response: unknown): string | null => {
     const isApiResponse = (r: unknown): r is ApiResponse<ItemResponse> => {

--- a/frontend/src/pages/admin/itemWorkflow.ts
+++ b/frontend/src/pages/admin/itemWorkflow.ts
@@ -4,6 +4,16 @@ export function buildStepUrlAfterCreate(itemId: string, step: ProductStep = 2): 
   return `/admin/items/${itemId}?step=${step}`;
 }
 
+/** Reads `?step=` for the admin item wizard (1–4). Invalid or missing → null (caller defaults to step 1). */
+export function parseProductStepFromSearchParams(searchParams: URLSearchParams): ProductStep | null {
+  const raw = searchParams.get('step');
+  if (raw === null || raw === '') return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return null;
+  if (n === 1 || n === 2 || n === 3 || n === 4) return n;
+  return null;
+}
+
 export function shouldBlockEnterSubmit(key: string, targetTagName?: string): boolean {
   if (key !== 'Enter') return false;
   if ((targetTagName || '').toLowerCase() === 'textarea') return false;

--- a/frontend/tests/e2e/fixtures/index.ts
+++ b/frontend/tests/e2e/fixtures/index.ts
@@ -120,13 +120,13 @@ type TestFixtures = {
 };
 
 export const test = base.extend<TestFixtures>({
-  authenticatedPage: async ({ page }, use) => {
+  // `use` is Playwright's fixture runner; name it to avoid tripping `react-hooks/rules-of-hooks` on `use*`.
+  authenticatedPage: async ({ page }, runFixture) => {
     await stubAuthCsrf(page);
     await page.route('**/api/v1/auth/me', (route: Route) =>
       route.fulfill({ json: authMePayload() }),
     );
-    // eslint-disable-next-line react-hooks/rules-of-hooks -- `use` is Playwright's fixture callback, not a React Hook
-    await use(page);
+    await runFixture(page);
   },
 });
 

--- a/frontend/tests/unit/ItemDetailPage.flow.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.flow.test.tsx
@@ -71,7 +71,20 @@ function createBaseItemData() {
 vi.mock('react-router-dom', () => ({
   useParams: () => h.params,
   useNavigate: () => h.mockNavigate,
-  useSearchParams: () => [new URLSearchParams(h.search)],
+  useSearchParams: () => {
+    const [params, setParams] = React.useState(() => new URLSearchParams(h.search));
+    const setSearchParams = React.useCallback(
+      (next: URLSearchParams | ((prev: URLSearchParams) => URLSearchParams)) => {
+        setParams((prev) => {
+          const resolved = typeof next === 'function' ? next(prev) : next;
+          h.search = resolved.toString();
+          return new URLSearchParams(resolved.toString());
+        });
+      },
+      [],
+    );
+    return [params, setSearchParams] as const;
+  },
 }));
 
 vi.mock('../../src/api/client', () => ({

--- a/frontend/tests/unit/ItemDetailPage.integration.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.integration.test.tsx
@@ -23,7 +23,20 @@ const h = vi.hoisted(() => ({
 vi.mock('react-router-dom', () => ({
   useParams: () => h.params,
   useNavigate: () => h.mockNavigate,
-  useSearchParams: () => [new URLSearchParams(h.search)],
+  useSearchParams: () => {
+    const [params, setParams] = React.useState(() => new URLSearchParams(h.search));
+    const setSearchParams = React.useCallback(
+      (next: URLSearchParams | ((prev: URLSearchParams) => URLSearchParams)) => {
+        setParams((prev) => {
+          const resolved = typeof next === 'function' ? next(prev) : next;
+          h.search = resolved.toString();
+          return new URLSearchParams(resolved.toString());
+        });
+      },
+      [],
+    );
+    return [params, setSearchParams] as const;
+  },
 }));
 
 vi.mock('../../src/api/client', () => ({
@@ -152,6 +165,25 @@ describe('ItemDetailPage integration (real React Query)', () => {
       expect(h.apiClient.post).toHaveBeenCalled();
       expect(h.mockNavigate).not.toHaveBeenCalled();
       expect(h.mockShowToast).toHaveBeenCalledWith('Không thể tạo sản phẩm. Vui lòng thử lại.');
+    });
+  });
+
+  it('writes ?step= to the URL when advancing the wizard via the stepper', async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect((screen.getAllByRole('textbox')[0] as HTMLInputElement).value).toBe('Ferrari F40');
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Hình ảnh/i })[0]);
+
+    await waitFor(() => {
+      expect(h.search).toContain('step=2');
     });
   });
 

--- a/frontend/tests/unit/itemWorkflow.test.ts
+++ b/frontend/tests/unit/itemWorkflow.test.ts
@@ -2,12 +2,21 @@ import { describe, expect, it } from 'vitest';
 import {
   buildStepUrlAfterCreate,
   evaluateFinishDecision,
+  parseProductStepFromSearchParams,
   shouldBlockEnterSubmit,
 } from '../../src/pages/admin/itemWorkflow';
 
 describe('itemWorkflow', () => {
   it('builds create->step2 url correctly', () => {
     expect(buildStepUrlAfterCreate('abc123')).toBe('/admin/items/abc123?step=2');
+  });
+
+  it('parses valid step query (1–4) and rejects invalid or missing', () => {
+    expect(parseProductStepFromSearchParams(new URLSearchParams('step=3'))).toBe(3);
+    expect(parseProductStepFromSearchParams(new URLSearchParams(''))).toBeNull();
+    expect(parseProductStepFromSearchParams(new URLSearchParams('step=0'))).toBeNull();
+    expect(parseProductStepFromSearchParams(new URLSearchParams('step=5'))).toBeNull();
+    expect(parseProductStepFromSearchParams(new URLSearchParams('step=banana'))).toBeNull();
   });
 
   it('allows finishing and returning to list when media is complete', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **ItemDetailPage:** The admin item wizard step is now derived from `?step=` (`parseProductStepFromSearchParams` in `itemWorkflow.ts`), and step changes update the query via `setSearchParams`. This removes the previous effect that mirrored the URL into local state (and avoids chained lint issues around `set-state-in-effect` / `exhaustive-deps` for that sync).
- **E2E fixtures:** Renamed Playwright’s fixture runner parameter from `use` to `runFixture` so `react-hooks/rules-of-hooks` does not false-positive; removed the last `eslint-disable` in the frontend tree (`grep eslint-disable frontend` → zero matches).
- **Tests:** Router mocks for ItemDetailPage tests now implement `setSearchParams` with React state. Added `parseProductStepFromSearchParams` unit tests, an integration test asserting `step=2` is written when opening step 2 via the stepper, and fixed the social-selling scroll effect’s exhaustive-deps by listing `setCurrentStep`.

## Audit notes (issue triage)
| Location | Disposition |
|----------|-------------|
| ItemDetailPage URL step sync | **Refactored:** URL is source of truth for step 1–4; no eslint bypass needed. |
| ItemDetailPage data hydrate / `id===new` microtasks | **Kept pattern:** Still uses `queueMicrotask` for heavy server→form hydration (avoids sync setState cascade in effects); no `eslint-disable` in repo. |
| ShopSettingsPage / ShopContext | **N/A in tree:** No `eslint-disable` present; Shop settings already use remount `key` pattern. |
| E2E `rules-of-hooks` | **Refactored:** Parameter rename removes false positive. |

## Verification
- `pnpm --filter ./frontend lint`
- `pnpm --filter ./frontend test:unit`
- `cd frontend && npx tsc -b --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1205b2d7-2add-458c-b7b3-d0bf6472fec5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1205b2d7-2add-458c-b7b3-d0bf6472fec5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

