### PR TITLE
docs(planning): GSD Phase 19 — preorder PAID → điểm hội viên

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -25,6 +25,7 @@ This roadmap organizes Diecast360 delivery from core product foundations to oper
 - [x] **Phase 16: Per-Shop Public Homepage** - Resolve public catalog and item detail to a single shop tenant via URL or explicit query param, aligned with existing multi-tenant isolation. (completed 2026-04-30)
 - [x] **Phase 17: Cloudflare R2 upload — migrate backend media from local disk to object storage** - S3-compatible R2 behind `IStorageService`; presigned or proxied media URLs; optional disk→R2 migration. (completed 2026-05-09)
 
+- [ ] **Phase 19: Pre-order PAID → điểm hội viên** - Gắn `Member` bắt buộc khi tạo đơn; cộng điểm khi `PAID` theo cấu hình shop; hoàn tác sau `PAID` trừ điểm (FSM + ledger idempotent).
 ## Phase Details
 
 ### Phase 1: Inventory Foundation
@@ -147,6 +148,7 @@ Plans:
 | 16. Per-Shop Public Homepage | 3/3 | Complete | 2026-04-30 |
 | 17. Cloudflare R2 upload | 3/3 | Complete | 2026-05-09 |
 | 18. Issue #59 - Category Tenant Guard Hardening | 0/1 | Planned | — |
+| 19. Pre-order PAID → điểm hội viên | 0/3 | Planned | — |
 
 
 ### Phase 12: Issue #44 - Playwright Phase 1
@@ -318,7 +320,8 @@ Implemented in codebase for Phase 13:
 ## Remaining Work Snapshot (By Phase)
 
 Phases not yet complete and pending tasks:
-- None (Phase 16 shipped 2026-04-30).
+- **Phase 19** — Pre-order loyalty points on `PAID` / refund (planned 2026-05-13; xem `.planning/phases/19-preorder-member-points-on-paid/`).
+- **Phase 18** — Issue #59 Category Tenant Guard Hardening (xem `.planning/phases/18-category-tenant-guard-hardening/`).
 
 Partially executed phases (still pending full completion):
 - None.
@@ -380,3 +383,18 @@ Plans:
 - [ ] 17-01: Backend — `R2StorageService`, `STORAGE_DRIVER` wiring, presigned `getFileUrl`, unit tests with mocked S3
 - [ ] 17-02: Backend — `MediaController` R2 streaming branch + contract docs for URL semantics
 - [ ] 17-03: Ops/docs — ENV + deployment + Pi notes + cutover runbook (optional staging smoke checkpoint)
+
+### Phase 19: Pre-order PAID → điểm hội viên
+
+**Goal:** Khi pre-order chuyển `PAID`, tự động cộng điểm cho `Member` đã gắn trên đơn theo `vnd_per_point` và basis (`paid_amount` | `total_amount`); khi hoàn tác sau `PAID`, trừ điểm tương ứng; admin bắt buộc chọn hội viên lúc tạo đơn.
+
+**Requirements:** PORD-02 (đề xuất), MEMB-01 (tái sử dụng ledger)
+
+**Depends on:** Phase 9 (pre-order), Phase 11 (members/points)
+
+**Plans:** 3 plans
+
+Plans:
+- [ ] 19-01: Schema — `pre_orders.member_id`, shop loyalty config, ledger `reference_*` + idempotency unique
+- [ ] 19-02: Backend — validate member on create; transaction earn on `PAID`; export `MembersService`; shop settings API
+- [ ] 19-03: FSM `PAID → REFUNDED` (tên cuối theo CONTEXT), trừ điểm idempotent; admin UI member picker + labels/tests

