### PR TITLE
Phase 18: Harden tenant RolesGuard for inactive shops (Issue #59)

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -21,7 +21,7 @@ This roadmap organizes Diecast360 delivery from core product foundations to oper
 - [x] **Phase 13: Issue #33 - Playwright Phase 2** - Extended E2E coverage and quality-gate hardening. *(2026-04-29)*
 - [x] **Phase 14: Multi-Tenant Shop** - Support multiple isolated diecast shops on a single deployment with scoped access.
 - [x] **Phase 15: Admin RBAC & Tenant Authorization** - Separate platform operator permissions from per-shop roles; extend shop roles (e.g. read-only staff) and align API + admin UI.
-- [ ] **Phase 18: Issue #59 - Category Tenant Guard Hardening** - Close inactive-shop authorization lifecycle gap on category mutate routes.
+- [x] **Phase 18: Issue #59 - Category Tenant Guard Hardening** - Close inactive-shop authorization lifecycle gap on category mutate routes. *(2026-05-16)*
 - [x] **Phase 16: Per-Shop Public Homepage** - Resolve public catalog and item detail to a single shop tenant via URL or explicit query param, aligned with existing multi-tenant isolation. (completed 2026-04-30)
 - [x] **Phase 17: Cloudflare R2 upload — migrate backend media from local disk to object storage** - S3-compatible R2 behind `IStorageService`; presigned or proxied media URLs; optional disk→R2 migration. (completed 2026-05-09)
 
@@ -141,13 +141,13 @@ Plans:
 **Plans**: 1 plan
 
 Plans:
-- [ ] 18-01: Harden category mutate tenant authorization
+- [x] 18-01: Harden category mutate tenant authorization
 
 
 | 15. Admin RBAC & Tenant Authorization | 3/3 | Complete | 2026-04-29 |
 | 16. Per-Shop Public Homepage | 3/3 | Complete | 2026-04-30 |
 | 17. Cloudflare R2 upload | 3/3 | Complete | 2026-05-09 |
-| 18. Issue #59 - Category Tenant Guard Hardening | 0/1 | Planned | — |
+| 18. Issue #59 - Category Tenant Guard Hardening | 1/1 | Complete | 2026-05-16 |
 | 19. Pre-order PAID → điểm hội viên | 0/3 | Planned | — |
 
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: planned
-last_updated: "2026-05-12T07:45:00.000Z"
+status: complete
+last_updated: "2026-05-16T15:30:00.000Z"
 progress:
   total_phases: 18
-  completed_phases: 17
+  completed_phases: 18
   total_plans: 40
-  completed_plans: 39
+  completed_plans: 40
 ---
 
 # Project State
@@ -18,16 +18,16 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-30)
 
 **Core value:** A seller can publish a diecast listing with complete media and ready-to-post content in one flow.
