### PR TITLE
Defense-in-depth: security headers, JWT bearer toggle, AI limits, observability

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,19 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,6 +33,10 @@ UPLOAD_DIR="./uploads"
 # Auth Settings
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"
 JWT_EXPIRES_IN="15m"
+# Web-only hardening: set to false to ignore Authorization: Bearer (cookie-only JWT).
+# JWT_ALLOW_AUTHORIZATION_BEARER=false
+# Emergency: disable HSTS while still in production (Helmet). Prefer fixing TLS instead.
+# SECURITY_HSTS_DISABLED=true
 COOKIE_SECRET="your-cookie-secret-change-this"
 # Optional: HMAC cho URL media (>=32 ký tự). Nếu bỏ trống sẽ dùng JWT_SECRET — nên tách để xoay JWT không làm hỏng link ảnh cũ.
 # MEDIA_SIGNING_SECRET="your-media-signing-secret-at-least-32-chars"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "class-validator": "^0.14.3",
         "cookie-parser": "^1.4.7",
         "dotenv": "^17.2.3",
+        "helmet": "^8.1.0",
         "ms": "^2.1.3",
         "multer": "^2.0.2",
         "openai": "^6.16.0",
@@ -8222,6 +8223,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/html-escaper": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,7 @@
     "class-validator": "^0.14.3",
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.2.3",
+    "helmet": "^8.1.0",
     "ms": "^2.1.3",
     "multer": "^2.0.2",
     "openai": "^6.16.0",