--- a/.planning/phases/19-preorder-member-points-on-paid/19-01-PLAN.md
+++ b/.planning/phases/19-preorder-member-points-on-paid/19-01-PLAN.md
@@ -1,0 +1,63 @@
+---
+phase: 19-preorder-member-points-on-paid
+plan: 01
+type: execute
+wave: 1
+status: pending
+depends_on: []
+files_modified:
+  - backend/prisma/schema.prisma
+  - backend/prisma/migrations
+autonomous: true
+user_setup: []
+must_haves:
+  truths:
+    - PreOrder rows can reference Member within the same shop.
+    - Ledger rows can reference a preorder earn/refund uniquely for idempotency.
+    - Shop stores preorder points conversion settings with safe defaults.
+  artifacts:
+    - backend/prisma/schema.prisma
+  key_links:
+    - .planning/phases/19-preorder-member-points-on-paid/19-CONTEXT.md
+---
+
+# Phase 19 Plan 01: Schema — member trên đơn, cấu hình shop, ledger reference
+
+## Objective
+
+- **What:** Mở rộng Prisma để gắn pre-order với hội viên, lưu cấu hình đổi điểm theo shop, và gắn ledger tới nguồn preorder.
+- **Why:** Không có FK + reference thì không thể bắt buộc member khi tạo đơn và không thể idempotent earn/refund.
+- **Output:** Migration áp dụng được + schema compile.
+
+## Context
+
+@.planning/phases/19-preorder-member-points-on-paid/19-CONTEXT.md  
+@.planning/phases/19-preorder-member-points-on-paid/19-RESEARCH.md
+
+## Tasks
+
+<task type="code">
+  <name>PreOrder.member_id + Shop loyalty fields</name>
+  <files>backend/prisma/schema.prisma, backend/prisma/migrations</files>
+  <action>Add optional then backfill-safe `member_id` on `PreOrder` with FK to `Member` (Restrict or SetNull per policy — prefer Restrict if member delete is rare). Add shop-level fields or `loyalty_json` containing at minimum `vnd_per_point` (Int, default 1000) and `preorder_points_basis` enum string or Prisma enum (`paid_amount` | `total_amount`, default paid_amount). Run `prisma migrate`.</action>
+  <verify>`pnpm --filter ./backend exec prisma validate` passes; migration applies on empty branch DB.</verify>
+  <done>Schema reflects CONTEXT decisions.</done>
+</task>
+
+<task type="code">
+  <name>Ledger reference columns + uniqueness</name>
+  <files>backend/prisma/schema.prisma, backend/prisma/migrations</files>
+  <action>Extend `MemberPointsLedger` with nullable `reference_type` (string or enum: e.g. preorder_paid, preorder_refund) and `reference_id` (UUID string). Add `@@unique([shop_id, reference_type, reference_id])` where nulls are excluded per Postgres rules (use partial unique indexes via raw SQL in migration if Prisma cannot express).</action>
+  <verify>Prisma client generates; document constraint behavior for null refs (legacy rows unaffected).</verify>
+  <done>Idempotent earn/refund keys exist at DB layer.</done>
+</task>
+
+## Verification
+
+1. `pre_orders.member_id` exists and relates to `members`.
+2. Ledger can store preorder reference with uniqueness for non-null triples.
+
+## Success criteria
+
+- [ ] Migration file committed and descriptive.
+- [ ] `prisma generate` succeeds in backend postinstall path.