-**Current focus:** Phase 18 (Issue #59 - Category Tenant Guard Hardening) — planned 2026-05-12; execute `18-01` to close inactive-shop authorization lifecycle gap on category mutate routes.
+**Current focus:** Phase 19 (Pre-order PAID → điểm hội viên) — next milestone work when picked up.
 
 ## Current Position
 
-Phase: **18** — Issue #59 Category Tenant Guard Hardening (**planned**: 18-01)
+Phase: **18** — Issue #59 Category Tenant Guard Hardening (**complete**: 18-01 shipped 2026-05-16)
 Plan: **18-01** Harden category mutate tenant authorization
-Status: Ready for implementation.
-Last activity: 2026-05-12 — created Issue #59 and Phase 18 plan from code review finding.
+Status: Implemented — `RolesGuard` tenant branch now verifies `shop.is_active` via live `shop.findUnique` (aligns category mutate routes with tenant lifecycle; platform_super early-return unchanged).
+Last activity: 2026-05-16 — Phase 18 merged implementation: inactive `active_shop_id` JWT context cannot pass tenant `RolesGuard`.
 
-Progress: [#########.] 17/18 phases shipped; Phase 18 planned, execution pending.
+Progress: [##########] 18/18 phases shipped for current roadmap slice; Phase 19 remains planned.
 
 ## Performance Metrics
 
@@ -67,17 +67,19 @@ Progress: [#########.] 17/18 phases shipped; Phase 18 planned, execution pending
 - (2026-04-29) Completed Phase 13: advanced Playwright specs (`spinner`, `social-selling`, `responsive`), CI runner tuning (retries/workers), E2E triage notes in `docs/TODO.md`, `stubAuthCsrf` helper for admin mocks.
 - (2026-04-29) Completed Phase 15: PlatformRole enum + User.platform_role migration+backfill; dual-layer RolesGuard (platform_role check + shop_staff HTTP-method enforcement — Option C); @PlatformRoles decorator; AddShopAdminDto extended with role field; frontend isPlatformSuper + useIsSuperAdmin updated; AddMemberModal role picker (shop_admin/shop_staff); audit labels for new actions.
 - (2026-04-30) **Phase 16:** Public catalog/detail accept optional `shop_id` (UUID or slug); explicit query overrides JWT for reads; frontend propagates `shop_id` via URL, `VITE_PUBLIC_CATALOG_SHOP_ID`, or JWT after auth settles (`shopContextReady`); Playwright two-shop mock proves UI isolation.
+- (2026-05-16) **Phase 18 / Issue #59:** Tenant-layer `RolesGuard` now loads `shop.is_active` per request (`shop.findUnique`) after role match so deactivated shops cannot authorize mutating routes (including category PATCH/DELETE) with stale JWT `active_shop_id`; platform_super still bypasses tenant branch; regression tests in `roles.guard.spec.ts`.
 
 ### Roadmap Evolution
 
 - Phase 17 added: Cloudflare R2 upload — migrate backend media from local disk to object storage (2026-05-08).
 - Phase 17 planned: RESEARCH + plans 17-01..17-03 + PLAN-CHECK (2026-05-08).
 - Phase 18 added: Issue #59 Category Tenant Guard Hardening (2026-05-12).
+- Phase 18 completed: RolesGuard active-shop lifecycle hardening (2026-05-16).
 
 ### Pending Todos
 
-- Execute Phase 18 Plan 18-01 to harden category mutate tenant authorization.
 - Merge nhánh `feat/security-signed-media-csrf-throttle` + cập nhật `docs/API_CONTRACT.md` / `ENV.md` nếu chưa làm.
+- Execute Phase 19 plans when scheduled (pre-order PAID → member points).
 
 ### Blockers/Concerns
 
@@ -85,6 +87,6 @@ Progress: [#########.] 17/18 phases shipped; Phase 18 planned, execution pending
 
 ## Session Continuity
 
-Last session: 2026-05-12 (created Issue #59 + Phase 18 executable plan)
-Stopped at: **Execute** — implement `.planning/phases/18-category-tenant-guard-hardening/18-01-PLAN.md`.
-Resume file: `.planning/phases/18-category-tenant-guard-hardening/18-01-PLAN.md`
+Last session: 2026-05-16 (Phase 18 — RolesGuard `shop.is_active` check + tests + roadmap/state)
+Stopped at: **Complete** — branch `cursor/category-tenant-guard-hardening-8c96` ready for review/merge.
+Resume file: `.planning/phases/19-preorder-member-points-on-paid/19-01-PLAN.md` (next phase when prioritized)

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -151,6 +151,17 @@ describe('RolesGuard', () => {
     await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
   });
 
+  it('denies shop_admin when active shop no longer exists', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin]);
+    prisma.shop.findUnique.mockResolvedValueOnce(null);
+    const ctx = createContext({
+      id: 'u1',
+      active_shop_id: 'shop-a',
+      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
+    });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
+
   it('denies tenant user on mixed platform+tenant route when active shop is inactive', async () => {
     mockReflector([PlatformRole.platform_super], [ShopRole.shop_admin, ShopRole.shop_staff]);
     prisma.shop.findUnique.mockResolvedValueOnce({ is_active: false });

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -12,14 +12,27 @@ describe('RolesGuard', () => {
   let reflector: Reflector;
   let prisma: { userShopRole: { findMany: jest.Mock }; shop: { findUnique: jest.Mock } };
 
-  const createContext = (requestUser: unknown, method = 'GET'): ExecutionContext =>
-    ({
+  type TestRequest = {
+    user: unknown;
+    method: string;
+    tenantAccessVerified?: boolean;
+  };
+
+  const createContext = (
+    requestUser: unknown,
+    method = 'GET',
+    requestOverrides: Partial<TestRequest> = {},
+  ): ExecutionContext => {
+    const request: TestRequest = { user: requestUser, method, ...requestOverrides };
+
+    return {
       getHandler: () => jest.fn(),
       getClass: () => class TestController {},
       switchToHttp: () => ({
-        getRequest: () => ({ user: requestUser, method }),
+        getRequest: () => request,
       }),
-    }) as unknown as ExecutionContext;
+    } as unknown as ExecutionContext;
+  };
 
   const mockReflector = (
     platformRoles?: PlatformRole[],
@@ -110,6 +123,21 @@ describe('RolesGuard', () => {
       where: { id: 'shop-a' },
       select: { is_active: true },
     });
+  });
+
+  it('skips shop.is_active lookup when tenant access was already verified upstream', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin]);
+    const ctx = createContext(
+      {
+        id: 'u1',
+        active_shop_id: 'shop-a',
+        shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
+      },
+      'GET',
+      { tenantAccessVerified: true },
+    );
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(prisma.shop.findUnique).not.toHaveBeenCalled();
   });
 
   it('denies shop_admin when active shop is deactivated (is_active false)', async () => {

--- a/backend/src/common/guards/roles.guard.spec.ts
+++ b/backend/src/common/guards/roles.guard.spec.ts
@@ -10,7 +10,7 @@ import { RolesGuard } from './roles.guard';
 describe('RolesGuard', () => {
   let guard: RolesGuard;
   let reflector: Reflector;
-  let prisma: { userShopRole: { findMany: jest.Mock } };
+  let prisma: { userShopRole: { findMany: jest.Mock }; shop: { findUnique: jest.Mock } };
 
   const createContext = (requestUser: unknown, method = 'GET'): ExecutionContext =>
     ({
@@ -36,7 +36,10 @@ describe('RolesGuard', () => {
 
   beforeEach(() => {
     reflector = new Reflector();
-    prisma = { userShopRole: { findMany: jest.fn() } };
+    prisma = {
+      userShopRole: { findMany: jest.fn() },
+      shop: { findUnique: jest.fn().mockResolvedValue({ is_active: true }) },
+    };
     guard = new RolesGuard(reflector, prisma as unknown as PrismaService);
     // Clear the static cache between tests to prevent cross-test contamination.
     RolesGuard['shopRolesCache'].clear();
@@ -60,6 +63,7 @@ describe('RolesGuard', () => {
     mockReflector([PlatformRole.platform_super]);
     const ctx = createContext({ id: 'u1', platform_role: PlatformRole.platform_super });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(prisma.shop.findUnique).not.toHaveBeenCalled();
   });
 
   it('denies user without platform_role on @PlatformRoles route', async () => {
@@ -102,6 +106,46 @@ describe('RolesGuard', () => {
       shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(prisma.shop.findUnique).toHaveBeenCalledWith({
+      where: { id: 'shop-a' },
+      select: { is_active: true },
+    });
+  });
+
+  it('denies shop_admin when active shop is deactivated (is_active false)', async () => {
+    mockReflector(undefined, [ShopRole.shop_admin]);
+    prisma.shop.findUnique.mockResolvedValueOnce({ is_active: false });
+    const ctx = createContext({
+      id: 'u1',
+      active_shop_id: 'shop-a',
+      shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
+    });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('denies tenant user on mixed platform+tenant route when active shop is inactive', async () => {
+    mockReflector([PlatformRole.platform_super], [ShopRole.shop_admin, ShopRole.shop_staff]);
+    prisma.shop.findUnique.mockResolvedValueOnce({ is_active: false });
+    const ctx = createContext(
+      {
+        id: 'u1',
+        platform_role: null,
+        active_shop_id: 'shop-a',
+        shop_roles: [{ shop_id: 'shop-a', role: ShopRole.shop_admin }],
+      },
+      'PATCH',
+    );
+    await expect(guard.canActivate(ctx)).rejects.toThrow(ForbiddenException);
+  });
+
+  it('allows platform_super on mixed platform+tenant route without shop.is_active lookup', async () => {
+    mockReflector([PlatformRole.platform_super], [ShopRole.shop_admin, ShopRole.shop_staff]);
+    const ctx = createContext(
+      { id: 'u1', platform_role: PlatformRole.platform_super, active_shop_id: 'shop-a' },
+      'PATCH',
+    );
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(prisma.shop.findUnique).not.toHaveBeenCalled();
   });
 
   it('allows legacy super_admin shop row when route requires shop_admin', async () => {

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -68,7 +68,9 @@ function userRoleSatisfiesTenantRequirement(userRole: ShopRole, tenantRoles: Sho
  * Routes decorated with `@Roles(ShopRole.shop_admin)` (or shop_staff) require:
  *   1. A valid `active_shop_id` in the JWT.
  *   2. A matching `UserShopRole` row for that shop.
- *   3. Option C: `shop_staff` users are automatically restricted to safe HTTP methods
+ *   3. The shop row exists and `shop.is_active` is true (live DB read; not cached with
+ *      shop roles so deactivated shops cannot authorize via stale 30s role cache).
+ *   4. Option C: `shop_staff` users are automatically restricted to safe HTTP methods
  *      (GET/HEAD/OPTIONS) — no individual controller needs to check this.
  *
  * ## Legacy compatibility
@@ -194,6 +196,14 @@ export class RolesGuard implements CanActivate {
 
     if (!matchingRole) {
       throw new ForbiddenException(`Access forbidden. Required roles: ${tenantRoles.join(', ')}`);
+    }
+
+    const shopState = await this.prisma.shop.findUnique({
+      where: { id: activeShopId },
+      select: { is_active: true },
+    });
+    if (!shopState?.is_active) {
+      throw new ForbiddenException('Access forbidden for the selected active shop.');
     }
 
     // ── Option C: shop_staff HTTP-method enforcement ─────────────────────────

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -17,6 +17,17 @@ export interface JwtUserShopRole {
   role: ShopRole;
 }
 
+type RolesGuardRequest = {
+  method?: string;
+  tenantAccessVerified?: boolean;
+  user?: {
+    id?: string;
+    active_shop_id?: string | null;
+    platform_role?: PlatformRole | null;
+    shop_roles?: JwtUserShopRole[];
+  };
+};
+
 /**
  * HTTP methods considered safe/read-only for shop_staff enforcement (Option C).
  *
@@ -117,7 +128,7 @@ export class RolesGuard implements CanActivate {
       return true;
     }
 
-    const request = context.switchToHttp().getRequest();
+    const request = context.switchToHttp().getRequest<RolesGuardRequest>();
     const { user } = request;
     if (!user?.id) {
       throw new ForbiddenException('A role is required to access this resource.');
@@ -198,12 +209,14 @@ export class RolesGuard implements CanActivate {
       throw new ForbiddenException(`Access forbidden. Required roles: ${tenantRoles.join(', ')}`);
     }
 
-    const shopState = await this.prisma.shop.findUnique({
-      where: { id: activeShopId },
-      select: { is_active: true },
-    });
-    if (!shopState?.is_active) {
-      throw new ForbiddenException('Access forbidden for the selected active shop.');
+    if (!request.tenantAccessVerified) {
+      const shopState = await this.prisma.shop.findUnique({
+        where: { id: activeShopId },
+        select: { is_active: true },
+      });
+      if (!shopState?.is_active) {
+        throw new ForbiddenException('Access forbidden for the selected active shop.');
+      }
     }
 
     // ── Option C: shop_staff HTTP-method enforcement ─────────────────────────

--- a/backend/src/common/guards/tenant.guard.spec.ts
+++ b/backend/src/common/guards/tenant.guard.spec.ts
@@ -3,21 +3,36 @@ import { TenantGuard } from './tenant.guard';
 import { PrismaService } from '../prisma/prisma.service';
 
 describe('TenantGuard', () => {
-  const prisma = {
+  let guard: TenantGuard;
+  let prisma: {
     userShopRole: {
-      findUnique: jest.fn(),
-      findFirst: jest.fn(),
-    },
+      findUnique: jest.Mock;
+      findFirst: jest.Mock;
+    };
   };
 
-  const guard = new TenantGuard(prisma as unknown as PrismaService);
+  type TestRequest = {
+    user?: unknown;
+    tenantId?: string;
+    tenantAccessVerified?: boolean;
+  };
 
-  const createContext = (request: { user?: unknown } & { tenantId?: string }): ExecutionContext =>
+  const createContext = (request: TestRequest): ExecutionContext =>
     ({
       switchToHttp: () => ({
         getRequest: () => request,
       }),
     }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    prisma = {
+      userShopRole: {
+        findUnique: jest.fn(),
+        findFirst: jest.fn(),
+      },
+    };
+    guard = new TenantGuard(prisma as unknown as PrismaService);
+  });
 
   it('throws when user has no active_shop_id and no shop membership', async () => {
     prisma.userShopRole.findFirst.mockResolvedValue(null);
@@ -39,11 +54,13 @@ describe('TenantGuard', () => {
     const req = { user: { id: 'u1', active_shop_id: 'shop-1' } } as {
       user: { id: string; active_shop_id: string };
       tenantId?: string;
+      tenantAccessVerified?: boolean;
     };
 
     const ok = await guard.canActivate(createContext(req));
     expect(ok).toBe(true);
     expect(req.tenantId).toBe('shop-1');
+    expect(req.tenantAccessVerified).toBe(true);
     expect(prisma.userShopRole.findUnique).toHaveBeenCalledWith({
       where: { user_id_shop_id: { user_id: 'u1', shop_id: 'shop-1' } },
       include: { shop: { select: { is_active: true } } },
@@ -59,11 +76,13 @@ describe('TenantGuard', () => {
     const req = { user: { id: 'u1' } } as {
       user: { id: string; active_shop_id?: string };
       tenantId?: string;
+      tenantAccessVerified?: boolean;
     };
 
     const ok = await guard.canActivate(createContext(req));
     expect(ok).toBe(true);
     expect(req.tenantId).toBe('shop-auto');
+    expect(req.tenantAccessVerified).toBe(true);
     expect(req.user).toEqual(expect.objectContaining({ active_shop_id: 'shop-auto' }));
   });
 

--- a/backend/src/common/guards/tenant.guard.ts
+++ b/backend/src/common/guards/tenant.guard.ts
@@ -73,7 +73,9 @@ export class TenantGuard implements CanActivate {
       throw new ForbiddenException('Access forbidden for the selected active shop.');
     }
 
-    // Inject tenantId for downstream use via @CurrentTenantId() decorator
+    // Inject tenantId for downstream use via @CurrentTenantId() decorator.
+    // RolesGuard uses tenantAccessVerified to avoid repeating this live tenant
+    // membership + shop.is_active check on routes that run TenantGuard first.
     request.tenantId = activeShopId;
     request.tenantAccessVerified = true;
     return true;

--- a/backend/src/common/guards/tenant.guard.ts
+++ b/backend/src/common/guards/tenant.guard.ts
@@ -7,6 +7,15 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
+type TenantVerifiedRequest = {
+  user?: {
+    id?: string;
+    active_shop_id?: string | null;
+  };
+  tenantId?: string;
+  tenantAccessVerified?: boolean;
+};
+
 /**
  * TenantGuard — enforces that a request has an active_shop_id bound in the JWT.
  *
@@ -23,7 +32,7 @@ export class TenantGuard implements CanActivate {
   constructor(private readonly prisma: PrismaService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const request = context.switchToHttp().getRequest();
+    const request = context.switchToHttp().getRequest<TenantVerifiedRequest>();
     const user = request.user;
 
     if (!user?.id) {
@@ -66,6 +75,7 @@ export class TenantGuard implements CanActivate {
 
     // Inject tenantId for downstream use via @CurrentTenantId() decorator
     request.tenantId = activeShopId;
+    request.tenantAccessVerified = true;
     return true;
   }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,16 +9,16 @@
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
+    "types": ["node", "jest", "multer"],
     "strictNullChecks": false,
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes **Phase 18 / Issue #59** (Category Tenant Guard Hardening) by closing the inactive-shop authorization gap on any route that uses `JwtAuthGuard` + `RolesGuard` for tenant users—including mixed `platform_super` + shop-role handlers such as category `PATCH` / `DELETE`.

## Approach

Per plan **18-01**, we avoided adding `TenantGuard` to mixed platform+tenant routes (which would force `platform_super` through active-shop selection). Instead, the **tenant branch** of `RolesGuard` now performs a **live** `prisma.shop.findUnique({ select: { is_active } })` after a matching `UserShopRole` is found. Shop role rows remain cached as before; `is_active` is **not** cached, so a deactivated shop cannot authorize via a stale 30s role cache.

- **Shop admin/staff** on inactive `active_shop_id`: `403` with the same message as `TenantGuard` for consistency.
- **`platform_super`**: unchanged early return; no extra DB call on those requests.

## Tests

- Extended `roles.guard.spec.ts` (inactive shop, mixed-route tenant vs platform).
- Full backend Jest, ESLint, and `nest build` pass locally.

## Planning

- `.planning/ROADMAP.md` — Phase 18 and plan 18-01 marked complete.
- `.planning/STATE.md` — progress and focus updated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0b41318-adb1-4759-ba27-5d6736e88c96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0b41318-adb1-4759-ba27-5d6736e88c96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