--- a/backend/src/ai/ai.controller.ts
+++ b/backend/src/ai/ai.controller.ts
@@ -16,7 +16,7 @@ export class AiController {
   constructor(private readonly aiService: AiService) {}
 
   @Post(':id/ai-description')
-  @Throttle({ default: { ttl: 60000, limit: 25 } })
+  @Throttle({ default: { ttl: 60000, limit: 20 } })
   async generateDescription(
     @Param('id') id: string,
     @Body() dto: GenerateAiDescriptionDto,
@@ -26,7 +26,7 @@ export class AiController {
   }
 
   @Post(':id/fb-post')
-  @Throttle({ default: { ttl: 60000, limit: 25 } })
+  @Throttle({ default: { ttl: 60000, limit: 20 } })
   async generateFbPost(
     @Param('id') id: string,
     @Body() dto: GenerateFbPostDto,

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
 import { Item } from '../generated/prisma/client';
@@ -11,6 +11,9 @@ import { AiDescriptionResponseDto } from './dto/ai-description.dto';
 @Injectable()
 export class AiService {
   private openai: OpenAI;
+  private readonly logger = new Logger(AiService.name);
+
+  private static readonly CUSTOM_INSTRUCTIONS_MAX = 2000;
 
   constructor(
     private prisma: PrismaService,
@@ -18,7 +21,7 @@ export class AiService {
   ) {
     const apiKey = this.configService.get<string>('OPENAI_API_KEY');
     if (!apiKey) {
-      console.warn('OPENAI_API_KEY not configured. AI features will not work.');
+      this.logger.warn('OPENAI_API_KEY not configured. AI features will not work.');
     }
     this.openai = new OpenAI({
       apiKey: apiKey || 'not-configured',
@@ -46,11 +49,13 @@ export class AiService {
     }
 
     // Build prompt
-    const prompt = this.buildPrompt(item, customInstructions);
+    const prompt = this.buildPrompt(item, this.clampCustomInstructions(customInstructions));
 
     try {
       const model = this.configService.get<string>('OPENAI_MODEL') || 'gpt-4o-mini';
-      
+      this.logger.log(
+        `ai.openai_call op=description shop_id=${tenantId} item_id=${itemId} model=${model}`,
+      );
       const completion = await this.openai.chat.completions.create({
         model,
         messages: [
@@ -87,7 +92,7 @@ Trả về JSON với format sau (KHÔNG có markdown code block):
       if (error instanceof AppException) {
         throw error;
       }
-      console.error('OpenAI API error:', error);
+      this.logger.error('OpenAI API error', error instanceof Error ? error.stack : String(error));
       throw this.mapProviderError(error, 'Failed to generate AI description');
     }
   }
@@ -113,11 +118,11 @@ Trả về JSON với format sau (KHÔNG có markdown code block):
     }
 
     // Build prompt for FB post
-    const prompt = this.buildFbPostPrompt(item, customInstructions);
+    const prompt = this.buildFbPostPrompt(item, this.clampCustomInstructions(customInstructions));
 
     try {
       const model = this.configService.get<string>('OPENAI_MODEL') || 'gpt-4o-mini';
-      
+      this.logger.log(`ai.openai_call op=fb_post shop_id=${tenantId} item_id=${itemId} model=${model}`);
       const completion = await this.openai.chat.completions.create({
         model,
         messages: [
@@ -154,7 +159,7 @@ Cấu trúc bài viết:
       if (error instanceof AppException) {
         throw error;
       }
-      console.error('OpenAI API error:', error);
+      this.logger.error('OpenAI API error', error instanceof Error ? error.stack : String(error));
       throw this.mapProviderError(error, 'Failed to generate Facebook post');
     }
   }
@@ -234,10 +239,18 @@ Cấu trúc bài viết:
   }
 
 
-  async analyzeImages(imageBuffers: Buffer[]): Promise<import('../items/dto/ai-draft.dto').AiAnalysisResult> {
+  async analyzeImages(
+    imageBuffers: Buffer[],
+    context?: { shop_id?: string; op?: string },
+  ): Promise<import('../items/dto/ai-draft.dto').AiAnalysisResult> {
     this.ensureApiKeyConfigured();
 
     const model = this.configService.get<string>('OPENAI_MODEL') || 'gpt-4o-mini';
+    if (context?.shop_id) {
+      this.logger.log(
+        `ai.openai_call op=${context.op ?? 'image_analyze'} shop_id=${context.shop_id} model=${model} images=${imageBuffers.length}`,
+      );
+    }
 
     const imageMessages = imageBuffers.map(buffer => ({
       type: 'image_url' as const,
@@ -298,9 +311,21 @@ Cấu trúc bài viết:
       if (error instanceof AppException) {
         throw error;
       }
-      console.error('OpenAI Vision Error:', error);
+      this.logger.error('OpenAI Vision Error', error instanceof Error ? error.stack : String(error));
       throw this.mapProviderError(error, 'Failed to analyze images');
     }
+  }
+
+  private clampCustomInstructions(raw?: string): string | undefined {
+    if (raw == null || typeof raw !== 'string') {
+      return undefined;
+    }
+    const t = raw.trim();
+    if (!t) return undefined;
+    if (t.length <= AiService.CUSTOM_INSTRUCTIONS_MAX) {
+      return t;
+    }
+    return t.slice(0, AiService.CUSTOM_INSTRUCTIONS_MAX);
   }
 
   private ensureApiKeyConfigured() {

--- a/backend/src/ai/dto/ai-description.dto.ts
+++ b/backend/src/ai/dto/ai-description.dto.ts
@@ -1,8 +1,9 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class GenerateAiDescriptionDto {
   @IsOptional()
   @IsString()
+  @MaxLength(2000, { message: 'custom_instructions must be at most 2000 characters' })
   custom_instructions?: string;
 }
 
@@ -17,6 +18,7 @@ export class AiDescriptionResponseDto {
 export class GenerateFbPostDto {
   @IsOptional()
   @IsString()
+  @MaxLength(2000, { message: 'custom_instructions must be at most 2000 characters' })
   custom_instructions?: string;
 }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import type { StringValue } from 'ms';
 import * as bcrypt from 'bcrypt';
@@ -12,6 +12,8 @@ import { SwitchShopDto } from './dto/switch-shop.dto';
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
   constructor(
     private prisma: PrismaService,
     private jwtService: JwtService,
@@ -23,11 +25,13 @@ export class AuthService {
     });
 
     if (!user || !user.is_active) {
+      this.logger.warn(`auth.login_failed reason=user_missing_or_inactive email=${loginDto.email}`);
       throw new AppException(ErrorCode.AUTH_INVALID_CREDENTIALS, 'Invalid credentials');
     }
 
     const isPasswordValid = await bcrypt.compare(loginDto.password, user.password_hash);
     if (!isPasswordValid) {
+      this.logger.warn(`auth.login_failed reason=bad_password email=${loginDto.email}`);
       throw new AppException(ErrorCode.AUTH_INVALID_CREDENTIALS, 'Invalid credentials');
     }
 

--- a/backend/src/auth/strategies/jwt-from-request.spec.ts
+++ b/backend/src/auth/strategies/jwt-from-request.spec.ts
@@ -1,0 +1,34 @@
+import { createAccessTokenExtractor } from './jwt-from-request';
+import type { Request } from 'express';
+
+function makeReq(partial: Partial<Request>): Request {
+  return partial as Request;
+}
+
+describe('createAccessTokenExtractor', () => {
+  it('prefers access_token cookie over Bearer when both present', () => {
+    const extract = createAccessTokenExtractor(true);
+    const token = extract(
+      makeReq({
+        cookies: { access_token: 'from-cookie' },
+        headers: { authorization: 'Bearer from-header' },
+      }),
+    );
+    expect(token).toBe('from-cookie');
+  });
+
+  it('reads Bearer when cookie missing and bearer allowed', () => {
+    const extract = createAccessTokenExtractor(true);
+    expect(extract(makeReq({ headers: { authorization: 'Bearer abc.def' } }))).toBe('abc.def');
+  });
+
+  it('returns null for Bearer when bearer disallowed', () => {
+    const extract = createAccessTokenExtractor(false);
+    expect(extract(makeReq({ headers: { authorization: 'Bearer abc.def' } }))).toBeNull();
+  });
+
+  it('returns null when no auth', () => {
+    const extract = createAccessTokenExtractor(true);
+    expect(extract(makeReq({}))).toBeNull();
+  });
+});

--- a/backend/src/auth/strategies/jwt-from-request.ts
+++ b/backend/src/auth/strategies/jwt-from-request.ts
@@ -1,0 +1,21 @@
+import { Request } from 'express';
+
+/**
+ * Reads access JWT from HttpOnly cookie first, then optionally Authorization: Bearer.
+ * Bearer can be disabled via env for web-only deployments (smaller XSS token theft surface).
+ */
+export function createAccessTokenExtractor(allowAuthorizationBearer: boolean) {
+  return (req: Request): string | null => {
+    if (req?.cookies && typeof req.cookies.access_token === 'string' && req.cookies.access_token.length > 0) {
+      return req.cookies.access_token;
+    }
+    if (!allowAuthorizationBearer) {
+      return null;
+    }
+    const authHeader = req?.headers?.authorization;
+    if (authHeader && typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+      return authHeader.substring(7);
+    }
+    return null;
+  };
+}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -3,26 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from '../auth.service';
-import { Request } from 'express';
-
-/**
- * Custom extractor function that reads JWT from HttpOnly cookie
- * Falls back to Authorization header for backward compatibility
- */
-const cookieExtractor = (req: Request): string | null => {
-  // First, try to get token from HttpOnly cookie (preferred for security)
-  if (req && req.cookies && req.cookies.access_token) {
-    return req.cookies.access_token;
-  }
-  
-  // Fallback: try to get from Authorization header (for API clients, mobile apps, etc.)
-  const authHeader = req?.headers?.authorization;
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    return authHeader.substring(7);
-  }
-  
-  return null;
-};
+import { createAccessTokenExtractor } from './jwt-from-request';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -34,8 +15,10 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!secret || secret.trim().length < 32) {
       throw new Error('JWT_SECRET must be set and at least 32 characters long');
     }
+    const allowBearer =
+      (configService.get<string>('JWT_ALLOW_AUTHORIZATION_BEARER') ?? 'true').trim().toLowerCase() !== 'false';
     super({
-      jwtFromRequest: cookieExtractor,
+      jwtFromRequest: createAccessTokenExtractor(allowBearer),
       ignoreExpiration: false,
       secretOrKey: secret,
     });

--- a/backend/src/common/exceptions/http-exception.filter.ts
+++ b/backend/src/common/exceptions/http-exception.filter.ts
@@ -107,6 +107,12 @@ export class AllExceptionsFilter implements ExceptionFilter {
       );
     }
 
+    if (status === 401 || status === 403) {
+      const code =
+        typeof errorResponse.error?.code === 'string' ? errorResponse.error.code : 'unknown';
+      this.logger.warn(`http.client_error status=${status} method=${request.method} path=${request.url} code=${code}`);
+    }
+
     response.status(status).json(errorResponse);
   }
 }

--- a/backend/src/common/exceptions/http-exception.filter.ts
+++ b/backend/src/common/exceptions/http-exception.filter.ts
@@ -110,7 +110,11 @@ export class AllExceptionsFilter implements ExceptionFilter {
     if (status === 401 || status === 403) {
       const code =
         typeof errorResponse.error?.code === 'string' ? errorResponse.error.code : 'unknown';
-      this.logger.warn(`http.client_error status=${status} method=${request.method} path=${request.url} code=${code}`);
+      if (code !== ErrorCode.AUTH_INVALID_CREDENTIALS) {
+        this.logger.warn(
+          `http.client_error status=${status} method=${request.method} path=${request.url} code=${code}`,
+        );
+      }
     }
 
     response.status(status).json(errorResponse);

--- a/backend/src/common/exceptions/http-exception.filter.ts
+++ b/backend/src/common/exceptions/http-exception.filter.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { Response } from 'express';
 import { ErrorCode, HTTP_STATUS_MAP } from '../constants/error-codes';
+import { pathWithoutQuery } from '../middleware/csrf.middleware';
 
 // Export ErrorCode để các module khác có thể import
 export { ErrorCode };
@@ -50,6 +51,9 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest();
+    const logPath = pathWithoutQuery(
+      typeof request.originalUrl === 'string' ? request.originalUrl : String(request.url ?? ''),
+    );
 
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let errorResponse: ErrorResponse = {
@@ -103,7 +107,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
       this.logger.error(
         `Unexpected error: ${exception instanceof Error ? exception.message : String(exception)}`,
         exception instanceof Error ? exception.stack : undefined,
-        `${request.method} ${request.url}`,
+        `${request.method} ${logPath}`,
       );
     }
 
@@ -112,7 +116,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         typeof errorResponse.error?.code === 'string' ? errorResponse.error.code : 'unknown';
       if (code !== ErrorCode.AUTH_INVALID_CREDENTIALS) {
         this.logger.warn(
-          `http.client_error status=${status} method=${request.method} path=${request.url} code=${code}`,
+          `http.client_error status=${status} method=${request.method} path=${logPath} code=${code}`,
         );
       }
     }

--- a/backend/src/common/middleware/csrf.middleware.ts
+++ b/backend/src/common/middleware/csrf.middleware.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
+import { Logger } from '@nestjs/common';
 
 const CSRF_COOKIE = 'csrf_token';
 const CSRF_HEADER = 'x-csrf-token';
@@ -51,6 +52,7 @@ export function isCsrfExemptRoute(fullUrl: string): boolean {
  * Raw binary endpoint GET /api/v1/media is also safe method — not listed here intentionally.
  */
 export function createCsrfMiddleware(): (req: Request, res: Response, next: NextFunction) => void {
+  const logger = new Logger('CsrfMiddleware');
   return (req: Request, res: Response, next: NextFunction) => {
     const method = (req.method || 'GET').toUpperCase();
     if (isSafeMethod(method)) {
@@ -70,6 +72,8 @@ export function createCsrfMiddleware(): (req: Request, res: Response, next: Next
     const cookie = req.cookies?.[CSRF_COOKIE] as string | undefined;
 
     if (!header || !cookie || header !== cookie) {
+      const pathOnly = pathWithoutQuery(fullPath);
+      logger.warn(`csrf.rejected method=${method} path=${pathOnly}`);
       res.status(403).json({
         ok: false,
         error: { code: 'CSRF_INVALID', details: [] },

--- a/backend/src/common/security/security-headers.spec.ts
+++ b/backend/src/common/security/security-headers.spec.ts
@@ -1,0 +1,41 @@
+import { buildHelmetOptions } from './security-headers';
+
+describe('buildHelmetOptions', () => {
+  it('disables HSTS outside production', () => {
+    const opts = buildHelmetOptions({
+      NODE_ENV: 'development',
+      COOKIE_SECURE: 'true',
+    });
+    expect(opts.hsts).toBe(false);
+  });
+
+  it('enables HSTS in production with secure cookies by default', () => {
+    const opts = buildHelmetOptions({
+      NODE_ENV: 'production',
+      COOKIE_SECURE: 'true',
+    });
+    expect(opts.hsts).toEqual(
+      expect.objectContaining({ maxAge: 31536000, includeSubDomains: true, preload: false }),
+    );
+  });
+
+  it('disables HSTS when SECURITY_HSTS_DISABLED=true', () => {
+    const opts = buildHelmetOptions({
+      NODE_ENV: 'production',
+      COOKIE_SECURE: 'true',
+      SECURITY_HSTS_DISABLED: 'true',
+    });
+    expect(opts.hsts).toBe(false);
+  });
+
+  it('sets API-oriented CSP', () => {
+    const opts = buildHelmetOptions({});
+    expect(opts.contentSecurityPolicy).toMatchObject({
+      useDefaults: false,
+      directives: {
+        defaultSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    });
+  });
+});

--- a/backend/src/common/security/security-headers.ts
+++ b/backend/src/common/security/security-headers.ts
@@ -1,0 +1,28 @@
+import { type HelmetOptions } from 'helmet';
+
+/**
+ * Helmet defaults tuned for JSON API + cookie auth (SPA calls API cross-origin).
+ * CSP/frame-ancestors reduce impact if a response is ever misinterpreted as HTML.
+ */
+export function buildHelmetOptions(env: NodeJS.ProcessEnv = process.env): HelmetOptions {
+  const isProd = (env.NODE_ENV || '').trim().toLowerCase() === 'production';
+  const cookieSecure = (env.COOKIE_SECURE || '').trim().toLowerCase() === 'true';
+  const hstsDisabled = (env.SECURITY_HSTS_DISABLED || '').trim().toLowerCase() === 'true';
+
+  return {
+    contentSecurityPolicy: {
+      useDefaults: false,
+      directives: {
+        defaultSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
+    crossOriginEmbedderPolicy: false,
+    crossOriginOpenerPolicy: { policy: 'same-origin' },
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+    hsts:
+      isProd && cookieSecure && !hstsDisabled
+        ? { maxAge: 31536000, includeSubDomains: true, preload: false }
+        : false,
+  };
+}

--- a/backend/src/items/ai-draft.controller.spec.ts
+++ b/backend/src/items/ai-draft.controller.spec.ts
@@ -65,7 +65,10 @@ describe('AiDraftController', () => {
   it('should create a draft after analyzing and saving images', async () => {
     const result = await controller.createDraft([buildFile('box.jpg'), buildFile('bottom.jpg')], 'shop-1');
 
-    expect(aiService.analyzeImages).toHaveBeenCalledWith([Buffer.from('box.jpg'), Buffer.from('bottom.jpg')]);
+    expect(aiService.analyzeImages).toHaveBeenCalledWith(
+      [Buffer.from('box.jpg'), Buffer.from('bottom.jpg')],
+      { shop_id: 'shop-1', op: 'image_draft_analyze' },
+    );
     expect(prisma.aiItemDraft.create).toHaveBeenCalledWith({
       data: {
         images_json: JSON.stringify([

--- a/backend/src/items/ai-draft.controller.ts
+++ b/backend/src/items/ai-draft.controller.ts
@@ -48,7 +48,10 @@ export class AiDraftController {
     }
 
     // 1. Analyze
-    const analysis = await this.aiService.analyzeImages(files.map(f => f.buffer));
+    const analysis = await this.aiService.analyzeImages(files.map(f => f.buffer), {
+      shop_id: tenantId,
+      op: 'image_draft_analyze',
+    });
 
     const savedPaths: string[] = [];
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,8 +6,10 @@ import { AllExceptionsFilter } from './common/exceptions/http-exception.filter';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 import * as sharp from 'sharp';
 import * as cookieParser from 'cookie-parser';
+import helmet from 'helmet';
 import { createCsrfMiddleware } from './common/middleware/csrf.middleware';
 import { validateRuntimeSecurityConfig } from './common/security/runtime-security';
+import { buildHelmetOptions } from './common/security/security-headers';
 
 /** Merge FRONTEND_URL + FRONTEND_URLS and add localhost ↔ 127.0.0.1 variants (same port). */
 function buildCorsAllowedOrigins(): string[] {
@@ -63,7 +65,9 @@ sharp.simd(false); // Disable SIMD to reduce memory footprint (slight performanc
 async function bootstrap() {
   validateRuntimeSecurityConfig();
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
-  
+
+  app.use(helmet(buildHelmetOptions()));
+
   // Cookie parser middleware - enables reading cookies from requests
   const cookieSecret = process.env.COOKIE_SECRET;
   if (!cookieSecret || cookieSecret.trim().length < 32) {

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -18,6 +18,7 @@ Diecast360 dùng PostgreSQL làm chuẩn cho runtime và Prisma CLI:
 | DATABASE_URL | Kết nối Database | Xem bên dưới | Bắt buộc |
 | DIRECT_URL | Kết nối trực tiếp DB cho Prisma CLI | Xem bên dưới | Bắt buộc với PostgreSQL + Prisma migrate/introspect |
 | JWT_SECRET | Secret ký access token | `super-secret` | Bắt buộc, đủ entropy |
+| JWT_ALLOW_AUTHORIZATION_BEARER | Cho phép đọc access JWT từ header `Authorization: Bearer` | `true` (mặc định) | Đặt `false` khi chỉ dùng web + cookie HttpOnly để thu hẹp kênh lộ token (XSS không đọc được cookie nhưng có thể đọc header nếu JS chèn được fetch tùy biến). |
 | JWT_EXPIRES_IN | TTL access token | `15m` | Chuỗi thời gian (ms, s, m, h...) |
 | REFRESH_TOKEN_EXPIRES_IN | TTL refresh token | `7d` | Dùng để tính `expires_at` |
 | UPLOAD_DIR | Thư mục lưu file local | `./uploads` | Khi `STORAGE_DRIVER=local` phải tồn tại/ghi được. Khi `STORAGE_DRIVER=r2`, thư mục không dùng cho đọc media (upload qua S3 API); vẫn có thể để mặc định cho dev. |
@@ -29,6 +30,7 @@ Diecast360 dùng PostgreSQL làm chuẩn cho runtime và Prisma CLI:
 | COOKIE_SECRET | Secret ký cookies | random 32+ chars | Bắt buộc, đổi trong production |
 | COOKIE_SECURE | Chỉ gửi cookies qua HTTPS | `false` (dev) / `true` (prod) | Bật khi deploy HTTPS |
 | COOKIE_SAME_SITE | SameSite attribute cho cookies | `lax` (dev) / `strict` hoặc `none` (prod) | Dùng **`none`** khi frontend và API **khác domain**; bắt buộc `COOKIE_SECURE=true` |
+| SECURITY_HSTS_DISABLED | Tắt header HSTS dù production + HTTPS cookie | `false` (mặc định) | Chỉ đặt `true` khi cần rollback khẩn cấp; HSTS được bật khi `NODE_ENV=production` và `COOKIE_SECURE=true`. Header bảo mật khác (CSP API, `X-Content-Type-Options`, frame) do Helmet trong `main.ts`. |
 | FRONTEND_URLS | Danh sách origin frontend bổ sung | `https://preview.example.com,https://admin.example.com` | Tùy chọn; tách bằng dấu phẩy. Backend tự thêm biến thể `localhost`/`127.0.0.1` cùng port từ `FRONTEND_URL`. |
 | CORS_ALLOW_LAN | Cho phép origin LAN private trong dev | `true` (dev LAN) / `false` (prod) | Chỉ dùng khi test UI qua Vite `--host`; production boot sẽ reject nếu `true`. |
 | MEDIA_SIGNING_SECRET | Secret ký URL media | random 32+ chars | Tùy chọn nhưng khuyến nghị; nếu bỏ trống dùng `JWT_SECRET`, làm xoay JWT có thể vô hiệu link ảnh cũ. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Plan assessment

The checklist is directionally correct for this codebase:

- **Headers:** The API had no Helmet; CSRF and cookies were already in place. Adding Helmet closes the gap for HSTS (when HTTPS cookies are enforced), `X-Content-Type-Options`, framing/CSP suitable for a JSON API, and related hardening.
- **JWT Bearer:** `jwt.strategy.ts` already preferred the HttpOnly cookie and fell back to `Authorization: Bearer`. Making Bearer **configurable** matches the “web + cookie only” posture without breaking scripts/API clients that still rely on Bearer (default remains allowed).
- **AI:** Throttling existed per route; this adds **length limits** on `custom_instructions`, slightly tighter per-minute limits, structured **logs** (shop + operation + model) for cost/abuse monitoring, and passes shop context into vision draft analysis logging.
- **Edge WAF / backup / DR / token policy:** These remain **operational or platform** concerns outside this PR; CI already runs `npm audit` with high severity.
- **Dependabot:** Only `devcontainers` was configured; npm manifests for `backend/` and `frontend/` are now included on a weekly schedule.

## What changed

- `helmet` + `buildHelmetOptions()` wired in `main.ts` (CSP for API JSON responses, CORP for cross-origin SPA fetches, COOP, HSTS when `NODE_ENV=production` and `COOKIE_SECURE=true`, opt-out `SECURITY_HSTS_DISABLED`).
- `JWT_ALLOW_AUTHORIZATION_BEARER` (default `true`): set to `false` for cookie-only token transport; extracted logic in `jwt-from-request.ts` with unit tests.
- AI: `@MaxLength(2000)` on DTOs, service-side clamp, `Logger` usage, `ai.openai_call` log lines, `analyzeImages` optional context for shop-scoped vision logging.
- Observability: failed login warnings (email only, never password), CSRF rejection warnings, `AllExceptionsFilter` warns on HTTP 401/403 with error code except `AUTH_INVALID_CREDENTIALS` (already covered by `AuthService` to avoid duplicate lines). **Follow-up:** client-error and unexpected-error logs use **path without query string** (per review) via `pathWithoutQuery`.
- Dependabot npm entries for `/backend` and `/frontend`.
- Documented new env vars in `docs/ENV.md` and `backend/.env.example`.

## Verification

- `npm run lint`, `npm run build`, and `npx jest --runInBand` in `backend/` all pass on this branch.

## Review response

- Addressed Cursor risk review note on logging `request.url` (query may be sensitive): `AllExceptionsFilter` now logs `pathWithoutQuery(originalUrl)`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ecf3b6b-17ca-469e-b78d-9499b8872b4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ecf3b6b-17ca-469e-b78d-9499b8872b4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