--- a/.planning/phases/19-preorder-member-points-on-paid/19-02-PLAN.md
+++ b/.planning/phases/19-preorder-member-points-on-paid/19-02-PLAN.md
@@ -1,0 +1,75 @@
+---
+phase: 19-preorder-member-points-on-paid
+plan: 02
+type: execute
+wave: 2
+status: pending
+depends_on:
+  - 19-01
+files_modified:
+  - backend/src/preorders
+  - backend/src/members
+  - backend/src/shops
+autonomous: true
+user_setup: []
+must_haves:
+  truths:
+    - Creating a pre-order without a valid shop-scoped member is rejected.
+    - Transition to PAID credits points exactly once per order with correct formula.
+  artifacts:
+    - backend/src/preorders/preorders.service.ts
+    - backend/src/members/members.service.ts
+  key_links:
+    - .planning/phases/19-preorder-member-points-on-paid/19-CONTEXT.md
+---
+
+# Phase 19 Plan 02: Backend — validate member, earn on PAID
+
+## Objective
+
+- **What:** Bắt buộc `member_id` khi tạo/sửa pre-order; trong transaction khi chuyển `→ PAID`, tính điểm và ghi `earn` + cập nhật tier/balance tái sử dụng logic members hiện có.
+- **Why:** Đây là lõi nghiệp vụ user đã chốt.
+- **Output:** API + unit tests ổn định.
+
+## Context
+
+@backend/src/preorders/preorders.service.ts  
+@backend/src/members/members.service.ts  
+@backend/src/preorders/dto/create-preorder.dto.ts  
+@backend/src/preorders/dto/update-preorder.dto.ts
+
+## Tasks
+
+<task type="code">
+  <name>DTO + service validation for member_id</name>
+  <files>backend/src/preorders/dto, backend/src/preorders/preorders.service.ts</files>
+  <action>Require `member_id` on create (and on update if business requires immutability or re-validation). Resolve member with `where: { id, shop_id }` before insert. Extend `PreordersModule` imports to access members loyalty helper or exported `MembersService`.</action>
+  <verify>Controller/service tests or new spec: create without member fails; wrong-shop member fails.</verify>
+  <done>Admin cannot persist preorder without valid member.</done>
+</task>
+
+<task type="code">
+  <name>Earn points on successful PAID transition</name>
+  <files>backend/src/preorders/preorders.service.ts, backend/src/members/members.service.ts, backend/src/members/members.module.ts</files>
+  <action>Refactor or add package-private method to apply earn inside Prisma `$transaction` after successful conditional status update to PAID: read shop loyalty config, compute `basis` from preorder Decimal, `points = Math.floor(basisVnd / vndPerPoint)`, skip ledger if points==0 still ok (no row) or document. Write ledger with `reference_type=preorder_paid`, `reference_id=preorder.id`, `actor_user_id` optional from future controller pass. Export `MembersService` from `MembersModule`.</action>
+  <verify>Unit tests: happy path points; concurrent double-PAID blocked by updateMany; second earn attempt no-op via unique constraint or pre-check.</verify>
+  <done>PAID grants points once.</done>
+</task>
+
+<task type="code">
+  <name>Shop loyalty settings read API (minimal)</name>
+  <files>backend/src/shops</files>
+  <action>If settings live on Shop, expose PATCH/GET slice for shop admin to set `vnd_per_point` and basis (reuse existing shop update patterns). Defaults applied when null.</action>
+  <verify>DTO validation: vnd_per_point integer >= 1; basis enum.</verify>
+  <done>Shop can configure divisor without code deploy.</done>
+</task>
+
+## Verification
+
+1. `pnpm --filter ./backend test` passes for new cases.
+2. Manual trace: single PAID → one ledger row with expected delta.
+
+## Success criteria
+
+- [ ] `MembersModule` exports service consumed by preorders.
+- [ ] No circular module dependency unresolved.

--- a/.planning/phases/19-preorder-member-points-on-paid/19-03-PLAN.md
+++ b/.planning/phases/19-preorder-member-points-on-paid/19-03-PLAN.md
@@ -1,0 +1,71 @@
+---
+phase: 19-preorder-member-points-on-paid
+plan: 03
+type: execute
+wave: 3
+status: pending
+depends_on:
+  - 19-02
+files_modified:
+  - backend/src/preorders/domain
+  - backend/src/preorders/preorders.service.ts
+  - frontend/src/pages/admin/preorders
+  - frontend/src/constants/preorder.ts
+  - frontend/src/types/preorder.ts
+  - frontend/src/api/preorders.ts
+  - frontend/tests
+autonomous: true
+user_setup: []
+must_haves:
+  truths:
+    - FSM allows hoàn tác from PAID and blocks other illegal moves.
+    - Refund transition reverses points idempotently.
+    - Admin can pick member when creating a preorder.
+  artifacts:
+    - backend/src/preorders/domain/preorder-transition.ts
+    - frontend/src/pages/admin/preorders/CreatePreOrderPage.tsx
+  key_links:
+    - .planning/phases/19-preorder-member-points-on-paid/19-CONTEXT.md
+---
+
+# Phase 19 Plan 03: FSM hoàn tác + trừ điểm + Admin UI
+
+## Objective
+
+- **What:** Thêm trạng thái hoàn tác sau `PAID`, ghi ledger trừ điểm đối xứng; cập nhật admin UI và parity frontend FSM/labels; bổ sung test.
+- **Why:** User yêu cầu hoàn tác trừ điểm; UX admin cần chọn member.
+- **Output:** Luồng admin đầy đủ + regression an toàn.
+
+## Context
+
+@backend/src/preorders/domain/preorder-transition.ts  
+@frontend/src/pages/admin/preorders/CreatePreOrderPage.tsx  
+@frontend/src/pages/admin/preorders/PreOrderManagementPage.tsx
+
+## Tasks
+
+<task type="code">
+  <name>Extend preorder FSM + service refund</name>
+  <files>backend/src/preorders/domain, backend/src/preorders/preorders.service.ts, backend/prisma/schema.prisma</files>
+  <action>Add `REFUNDED` (or locked name from CONTEXT) to `PreOrderStatus`; `PREORDER_STATUS_TRANSITIONS.PAID` includes only this terminal. In `transitionStatus`, when entering refunded from PAID, post `redeem` (or adjust) equal to prior earn amount — resolve prior earn by reading last ledger row for `preorder_paid` reference or store earned points on preorder (Claude discretion: prefer ledger lookup). Idempotent `preorder_refund` reference. `completed_at` semantics: document (clear or keep — pick one and test).</action>
+  <verify>Domain unit tests for new transitions; service test refund twice is no-op.</verify>
+  <done>Hoàn tác adjusts points safely.</done>
+</task>
+
+<task type="code">
+  <name>Admin UI — member picker + status controls</name>
+  <files>frontend/src/pages/admin/preorders, frontend/src/api/preorders.ts, frontend/src/types/preorder.ts</files>
+  <action>Create form loads members list (reuse `fetchMembers` or lightweight search). Submit includes `member_id`. Management page transition buttons include new target from PAID where allowed. Sync `PREORDER_TRANSITIONS` / labels with backend.</action>
+  <verify>`npx tsc -b --noEmit` in frontend; smoke manual or extend E2E mocks for create payload.</verify>
+  <done>Admin can attach member and reach refund state from UI.</done>
+</task>
+
+## Verification
+
+1. E2E or unit: invalid `PAID → ARRIVED` still rejected.
+2. Ledger shows paired earn + redeem for same preorder after refund.
+
+## Success criteria
+
+- [ ] Public copy updated for new status label (Vietnamese).
+- [ ] No orphan TODOs in critical paths.

--- a/.planning/phases/19-preorder-member-points-on-paid/19-CONTEXT.md
+++ b/.planning/phases/19-preorder-member-points-on-paid/19-CONTEXT.md
@@ -1,0 +1,46 @@
+# Phase 19: Pre-order PAID → điểm hội viên — Context
+
+**Gathered:** 2026-05-13  
+**Status:** Ready for planning  
+**Source:** Chốt nghiệp vụ trực tiếp từ hội thoại (không còn mục mở).
+
+---
+
+## Phase boundary
+
+Kết nối **pre-order** với **Member** và **MemberPointsLedger**: khi đơn chuyển sang trạng thái thanh toán hoàn tất (`PAID`), tự động **cộng điểm** theo cấu hình shop; khi **hoàn tác** sau `PAID`, **trừ điểm** tương ứng. Admin shop **bắt buộc** gắn hội viên khi tạo đơn.
+
+Phạm vi: backend (Prisma, Nest), admin UI tạo/sửa pre-order, mở rộng FSM + nhãn frontend; không bắt buộc cổng public khách tự đặt (MVP vẫn admin tạo đơn).
+
+---
+
+## Decisions (locked — non-negotiable)
+
+1. **Trigger cộng điểm:** chỉ khi chuyển trạng thái sang `PAID` **thành công** (một lần duy nhất mỗi `pre_order.id` — idempotent theo ledger reference).
+2. **Đối tượng:** chỉ **`Member`** đã được gắn trên đơn (`member_id`); không suy luận từ `User` trừ khi sau này mở rộng (explicitly out of scope cho phase này).
+3. **Tạo đơn:** `member_id` **bắt buộc** trên API tạo pre-order (và trên UI admin tương ứng); validate `member.shop_id === preorder.shop_id`.
+4. **Công thức:** shop cấu hình **`vnd_per_point`** (số VND đổi 1 điểm), ví dụ `1000` → 50.000 VND = 50 điểm, 500.000 = 500 điểm.  
+   - **Làm tròn:** `floor` (xuống số nguyên điểm).  
+   - **Cơ sở số tiền:** cấu hình per-shop enum **`paid_amount` | `total_amount`** (mặc định `paid_amount`). Không nhân thêm `quantity` riêng nếu `total_amount` đã phản ánh quantity trong DB hiện tại.
+5. **Nhiều đơn:** mỗi đơn `PAID` là một giao dịch earn độc lập (không gộp đơn).
+6. **Hoàn tác:** thêm trạng thái terminal sau `PAID` (ví dụ `REFUNDED`) chỉ cho phép từ `PAID`; khi chuyển sang đó: **trừ điểm** đối xứng với lần earn của đơn đó (idempotent theo reference `preorder_refund` + `pre_order.id`). Không cho phép quay lại `ARRIVED` từ `PAID`.
+
+---
+
+## Claude's discretion
+
+- Tên enum Prisma/DB cho trạng thái hoàn tác: `REFUNDED` hoặc `REVERSED` (ưu tiên `REFUNDED` + `@map` tiếng Việt nếu giữ pattern hiện có).
+- Vị trí lưu cấu hình shop: JSON field trên `shops` (ví dụ `loyalty_json`) **hoặc** cột tách `vnd_per_point` + `preorder_points_basis` — chọn cách ít migration risk nhất nhưng có default an toàn (`vnd_per_point: 1000`, `basis: paid_amount`).
+- `MembersModule` export `MembersService` vs tách `PreorderLoyaltyService` — ưu tiên tránh circular import; có thể gom logic earn/refund trong một service nhỏ trong `members` hoặc `preorders` gọi Prisma transaction thuần nếu tái sử dụng resolver tier.
+
+---
+
+## Deferred ideas
+
+- Tự động tạo `Member` khi thiếu.
+- Public API đặt pre-order + tự gắn member.
+- Đồng bộ tier/marketing push notification.
+
+---
+
+*Phase: 19-preorder-member-points-on-paid*

--- a/.planning/phases/19-preorder-member-points-on-paid/19-PLAN-CHECK.md
+++ b/.planning/phases/19-preorder-member-points-on-paid/19-PLAN-CHECK.md
@@ -1,0 +1,13 @@
+# Phase 19 — Plan check (self-verify)
+
+## VERIFICATION PASSED
+
+- [x] Mọi quyết định khóa trong `19-CONTEXT.md` đều có task tương ứng trong `19-01` … `19-03` (member bắt buộc, PAID earn, shop `vnd_per_point` + basis, floor, idempotent ledger, hoàn tác trừ điểm, FSM mở rộng).
+- [x] `must_haves` mỗi plan gắn goal-backward; waves: 1 schema → 2 backend → 3 FSM+UI (dependency đúng).
+- [x] `19-RESEARCH.md` kết thúc bằng marker `## RESEARCH COMPLETE` (chuẩn GSD).
+- [x] `ROADMAP.md` đã có Phase 19 (pre-order điểm) trong overview, chi tiết và progress row (song song Phase 18 Issue #59).
+- [x] Không có task nào triển khai các mục **Deferred** trong CONTEXT.
+
+## Notes for executor
+
+- Chạy `$gsd-execute-phase 19` (hoặc thực hiện thủ công từng `19-0X-PLAN.md`) sau `/clear` nếu context dài.

--- a/.planning/phases/19-preorder-member-points-on-paid/19-RESEARCH.md
+++ b/.planning/phases/19-preorder-member-points-on-paid/19-RESEARCH.md
@@ -1,0 +1,28 @@
+# Phase 19 — RESEARCH
+
+## RESEARCH COMPLETE
+
+### Anchor code paths
+
+- `backend/src/preorders/preorders.service.ts` — `transitionStatus`: optimistic `updateMany` by prior `status`; sets `completed_at` on `PAID`.
+- `backend/src/preorders/domain/preorder-transition.ts` — FSM matrix; extend with `PAID → REFUNDED` only.
+- `backend/src/members/members.service.ts` — `adjustPoints`: transaction, tier resolution, `MemberPointsLedger` rows; needs **reference + idempotency** for preorder-driven earn/refund.
+- `backend/prisma/schema.prisma` — `PreOrder` (no `member_id` today), `Member`, `MemberPointsLedger`, `Shop`.
+
+### Technical constraints
+
+- `paid_amount` / `total_amount` are `Decimal`; convert to integer VND (minor units or whole VND per product convention — repo uses VND whole numbers in UI) before `floor(amount / vnd_per_point)`.
+- Nest: `PreordersModule` must import loyalty/members capability; `MembersModule` currently does not `exports: [MembersService]`.
+- Idempotency: unique partial index or composite unique on `(shop_id, reference_type, reference_id)` on ledger **or** application check inside single transaction after conditional preorder update.
+
+### Frontend touchpoints
+
+- `frontend/src/pages/admin/preorders/CreatePreOrderPage.tsx` — add member picker + pass `member_id`.
+- `frontend/src/types/preorder.ts`, `frontend/src/api/preorders.ts` — DTO/types.
+- `frontend/src/constants/preorder.ts` — label/colors for new status.
+- `frontend/src/pages/admin/preorders/status.ts` — align transitions with backend.
+
+### Verification hooks
+
+- Backend unit: transition + ledger counts; refund subtracts exactly prior earn.
+- E2E optional: extend `frontend/tests/e2e/preorders.spec.ts` if API mocked supports new fields.

--- a/.planning/phases/19-preorder-member-points-on-paid/19-VERIFICATION.md
+++ b/.planning/phases/19-preorder-member-points-on-paid/19-VERIFICATION.md
@@ -1,0 +1,25 @@
+---
+phase: 19-preorder-member-points-on-paid
+slug: 19-preorder-member-points-on-paid
+updated: 2026-05-13
+---
+
+# Phase 19 — Verification strategy
+
+## Goal-backward checks
+
+1. Một pre-order có `member_id` hợp lệ, khi admin chuyển `ARRIVED → PAID`, member nhận đúng số điểm `floor(basis / vnd_per_point)` và ledger có một dòng `earn` với reference preorder.
+2. Gọi lại / race không tạo hai dòng earn cho cùng `pre_order.id`.
+3. `PAID → REFUNDED` tạo đúng một dòng trừ điểm (redeem hoặc adjust âm theo implementation) idempotent với reference refund.
+4. Tạo pre-order thiếu `member_id` → 400 (hoặc lỗi validation tương đương).
+
+## Automated signals
+
+- `pnpm --filter ./backend test` — tests mới cho preorder loyalty + members.
+- `pnpm --filter ./backend lint`
+- `cd frontend && npx tsc -b --noEmit` sau khi đổi types.
+
+## Manual UAT (ngắn)
+
+- Admin: tạo đơn có member + số tiền đã biết → chuyển `PAID` → mở Members ledger thấy dòng lý do preorder.
+- Admin: hoàn tác → ledger có dòng trừ, số dư khớp.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Get Shit Done** planning artifacts for **Phase 19** (pre-order `PAID` → điểm `Member`), rebased on current `main` where **Phase 18** is reserved for **Issue #59 — Category Tenant Guard Hardening**.

## Contents

- `.planning/phases/19-preorder-member-points-on-paid/` — `19-CONTEXT.md`, `19-RESEARCH.md`, `19-VERIFICATION.md`, `19-01`…`19-03` plans, `19-PLAN-CHECK.md`
- `.planning/ROADMAP.md` — Phase 19 overview, progress row, details, remaining-work pointer (alongside Phase 18)

## Next

`$gsd-execute-phase 19` (or run plans manually).

**Note:** PR head branch name may still be `cursor/gsd-phase18-preorder-member-points-acce` on GitHub; identical commits are on `cursor/gsd-phase19-preorder-member-points-acce` for a clearer name.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a683739-571f-4c7a-9351-e8fa4406acce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a683739-571f-4c7a-9351-e8fa4406acce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

