### PR TITLE
feat(item): add preorder status with transition rules and campaign shortcut button

### DIFF
--- a/backend/prisma/migrations/20260522000000_add_preorder_item_status/migration.sql
+++ b/backend/prisma/migrations/20260522000000_add_preorder_item_status/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "ItemStatus" ADD VALUE 'preorder';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ enum ItemStatus {
   con_hang
   giu_cho
   da_ban
+  preorder
 }
 
 enum PlatformRole {

--- a/backend/src/ai/ai.service.ts
+++ b/backend/src/ai/ai.service.ts
@@ -212,7 +212,7 @@ Cấu trúc bài viết:
       itemData.push(`Tình trạng: ${conditionText}`);
     }
     if (item.status) {
-      const statusText = item.status === 'con_hang' ? 'Còn hàng' : item.status === 'giu_cho' ? 'Giữ chỗ' : 'Đã bán';
+      const statusText = item.status === 'con_hang' ? 'Còn hàng' : item.status === 'giu_cho' ? 'Giữ chỗ' : item.status === 'preorder' ? 'Pre-order' : 'Đã bán';
       itemData.push(`Trạng thái: ${statusText}`);
     }
     if (item.price != null) {

--- a/backend/src/items/dto/query-items.dto.ts
+++ b/backend/src/items/dto/query-items.dto.ts
@@ -17,7 +17,7 @@ export class QueryItemsDto {
   page_size?: number = 20;
 
   @IsOptional()
-  @IsIn(['con_hang', 'giu_cho', 'da_ban'])
+  @IsIn(['con_hang', 'giu_cho', 'da_ban', 'preorder'])
   status?: ItemStatus;
 
   @IsOptional()

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -981,6 +981,36 @@ describe('ItemsService', () => {
       expect(result.item.status).toBe('con_hang');
     });
 
+    it('should auto-set quantity to 1 when transitioning from da_ban to con_hang without explicit quantity', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 1 });
+
+      await service.update('item-123', { status: 'con_hang' }, TEST_SHOP_ID);
+
+      expect(prisma.item.update).toHaveBeenCalledWith({
+        where: { id: 'item-123' },
+        data: expect.objectContaining({
+          status: 'con_hang',
+          quantity: 1,
+        }),
+      });
+    });
+
+    it('should respect explicit quantity when transitioning from da_ban to con_hang', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 5 });
+
+      await service.update('item-123', { status: 'con_hang', quantity: 5 }, TEST_SHOP_ID);
+
+      expect(prisma.item.update).toHaveBeenCalledWith({
+        where: { id: 'item-123' },
+        data: expect.objectContaining({
+          status: 'con_hang',
+          quantity: 5,
+        }),
+      });
+    });
+
     it('should force quantity to zero when marking an item as sold', async () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       prisma.item.update.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -1064,6 +1064,66 @@ describe('ItemsService', () => {
         }),
       });
     });
+
+    it('should allow transition from da_ban to preorder', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 0 });
+
+      const result = await service.update('item-123', { status: 'preorder' }, TEST_SHOP_ID);
+
+      expect(result.item.status).toBe('preorder');
+    });
+
+    it('should reject transition from preorder to da_ban', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder' });
+
+      await expect(
+        service.update('item-123', { status: 'da_ban' }, TEST_SHOP_ID),
+      ).rejects.toMatchObject({
+        errorCode: ErrorCode.ITEM_STATUS_TRANSITION_INVALID,
+      });
+    });
+
+    it('should reject transition from preorder to giu_cho', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder' });
+
+      await expect(
+        service.update('item-123', { status: 'giu_cho' }, TEST_SHOP_ID),
+      ).rejects.toMatchObject({
+        errorCode: ErrorCode.ITEM_STATUS_TRANSITION_INVALID,
+      });
+    });
+
+    it('should allow transition from giu_cho to preorder', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'giu_cho' });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder' });
+
+      const result = await service.update('item-123', { status: 'preorder' }, TEST_SHOP_ID);
+
+      expect(result.item.status).toBe('preorder');
+    });
+
+    it('should not force quantity to zero when transitioning to preorder', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, quantity: 5 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 5 });
+
+      await service.update('item-123', { status: 'preorder' }, TEST_SHOP_ID);
+
+      const updateCall = prisma.item.update.mock.calls[0][0];
+      expect(updateCall.data.quantity).not.toBe(0);
+    });
+
+    it('should allow quantity updates freely on preorder items', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 3 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 10 });
+
+      await service.update('item-123', { quantity: 10 }, TEST_SHOP_ID);
+
+      expect(prisma.item.update).toHaveBeenCalledWith({
+        where: { id: 'item-123' },
+        data: expect.objectContaining({ quantity: 10 }),
+      });
+    });
   });
 
   // ============================================================

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -15,6 +15,7 @@ describe('ItemsService', () => {
   let service: ItemsService;
   let prisma: {
     item: Record<string, jest.Mock>;
+    preOrder: Record<string, jest.Mock>;
     category: Record<string, jest.Mock>;
     aiItemDraft: Record<string, jest.Mock>;
     itemImage: Record<string, jest.Mock>;
@@ -91,6 +92,9 @@ describe('ItemsService', () => {
         findFirst: jest.fn(),
         findMany: jest.fn(),
         count: jest.fn(),
+      },
+      preOrder: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
       },
       category: {
         findFirst: jest.fn(),
@@ -1120,16 +1124,6 @@ describe('ItemsService', () => {
       });
     });
 
-    it('should reject transition from preorder to da_ban', async () => {
-      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder' });
-
-      await expect(
-        service.update('item-123', { status: 'da_ban' }, TEST_SHOP_ID),
-      ).rejects.toMatchObject({
-        errorCode: ErrorCode.ITEM_STATUS_TRANSITION_INVALID,
-      });
-    });
-
     it('should reject transition from preorder to giu_cho', async () => {
       prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder' });
 
@@ -1181,6 +1175,41 @@ describe('ItemsService', () => {
         where: { id: 'item-123' },
         data: expect.objectContaining({ quantity: 10 }),
       });
+    });
+
+    it('should allow transition from preorder to da_ban (supplier cancelled)', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 5 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+
+      const result = await service.update('item-123', { status: 'da_ban' }, TEST_SHOP_ID);
+
+      expect(result.item.status).toBe('da_ban');
+      expect(prisma.item.update).toHaveBeenCalledWith({
+        where: { id: 'item-123' },
+        data: expect.objectContaining({ status: 'da_ban', quantity: 0 }),
+      });
+    });
+
+    it('should trigger WAITING_FOR_GOODS → ARRIVED on preorder items when transitioning to con_hang', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 0 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 1 });
+      prisma.preOrder.updateMany.mockResolvedValue({ count: 2 });
+
+      await service.update('item-123', { status: 'con_hang' }, TEST_SHOP_ID);
+
+      expect(prisma.preOrder.updateMany).toHaveBeenCalledWith({
+        where: { item_id: 'item-123', shop_id: TEST_SHOP_ID, status: 'WAITING_FOR_GOODS' },
+        data: { status: 'ARRIVED' },
+      });
+    });
+
+    it('should not trigger preorder updateMany when transitioning between other statuses', async () => {
+      prisma.item.findFirst.mockResolvedValue(mockItem);
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'giu_cho' });
+
+      await service.update('item-123', { status: 'giu_cho' }, TEST_SHOP_ID);
+
+      expect(prisma.preOrder.updateMany).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -1025,6 +1025,21 @@ describe('ItemsService', () => {
       });
     });
 
+    it('should clamp explicit quantity=0 to 1 when transitioning from da_ban to con_hang', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 1 });
+
+      await service.update('item-123', { status: 'con_hang', quantity: 0 }, TEST_SHOP_ID);
+
+      expect(prisma.item.update).toHaveBeenCalledWith({
+        where: { id: 'item-123' },
+        data: expect.objectContaining({
+          status: 'con_hang',
+          quantity: 1,
+        }),
+      });
+    });
+
     it('should force quantity to zero when marking an item as sold', async () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       prisma.item.update.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -963,6 +963,24 @@ describe('ItemsService', () => {
       expect(prisma.category.findFirst).not.toHaveBeenCalled();
     });
 
+    it('should allow transition from con_hang to preorder', async () => {
+      prisma.item.findFirst.mockResolvedValue(mockItem);
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder' });
+
+      const result = await service.update('item-123', { status: 'preorder' }, TEST_SHOP_ID);
+
+      expect(result.item.status).toBe('preorder');
+    });
+
+    it('should allow transition from preorder to con_hang', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder' });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang' });
+
+      const result = await service.update('item-123', { status: 'con_hang' }, TEST_SHOP_ID);
+
+      expect(result.item.status).toBe('con_hang');
+    });
+
     it('should reject invalid status transition from da_ban to con_hang', async () => {
       prisma.item.findFirst.mockResolvedValue({
         ...mockItem,

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -1266,6 +1266,61 @@ describe('ItemsService', () => {
       expect(result.preorders_auto_cancelled_count).toBe(2);
       expect(result.preorders_with_deposit_count).toBe(1);
     });
+
+    it('should propagate error if preOrder.updateMany throws inside transaction on preorder → con_hang', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder' });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 1 });
+      prisma.preOrder.updateMany.mockRejectedValue(new Error('DB connection lost'));
+
+      await expect(
+        service.update('item-123', { status: 'con_hang' }, TEST_SHOP_ID),
+      ).rejects.toThrow('DB connection lost');
+    });
+
+    it('should use equals:0 filter — not lte — when auto-cancelling on preorder → da_ban', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 5 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.preOrder.updateMany.mockResolvedValue({ count: 1 });
+      prisma.preOrder.count.mockResolvedValue(0);
+
+      await service.update('item-123', { status: 'da_ban' }, TEST_SHOP_ID);
+
+      expect(prisma.preOrder.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ paid_amount: { equals: 0 } }),
+        }),
+      );
+    });
+
+    it('should cancel PENDING_CONFIRMATION-only orders on preorder → da_ban', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 5 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.preOrder.updateMany.mockResolvedValue({ count: 1 });
+      prisma.preOrder.count.mockResolvedValue(0);
+
+      const result = await service.update('item-123', { status: 'da_ban' }, TEST_SHOP_ID);
+
+      expect(prisma.preOrder.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: { in: ['PENDING_CONFIRMATION', 'WAITING_FOR_GOODS'] },
+          }),
+        }),
+      );
+      expect(result.preorders_auto_cancelled_count).toBe(1);
+    });
+
+    it('should return preorders_arrived_count=0 and preorders_pending_count=0 when no active preorders on preorder → con_hang', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 0 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 1 });
+      prisma.preOrder.updateMany.mockResolvedValue({ count: 0 });
+      prisma.preOrder.count.mockResolvedValue(0);
+
+      const result = await service.update('item-123', { status: 'con_hang' }, TEST_SHOP_ID);
+
+      expect(result.preorders_arrived_count).toBe(0);
+      expect(result.preorders_pending_count).toBe(0);
+    });
   });
 
   // ============================================================

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -981,19 +981,6 @@ describe('ItemsService', () => {
       expect(result.item.status).toBe('con_hang');
     });
 
-    it('should reject invalid status transition from da_ban to con_hang', async () => {
-      prisma.item.findFirst.mockResolvedValue({
-        ...mockItem,
-        status: 'da_ban',
-      });
-
-      await expect(
-        service.update('item-123', { status: 'con_hang' }, TEST_SHOP_ID),
-      ).rejects.toMatchObject({
-        errorCode: ErrorCode.ITEM_STATUS_TRANSITION_INVALID,
-      });
-    });
-
     it('should force quantity to zero when marking an item as sold', async () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       prisma.item.update.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
@@ -1065,11 +1052,30 @@ describe('ItemsService', () => {
       });
     });
 
-    it('should reject transition from da_ban to preorder (da_ban is terminal)', async () => {
+    it('should allow transition from da_ban to con_hang (re-stocked from another seller)', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 1 });
+
+      const result = await service.update('item-123', { status: 'con_hang', quantity: 1 }, TEST_SHOP_ID);
+
+      expect(result.item.status).toBe('con_hang');
+    });
+
+    it('should reject transition from da_ban to preorder', async () => {
       prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
 
       await expect(
         service.update('item-123', { status: 'preorder' }, TEST_SHOP_ID),
+      ).rejects.toMatchObject({
+        errorCode: ErrorCode.ITEM_STATUS_TRANSITION_INVALID,
+      });
+    });
+
+    it('should reject transition from da_ban to giu_cho', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+
+      await expect(
+        service.update('item-123', { status: 'giu_cho' }, TEST_SHOP_ID),
       ).rejects.toMatchObject({
         errorCode: ErrorCode.ITEM_STATUS_TRANSITION_INVALID,
       });

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -15,7 +15,7 @@ describe('ItemsService', () => {
   let service: ItemsService;
   let prisma: {
     item: Record<string, jest.Mock>;
-    preOrder: Record<string, jest.Mock>;
+    preOrder: { updateMany: jest.Mock; count: jest.Mock };
     category: Record<string, jest.Mock>;
     aiItemDraft: Record<string, jest.Mock>;
     itemImage: Record<string, jest.Mock>;
@@ -95,6 +95,7 @@ describe('ItemsService', () => {
       },
       preOrder: {
         updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+        count: jest.fn().mockResolvedValue(0),
       },
       category: {
         findFirst: jest.fn(),
@@ -1195,21 +1196,60 @@ describe('ItemsService', () => {
       prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 1 });
       prisma.preOrder.updateMany.mockResolvedValue({ count: 2 });
 
-      await service.update('item-123', { status: 'con_hang' }, TEST_SHOP_ID);
+      const result = await service.update('item-123', { status: 'con_hang' }, TEST_SHOP_ID);
 
       expect(prisma.preOrder.updateMany).toHaveBeenCalledWith({
         where: { item_id: 'item-123', shop_id: TEST_SHOP_ID, status: 'WAITING_FOR_GOODS' },
         data: { status: 'ARRIVED' },
       });
+      expect(result.preorders_arrived_count).toBe(2);
+      expect(result.preorders_auto_cancelled_count).toBe(0);
     });
 
     it('should not trigger preorder updateMany when transitioning between other statuses', async () => {
       prisma.item.findFirst.mockResolvedValue(mockItem);
       prisma.item.update.mockResolvedValue({ ...mockItem, status: 'giu_cho' });
 
-      await service.update('item-123', { status: 'giu_cho' }, TEST_SHOP_ID);
+      const result = await service.update('item-123', { status: 'giu_cho' }, TEST_SHOP_ID);
 
       expect(prisma.preOrder.updateMany).not.toHaveBeenCalled();
+      expect(result.preorders_arrived_count).toBe(0);
+      expect(result.preorders_auto_cancelled_count).toBe(0);
+    });
+
+    it('should auto-cancel no-deposit orders when preorder → da_ban', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 5 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.preOrder.updateMany.mockResolvedValue({ count: 3 });
+      prisma.preOrder.count.mockResolvedValue(0);
+
+      const result = await service.update('item-123', { status: 'da_ban' }, TEST_SHOP_ID);
+
+      expect(prisma.preOrder.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            item_id: 'item-123',
+            shop_id: TEST_SHOP_ID,
+            status: { in: ['PENDING_CONFIRMATION', 'WAITING_FOR_GOODS'] },
+            paid_amount: { lte: 0 },
+          }),
+          data: expect.objectContaining({ status: 'CANCELLED' }),
+        }),
+      );
+      expect(result.preorders_auto_cancelled_count).toBe(3);
+      expect(result.preorders_with_deposit_count).toBe(0);
+    });
+
+    it('should return preorders_with_deposit_count when some orders have deposit', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 5 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
+      prisma.preOrder.updateMany.mockResolvedValue({ count: 2 });
+      prisma.preOrder.count.mockResolvedValue(1);
+
+      const result = await service.update('item-123', { status: 'da_ban' }, TEST_SHOP_ID);
+
+      expect(result.preorders_auto_cancelled_count).toBe(2);
+      expect(result.preorders_with_deposit_count).toBe(1);
     });
   });
 

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -1065,13 +1065,14 @@ describe('ItemsService', () => {
       });
     });
 
-    it('should allow transition from da_ban to preorder', async () => {
+    it('should reject transition from da_ban to preorder (da_ban is terminal)', async () => {
       prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
-      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 0 });
 
-      const result = await service.update('item-123', { status: 'preorder' }, TEST_SHOP_ID);
-
-      expect(result.item.status).toBe('preorder');
+      await expect(
+        service.update('item-123', { status: 'preorder' }, TEST_SHOP_ID),
+      ).rejects.toMatchObject({
+        errorCode: ErrorCode.ITEM_STATUS_TRANSITION_INVALID,
+      });
     });
 
     it('should reject transition from preorder to da_ban', async () => {

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -1246,7 +1246,7 @@ describe('ItemsService', () => {
             item_id: 'item-123',
             shop_id: TEST_SHOP_ID,
             status: { in: ['PENDING_CONFIRMATION', 'WAITING_FOR_GOODS'] },
-            paid_amount: { lte: 0 },
+            paid_amount: { equals: 0 },
           }),
           data: expect.objectContaining({ status: 'CANCELLED' }),
         }),

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -1150,6 +1150,18 @@ describe('ItemsService', () => {
       expect(updateCall.data.quantity).not.toBe(0);
     });
 
+    it('should preserve quantity=0 when explicitly requested on preorder transition', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, quantity: 3 });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 0 });
+
+      await service.update('item-123', { status: 'preorder', quantity: 0 }, TEST_SHOP_ID);
+
+      expect(prisma.item.update).toHaveBeenCalledWith({
+        where: { id: 'item-123' },
+        data: expect.objectContaining({ status: 'preorder', quantity: 0 }),
+      });
+    });
+
     it('should allow quantity updates freely on preorder items', async () => {
       prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 3 });
       prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder', quantity: 10 });

--- a/backend/src/items/items.service.spec.ts
+++ b/backend/src/items/items.service.spec.ts
@@ -981,6 +981,15 @@ describe('ItemsService', () => {
       expect(result.item.status).toBe('con_hang');
     });
 
+    it('should allow preorder → preorder self-transition (editing other fields does not break)', async () => {
+      prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'preorder' });
+      prisma.item.update.mockResolvedValue({ ...mockItem, status: 'preorder', name: 'Updated name' });
+
+      const result = await service.update('item-123', { status: 'preorder', name: 'Updated name' }, TEST_SHOP_ID);
+
+      expect(result.item.status).toBe('preorder');
+    });
+
     it('should auto-set quantity to 1 when transitioning from da_ban to con_hang without explicit quantity', async () => {
       prisma.item.findFirst.mockResolvedValue({ ...mockItem, status: 'da_ban', quantity: 0 });
       prisma.item.update.mockResolvedValue({ ...mockItem, status: 'con_hang', quantity: 1 });

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -585,7 +585,12 @@ Condition: ${item.condition || ''}`;
     if (updateDto.original_price !== undefined) updateData.original_price = updateDto.original_price ?? null;
     if (updateDto.status !== undefined) updateData.status = updateDto.status;
     if (updateDto.quantity !== undefined) {
-      updateData.quantity = resolveQuantityForStatus(nextStatus, updateDto.quantity);
+      const resolved = resolveQuantityForStatus(nextStatus, updateDto.quantity);
+      // da_ban → con_hang must always result in quantity ≥ 1 (re-stocking invariant).
+      updateData.quantity =
+        existingItem.status === 'da_ban' && nextStatus === 'con_hang' && resolved <= 0
+          ? 1
+          : resolved;
     } else if (updateDto.status === 'da_ban' && existingItem.status !== 'da_ban') {
       updateData.quantity = 0;
     } else if (existingItem.status === 'da_ban' && nextStatus === 'con_hang') {

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -21,7 +21,7 @@ import { normalizeCategoryBrandField } from '../common/utils/category-brand.util
 const ALLOWED_STATUS_TRANSITIONS: Record<ItemStatus, ItemStatus[]> = {
   con_hang: ['con_hang', 'giu_cho', 'da_ban', 'preorder'],
   giu_cho: ['giu_cho', 'con_hang', 'da_ban', 'preorder'],
-  da_ban: ['da_ban', 'preorder'],
+  da_ban: ['da_ban'],
   preorder: ['con_hang'],
 };
 

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -587,6 +587,8 @@ Condition: ${item.condition || ''}`;
       updateData.quantity = resolveQuantityForStatus(nextStatus, updateDto.quantity);
     } else if (updateDto.status === 'da_ban' && existingItem.status !== 'da_ban') {
       updateData.quantity = 0;
+    } else if (nextStatus !== 'da_ban' && existingItem.status === 'da_ban') {
+      updateData.quantity = 1;
     }
     if (updateDto.attributes !== undefined) {
       updateData.attributes = toItemAttributesJson(updateDto.attributes);

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -613,6 +613,10 @@ Condition: ${item.condition || ''}`;
       );
     }
 
+    let preordersArrivedCount = 0;
+    let preordersAutoCancelledCount = 0;
+    let preordersWithDepositCount = 0;
+
     const item = await this.prisma.$transaction(async (tx) => {
       const updated = await tx.item.update({
         where: { id },
@@ -620,9 +624,32 @@ Condition: ${item.condition || ''}`;
       });
 
       if (existingItem.status === 'preorder' && nextStatus === 'con_hang') {
-        await tx.preOrder.updateMany({
+        const result = await tx.preOrder.updateMany({
           where: { item_id: id, shop_id: shopId, status: PreOrderStatus.WAITING_FOR_GOODS },
           data: { status: PreOrderStatus.ARRIVED },
+        });
+        preordersArrivedCount = result.count;
+      }
+
+      if (existingItem.status === 'preorder' && nextStatus === 'da_ban') {
+        const cancelled = await tx.preOrder.updateMany({
+          where: {
+            item_id: id,
+            shop_id: shopId,
+            status: { in: [PreOrderStatus.PENDING_CONFIRMATION, PreOrderStatus.WAITING_FOR_GOODS] },
+            paid_amount: { lte: 0 },
+          },
+          data: { status: PreOrderStatus.CANCELLED, cancelled_at: new Date() },
+        });
+        preordersAutoCancelledCount = cancelled.count;
+
+        preordersWithDepositCount = await tx.preOrder.count({
+          where: {
+            item_id: id,
+            shop_id: shopId,
+            status: { in: [PreOrderStatus.PENDING_CONFIRMATION, PreOrderStatus.WAITING_FOR_GOODS] },
+            paid_amount: { gt: 0 },
+          },
         });
       }
 
@@ -632,7 +659,7 @@ Condition: ${item.condition || ''}`;
     // Sync with vector store
     this.syncVectorStore(item);
 
-    return { item };
+    return { item, preorders_arrived_count: preordersArrivedCount, preorders_auto_cancelled_count: preordersAutoCancelledCount, preorders_with_deposit_count: preordersWithDepositCount };
   }
 
   async remove(id: string, tenantId: string) {

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -619,6 +619,7 @@ Condition: ${item.condition || ''}`;
     }
 
     let preordersArrivedCount = 0;
+    let preordersPendingCount = 0;
     let preordersAutoCancelledCount = 0;
     let preordersWithDepositCount = 0;
 
@@ -634,6 +635,10 @@ Condition: ${item.condition || ''}`;
           data: { status: PreOrderStatus.ARRIVED },
         });
         preordersArrivedCount = result.count;
+
+        preordersPendingCount = await tx.preOrder.count({
+          where: { item_id: id, shop_id: shopId, status: PreOrderStatus.PENDING_CONFIRMATION },
+        });
       }
 
       if (existingItem.status === 'preorder' && nextStatus === 'da_ban') {
@@ -642,7 +647,7 @@ Condition: ${item.condition || ''}`;
             item_id: id,
             shop_id: shopId,
             status: { in: [PreOrderStatus.PENDING_CONFIRMATION, PreOrderStatus.WAITING_FOR_GOODS] },
-            paid_amount: { lte: 0 },
+            paid_amount: { equals: 0 },
           },
           data: { status: PreOrderStatus.CANCELLED, cancelled_at: new Date() },
         });
@@ -667,6 +672,7 @@ Condition: ${item.condition || ''}`;
     return {
       item,
       preorders_arrived_count: preordersArrivedCount,
+      preorders_pending_count: preordersPendingCount,
       preorders_auto_cancelled_count: preordersAutoCancelledCount,
       preorders_with_deposit_count: preordersWithDepositCount,
     };

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -21,7 +21,7 @@ import { normalizeCategoryBrandField } from '../common/utils/category-brand.util
 const ALLOWED_STATUS_TRANSITIONS: Record<ItemStatus, ItemStatus[]> = {
   con_hang: ['con_hang', 'giu_cho', 'da_ban', 'preorder'],
   giu_cho: ['giu_cho', 'con_hang', 'da_ban', 'preorder'],
-  da_ban: ['da_ban'],
+  da_ban: ['da_ban', 'con_hang'],
   preorder: ['con_hang'],
 };
 

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -19,9 +19,10 @@ import { CategoriesService } from '../categories/categories.service';
 import { normalizeCategoryBrandField } from '../common/utils/category-brand.utils';
 
 const ALLOWED_STATUS_TRANSITIONS: Record<ItemStatus, ItemStatus[]> = {
-  con_hang: ['con_hang', 'giu_cho', 'da_ban'],
-  giu_cho: ['giu_cho', 'con_hang', 'da_ban'],
-  da_ban: ['da_ban'],
+  con_hang: ['con_hang', 'giu_cho', 'da_ban', 'preorder'],
+  giu_cho: ['giu_cho', 'con_hang', 'da_ban', 'preorder'],
+  da_ban: ['da_ban', 'preorder'],
+  preorder: ['con_hang'],
 };
 
 function getInitialQuantityForStatus(status: ItemStatus): number {

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
-import { Prisma, ItemStatus } from '../generated/prisma/client';
+import { Prisma, ItemStatus, PreOrderStatus } from '../generated/prisma/client';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { IStorageService } from '../storage/storage.interface';
 import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
@@ -18,15 +18,12 @@ import type { ItemAttributesInput } from './dto/item-attributes.validator';
 import { CategoriesService } from '../categories/categories.service';
 import { normalizeCategoryBrandField } from '../common/utils/category-brand.utils';
 
-// Allowed status transitions. da_ban → con_hang permitted for re-stocking;
-// da_ban → preorder/giu_cho blocked (must re-stock first).
-// preorder → con_hang only (campaign ends, item arrives); self-transition required
-// so that other fields can be updated without changing status.
+// Self-transitions included so other fields can be edited without changing status.
 const ALLOWED_STATUS_TRANSITIONS: Record<ItemStatus, ItemStatus[]> = {
   con_hang: ['con_hang', 'giu_cho', 'da_ban', 'preorder'],
   giu_cho: ['giu_cho', 'con_hang', 'da_ban', 'preorder'],
   da_ban: ['da_ban', 'con_hang'],
-  preorder: ['preorder', 'con_hang'],
+  preorder: ['preorder', 'con_hang', 'da_ban'],
 };
 
 function getInitialQuantityForStatus(status: ItemStatus): number {
@@ -591,7 +588,7 @@ Condition: ${item.condition || ''}`;
       updateData.quantity = resolveQuantityForStatus(nextStatus, updateDto.quantity);
     } else if (updateDto.status === 'da_ban' && existingItem.status !== 'da_ban') {
       updateData.quantity = 0;
-    } else if (nextStatus !== 'da_ban' && existingItem.status === 'da_ban') {
+    } else if (existingItem.status === 'da_ban' && nextStatus === 'con_hang') {
       updateData.quantity = 1;
     }
     if (updateDto.attributes !== undefined) {
@@ -616,9 +613,20 @@ Condition: ${item.condition || ''}`;
       );
     }
 
-    const item = await this.prisma.item.update({
-      where: { id },
-      data: updateData,
+    const item = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.item.update({
+        where: { id },
+        data: updateData,
+      });
+
+      if (existingItem.status === 'preorder' && nextStatus === 'con_hang') {
+        await tx.preOrder.updateMany({
+          where: { item_id: id, shop_id: shopId, status: PreOrderStatus.WAITING_FOR_GOODS },
+          data: { status: PreOrderStatus.ARRIVED },
+        });
+      }
+
+      return updated;
     });
 
     // Sync with vector store

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -20,12 +20,13 @@ import { normalizeCategoryBrandField } from '../common/utils/category-brand.util
 
 // Allowed status transitions. da_ban → con_hang permitted for re-stocking;
 // da_ban → preorder/giu_cho blocked (must re-stock first).
-// preorder → con_hang only (campaign ends, item arrives).
+// preorder → con_hang only (campaign ends, item arrives); self-transition required
+// so that other fields can be updated without changing status.
 const ALLOWED_STATUS_TRANSITIONS: Record<ItemStatus, ItemStatus[]> = {
   con_hang: ['con_hang', 'giu_cho', 'da_ban', 'preorder'],
   giu_cho: ['giu_cho', 'con_hang', 'da_ban', 'preorder'],
   da_ban: ['da_ban', 'con_hang'],
-  preorder: ['con_hang'],
+  preorder: ['preorder', 'con_hang'],
 };
 
 function getInitialQuantityForStatus(status: ItemStatus): number {

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -659,7 +659,12 @@ Condition: ${item.condition || ''}`;
     // Sync with vector store
     this.syncVectorStore(item);
 
-    return { item, preorders_arrived_count: preordersArrivedCount, preorders_auto_cancelled_count: preordersAutoCancelledCount, preorders_with_deposit_count: preordersWithDepositCount };
+    return {
+      item,
+      preorders_arrived_count: preordersArrivedCount,
+      preorders_auto_cancelled_count: preordersAutoCancelledCount,
+      preorders_with_deposit_count: preordersWithDepositCount,
+    };
   }
 
   async remove(id: string, tenantId: string) {

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -18,6 +18,9 @@ import type { ItemAttributesInput } from './dto/item-attributes.validator';
 import { CategoriesService } from '../categories/categories.service';
 import { normalizeCategoryBrandField } from '../common/utils/category-brand.utils';
 
+// Allowed status transitions. da_ban → con_hang permitted for re-stocking;
+// da_ban → preorder/giu_cho blocked (must re-stock first).
+// preorder → con_hang only (campaign ends, item arrives).
 const ALLOWED_STATUS_TRANSITIONS: Record<ItemStatus, ItemStatus[]> = {
   con_hang: ['con_hang', 'giu_cho', 'da_ban', 'preorder'],
   giu_cho: ['giu_cho', 'con_hang', 'da_ban', 'preorder'],

--- a/backend/src/preorders/preorders.controller.ts
+++ b/backend/src/preorders/preorders.controller.ts
@@ -72,6 +72,16 @@ export class PreordersController {
     return this.preordersService.getAdminSummary(tenantId);
   }
 
+  @Get('admin/campaigns/:itemId/summary')
+  @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
+  @Roles(ShopRole.shop_admin, ShopRole.shop_staff)
+  getCampaignItemSummary(
+    @Param('itemId') itemId: string,
+    @CurrentTenantId() tenantId: string,
+  ) {
+    return this.preordersService.getCampaignItemSummary(itemId, tenantId);
+  }
+
   @Get('admin/campaigns/:itemId/participants')
   @UseGuards(JwtAuthGuard, TenantGuard, RolesGuard)
   @Roles(ShopRole.shop_admin, ShopRole.shop_staff)

--- a/backend/src/preorders/preorders.service.ts
+++ b/backend/src/preorders/preorders.service.ts
@@ -637,4 +637,52 @@ export class PreordersService {
       },
     };
   }
+
+  async getCampaignItemSummary(itemId: string, tenantId: string) {
+    const shopId = this.requireActiveShopId(tenantId);
+
+    const activeStatuses = [
+      PreOrderStatus.PENDING_CONFIRMATION,
+      PreOrderStatus.WAITING_FOR_GOODS,
+      PreOrderStatus.ARRIVED,
+    ] as const;
+
+    const [grouped, cancelableCount, withDepositCount] = await Promise.all([
+      this.prisma.preOrder.groupBy({
+        by: ['status'],
+        where: { shop_id: shopId, item_id: itemId, status: { in: [...activeStatuses] } },
+        _count: { _all: true },
+      }),
+      this.prisma.preOrder.count({
+        where: {
+          shop_id: shopId,
+          item_id: itemId,
+          status: { in: [PreOrderStatus.PENDING_CONFIRMATION, PreOrderStatus.WAITING_FOR_GOODS] },
+          paid_amount: { equals: 0 },
+        },
+      }),
+      this.prisma.preOrder.count({
+        where: {
+          shop_id: shopId,
+          item_id: itemId,
+          status: { in: [PreOrderStatus.PENDING_CONFIRMATION, PreOrderStatus.WAITING_FOR_GOODS] },
+          paid_amount: { gt: 0 },
+        },
+      }),
+    ]);
+
+    const counts = { pending: 0, waiting: 0, arrived: 0 };
+    for (const row of grouped) {
+      if (row.status === PreOrderStatus.PENDING_CONFIRMATION) counts.pending = row._count._all;
+      if (row.status === PreOrderStatus.WAITING_FOR_GOODS) counts.waiting = row._count._all;
+      if (row.status === PreOrderStatus.ARRIVED) counts.arrived = row._count._all;
+    }
+
+    return {
+      ...counts,
+      total: counts.pending + counts.waiting + counts.arrived,
+      cancelable: cancelableCount,
+      with_deposit: withDepositCount,
+    };
+  }
 }

--- a/backend/src/public/dto/query-public-items.dto.ts
+++ b/backend/src/public/dto/query-public-items.dto.ts
@@ -16,8 +16,8 @@ export class QueryPublicItemsDto {
   page_size?: number = 20;
 
   @IsOptional()
-  @IsIn(['con_hang', 'giu_cho', 'da_ban'])
-  status?: 'con_hang' | 'giu_cho' | 'da_ban';
+  @IsIn(['con_hang', 'giu_cho', 'da_ban', 'preorder'])
+  status?: 'con_hang' | 'giu_cho' | 'da_ban' | 'preorder';
 
   @IsOptional()
   @IsString()

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -19,7 +19,7 @@
 - RBAC tenant: `shop_admin` có quyền đọc/ghi trong active shop; `shop_staff` hiện là read-only cho các HTTP method mutating (`POST`/`PATCH`/`DELETE`) trừ route nào được đánh dấu exception trong code.
 
 ## Data shape
-- `ItemStatus`: `"con_hang" | "giu_cho" | "da_ban" | "preorder"`. Transition rules: `con_hang`/`giu_cho` → any; `da_ban` → `con_hang` only (re-stock); `preorder` → `con_hang` only. `da_ban → preorder` và `da_ban → giu_cho` bị chặn.
+- `ItemStatus`: `"con_hang" | "giu_cho" | "da_ban" | "preorder"`. Transition rules: `con_hang`/`giu_cho` → any; `da_ban` → `con_hang` only (re-stock, tự set quantity=1); `da_ban → preorder`/`giu_cho` bị chặn; `preorder` → `con_hang` (hàng về, tự trigger cập nhật đơn `WAITING_FOR_GOODS→ARRIVED`) hoặc `preorder` → `da_ban` (nhà cung cấp hủy, quantity=0).
 - `Item`: `{ id, shop_id?, name, description, scale, brand, car_brand, model_brand, condition, price, original_price, status: ItemStatus, quantity, attributes, notes?, is_public, fb_post_content, cover_image_url, fb_post_url?, fb_posted_at?, fb_posts_count?, created_at, updated_at, deleted_at? }`.
 - `attributes`: object phẳng `Record<string, string | number | boolean | null>`, tối đa 50 key, key phải được trim và không được dùng các tên dự phòng như `__proto__`, `constructor`, `prototype`.
 - `FacebookPost`: `{ id, item_id, post_url, content, posted_at, created_at }`.
@@ -230,6 +230,8 @@ Các route dưới đây yêu cầu JWT đã gắn **active shop** (`active_shop
 - Khi PATCH chuyển hoặc đặt `status = "da_ban"`, server ghi `quantity = 0` (bỏ qua `quantity` khác 0 trong body nếu có).
 - Khi item đã `da_ban` và body **không** gửi `quantity`, server có thể **không** cập nhật cột `quantity` trong DB (vẫn 0); nếu body có `quantity`, server vẫn ép về `0` trước khi lưu.
 - Khi PATCH chuyển `status` từ `da_ban` sang `con_hang` mà body **không** gửi `quantity`, server tự động set `quantity = 1`.
+- Khi PATCH chuyển `status` từ `preorder` sang `con_hang`, server tự động cập nhật tất cả đơn pre-order của item đang ở `WAITING_FOR_GOODS` sang `ARRIVED` (trong cùng transaction).
+- Khi PATCH chuyển `status` từ `preorder` sang `da_ban` (nhà cung cấp hủy), server ép `quantity = 0`. Không auto-cancel các đơn pre-order (admin xử lý thủ công từng đơn).
 - Transition không hợp lệ (ví dụ `da_ban → preorder`) trả về `ITEM_STATUS_TRANSITION_INVALID (422)`.
 - Response 200: `data: { item }`.
 - Errors: `VALIDATION_ERROR (422)`, `NOT_FOUND (404)`.

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -231,10 +231,9 @@ Các route dưới đây yêu cầu JWT đã gắn **active shop** (`active_shop
 - Khi item đã `da_ban` và body **không** gửi `quantity`, server có thể **không** cập nhật cột `quantity` trong DB (vẫn 0); nếu body có `quantity`, server vẫn ép về `0` trước khi lưu.
 - Khi PATCH chuyển `status` từ `da_ban` sang `con_hang` mà body **không** gửi `quantity`, server tự động set `quantity = 1`.
 - Khi PATCH chuyển `status` từ `preorder` sang `con_hang`, server tự động cập nhật tất cả đơn pre-order của item đang ở `WAITING_FOR_GOODS` sang `ARRIVED` (trong cùng transaction).
-- Khi PATCH chuyển `status` từ `preorder` sang `da_ban` (nhà cung cấp hủy), server ép `quantity = 0`. Không auto-cancel các đơn pre-order (admin xử lý thủ công từng đơn).
+- Khi PATCH chuyển `status` từ `preorder` sang `da_ban` (nhà cung cấp hủy): server ép `quantity = 0`, tự động hủy các đơn có `paid_amount = 0` (chưa thu cọc) sang `CANCELLED`. Các đơn đã có cọc (`paid_amount > 0`) giữ nguyên để admin xử lý thủ công.
 - Transition không hợp lệ (ví dụ `da_ban → preorder`) trả về `ITEM_STATUS_TRANSITION_INVALID (422)`.
-- Response 200: `data: { item }`.
-- Errors: `VALIDATION_ERROR (422)`, `NOT_FOUND (404)`.
+- Response 200: `data: { item, preorders_arrived_count: number, preorders_auto_cancelled_count: number, preorders_with_deposit_count: number }`. Các count field luôn có giá trị (0 nếu không có auto-trigger).
 
 ### POST /api/v1/items/:id/facebook-posts
 - Body JSON: `{ "post_url": "https://facebook.com/...", "content": "string (optional)" }`.

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -233,7 +233,16 @@ Các route dưới đây yêu cầu JWT đã gắn **active shop** (`active_shop
 - Khi PATCH chuyển `status` từ `preorder` sang `con_hang`, server tự động cập nhật tất cả đơn pre-order của item đang ở `WAITING_FOR_GOODS` sang `ARRIVED` (trong cùng transaction).
 - Khi PATCH chuyển `status` từ `preorder` sang `da_ban` (nhà cung cấp hủy): server ép `quantity = 0`, tự động hủy các đơn có `paid_amount = 0` (chưa thu cọc) sang `CANCELLED`. Các đơn đã có cọc (`paid_amount > 0`) giữ nguyên để admin xử lý thủ công.
 - Transition không hợp lệ (ví dụ `da_ban → preorder`) trả về `ITEM_STATUS_TRANSITION_INVALID (422)`.
-- Response 200: `data: { item, preorders_arrived_count: number, preorders_auto_cancelled_count: number, preorders_with_deposit_count: number }`. Các count field luôn có giá trị (0 nếu không có auto-trigger).
+- Response 200: `data: { item, preorders_arrived_count: number, preorders_pending_count: number, preorders_auto_cancelled_count: number, preorders_with_deposit_count: number }`. Các count field luôn có giá trị (0 nếu không có auto-trigger). `preorders_pending_count` là số đơn `PENDING_CONFIRMATION` còn lại sau khi `preorder → con_hang` (không bị auto-advance, cần xử lý thủ công).
+
+### GET /api/v1/preorders/admin/campaigns/:itemId/summary
+- Auth: JWT + active shop (shop_admin hoặc shop_staff).
+- Response 200: `data: { pending: number, waiting: number, arrived: number, total: number, cancelable: number, with_deposit: number }`.
+  - `pending`: đơn `PENDING_CONFIRMATION`; `waiting`: đơn `WAITING_FOR_GOODS`; `arrived`: đơn `ARRIVED`.
+  - `total`: tổng ba trạng thái trên.
+  - `cancelable`: đơn `PENDING_CONFIRMATION | WAITING_FOR_GOODS` có `paid_amount = 0` (sẽ bị tự hủy nếu item chuyển sang `da_ban`).
+  - `with_deposit`: đơn `PENDING_CONFIRMATION | WAITING_FOR_GOODS` có `paid_amount > 0` (cần xử lý thủ công).
+- Dùng để hiển thị campaign widget trong admin item detail và populate modal xác nhận trước `preorder → da_ban`.
 
 ### POST /api/v1/items/:id/facebook-posts
 - Body JSON: `{ "post_url": "https://facebook.com/...", "content": "string (optional)" }`.

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -19,7 +19,8 @@
 - RBAC tenant: `shop_admin` có quyền đọc/ghi trong active shop; `shop_staff` hiện là read-only cho các HTTP method mutating (`POST`/`PATCH`/`DELETE`) trừ route nào được đánh dấu exception trong code.
 
 ## Data shape
-- `Item`: `{ id, shop_id?, name, description, scale, brand, car_brand, model_brand, condition, price, original_price, status, quantity, attributes, notes?, is_public, fb_post_content, cover_image_url, fb_post_url?, fb_posted_at?, fb_posts_count?, created_at, updated_at, deleted_at? }`.
+- `ItemStatus`: `"con_hang" | "giu_cho" | "da_ban" | "preorder"`. Transition rules: `con_hang`/`giu_cho` → any; `da_ban` → `con_hang` only (re-stock); `preorder` → `con_hang` only. `da_ban → preorder` và `da_ban → giu_cho` bị chặn.
+- `Item`: `{ id, shop_id?, name, description, scale, brand, car_brand, model_brand, condition, price, original_price, status: ItemStatus, quantity, attributes, notes?, is_public, fb_post_content, cover_image_url, fb_post_url?, fb_posted_at?, fb_posts_count?, created_at, updated_at, deleted_at? }`.
 - `attributes`: object phẳng `Record<string, string | number | boolean | null>`, tối đa 50 key, key phải được trim và không được dùng các tên dự phòng như `__proto__`, `constructor`, `prototype`.
 - `FacebookPost`: `{ id, item_id, post_url, content, posted_at, created_at }`.
 - `User`: `{ id, email, full_name, role, platform_role?, is_active?, allowed_shop_ids: string[], shop_roles?, allowed_shops?, active_shop_id? }`.
@@ -205,7 +206,7 @@ Các route dưới đây yêu cầu JWT đã gắn **active shop** (`active_shop
     "is_public": false
   }
   ```
-- `quantity` là integer `>= 0`. Nếu `status = "da_ban"` server sẽ ép `quantity = 0` bất kể payload gửi lên.
+- `quantity` là integer `>= 0`. Nếu `status = "da_ban"` server sẽ ép `quantity = 0` bất kể payload gửi lên. Nếu `status = "preorder"` quantity giữ nguyên giá trị yêu cầu (không ép về 0).
 - `attributes` là object phẳng; nested object/array không hợp lệ.
 - Response 201: `data: { item }` (images/spin_sets rỗng).
 - Errors: `VALIDATION_ERROR (422)`.
@@ -225,9 +226,11 @@ Các route dưới đây yêu cầu JWT đã gắn **active shop** (`active_shop
 
 ### PATCH /api/v1/items/:id
 - Body JSON: các field cho phép cập nhật `name/description/scale/brand/car_brand/model_brand/condition/price/original_price/status/quantity/attributes/is_public/fb_post_content`.
-- Invariant: item `da_ban` luôn có `quantity = 0` trong mọi response (GET/PATCH); client không thể giữ stock > 0 khi đã bán.
+- Invariant: item `da_ban` luôn có `quantity = 0`; client không thể giữ stock > 0 khi đã bán.
 - Khi PATCH chuyển hoặc đặt `status = "da_ban"`, server ghi `quantity = 0` (bỏ qua `quantity` khác 0 trong body nếu có).
 - Khi item đã `da_ban` và body **không** gửi `quantity`, server có thể **không** cập nhật cột `quantity` trong DB (vẫn 0); nếu body có `quantity`, server vẫn ép về `0` trước khi lưu.
+- Khi PATCH chuyển `status` từ `da_ban` sang `con_hang` mà body **không** gửi `quantity`, server tự động set `quantity = 1`.
+- Transition không hợp lệ (ví dụ `da_ban → preorder`) trả về `ITEM_STATUS_TRANSITION_INVALID (422)`.
 - Response 200: `data: { item }`.
 - Errors: `VALIDATION_ERROR (422)`, `NOT_FOUND (404)`.
 

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -15,7 +15,7 @@ Tài liệu này phản ánh `backend/prisma/schema.prisma` hiện tại. Runtim
 
 | Enum | Values |
 |------|--------|
-| `ItemStatus` | `con_hang`, `giu_cho`, `da_ban` |
+| `ItemStatus` | `con_hang`, `giu_cho`, `da_ban`, `preorder` |
 | `PlatformRole` | `platform_super` |
 | `ShopRole` | `shop_admin` (default), `shop_staff`; `super_admin` là giá trị legacy từ trước khi có RBAC đa cấp — không gán mới, chỉ tồn tại do backward-compat |
 | `ShopAuditAction` | `add_shop_admin`, `reset_member_password`, `set_member_active`, `update_shop`, `deactivate_shop`, `activate_shop`, `set_platform_role`, `set_shop_member_role` |

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -80,6 +80,7 @@
 - Public catalog: chỉ hiển thị item `is_public = true` và chưa bị soft delete; trạng thái hiển thị nguyên giá trị (`con_hang/giu_cho/da_ban`). Production yêu cầu `shop_id` hoặc JWT có active shop để tránh aggregate nhiều shop.
 - Social selling: UI cần cung cấp thao tác copy caption/link dựa trên dữ liệu item (không thay đổi dữ liệu gốc).
 - Pre-order: lifecycle phải đi qua state machine; không cập nhật trạng thái tùy ý.
+- Item status transition rules: `con_hang`/`giu_cho`/`da_ban` → `preorder` (bất kỳ trạng thái nào đều cho phép chuyển sang `preorder`); `preorder` → `con_hang` (chỉ được chuyển về `con_hang`). Quantity không bị ép về 0 khi chuyển sang `preorder` (khác với `da_ban`). Inventory transactions được phép trên item `preorder`.
 - Member points: mọi thay đổi điểm phải đi qua ledger để có audit trail.
 - QR code:
   - Token chỉ được tạo nếu item thuộc về tenant đang request (TenantGuard enforcement).

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -80,7 +80,7 @@
 - Public catalog: chỉ hiển thị item `is_public = true` và chưa bị soft delete; trạng thái hiển thị nguyên giá trị (`con_hang/giu_cho/da_ban`). Production yêu cầu `shop_id` hoặc JWT có active shop để tránh aggregate nhiều shop.
 - Social selling: UI cần cung cấp thao tác copy caption/link dựa trên dữ liệu item (không thay đổi dữ liệu gốc).
 - Pre-order: lifecycle phải đi qua state machine; không cập nhật trạng thái tùy ý.
-- Item status transition rules: `con_hang`/`giu_cho` → `preorder` (được phép chuyển sang `preorder`); `da_ban` là terminal — không chuyển sang bất kỳ trạng thái nào khác kể cả `preorder`; `preorder` → `con_hang` (chỉ được chuyển về `con_hang`). Quantity không bị ép về 0 khi chuyển sang `preorder` (khác với `da_ban`). Inventory transactions được phép trên item `preorder`.
+- Item status transition rules: `con_hang`/`giu_cho` → `preorder` (được phép); `da_ban` → `con_hang` (được phép, dùng khi nhập lại hàng từ seller khác); `da_ban` → `preorder`/`giu_cho` không được phép; `preorder` → `con_hang` (chỉ được chuyển về `con_hang`). Quantity không bị ép về 0 khi chuyển sang `preorder` (khác với `da_ban`). Inventory transactions được phép trên item `preorder`.
 - Member points: mọi thay đổi điểm phải đi qua ledger để có audit trail.
 - QR code:
   - Token chỉ được tạo nếu item thuộc về tenant đang request (TenantGuard enforcement).

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -80,7 +80,7 @@
 - Public catalog: chỉ hiển thị item `is_public = true` và chưa bị soft delete; trạng thái hiển thị nguyên giá trị (`con_hang/giu_cho/da_ban`). Production yêu cầu `shop_id` hoặc JWT có active shop để tránh aggregate nhiều shop.
 - Social selling: UI cần cung cấp thao tác copy caption/link dựa trên dữ liệu item (không thay đổi dữ liệu gốc).
 - Pre-order: lifecycle phải đi qua state machine; không cập nhật trạng thái tùy ý.
-- Item status transition rules: `con_hang`/`giu_cho`/`da_ban` → `preorder` (bất kỳ trạng thái nào đều cho phép chuyển sang `preorder`); `preorder` → `con_hang` (chỉ được chuyển về `con_hang`). Quantity không bị ép về 0 khi chuyển sang `preorder` (khác với `da_ban`). Inventory transactions được phép trên item `preorder`.
+- Item status transition rules: `con_hang`/`giu_cho` → `preorder` (được phép chuyển sang `preorder`); `da_ban` là terminal — không chuyển sang bất kỳ trạng thái nào khác kể cả `preorder`; `preorder` → `con_hang` (chỉ được chuyển về `con_hang`). Quantity không bị ép về 0 khi chuyển sang `preorder` (khác với `da_ban`). Inventory transactions được phép trên item `preorder`.
 - Member points: mọi thay đổi điểm phải đi qua ledger để có audit trail.
 - QR code:
   - Token chỉ được tạo nếu item thuộc về tenant đang request (TenantGuard enforcement).

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -9,7 +9,7 @@
 ### Item
 - Mẫu xe diecast thuộc một shop; thuộc tính chính: `id (uuid)`, `shop_id`, `name`, `description`, `scale` (mặc định "1:64"), `brand` (tùy chọn), `car_brand`, `model_brand`, `condition`, `price`, `original_price`, `status`, `quantity`, `attributes`, `notes`, `is_public`, `fb_post_content` (nội dung bài FB), `qr_token` (token QR định danh; NULL cho đến khi admin tạo mã QR lần đầu), `created_at`, `updated_at`, `deleted_at` (soft delete).
 - Quan hệ: nhiều `ItemImage`, nhiều `SpinSet`; duy nhất 1 `SpinSet` được gắn cờ `is_default`.
-- Giá trị trạng thái: `con_hang`, `giu_cho`, `da_ban` (lưu ý khi hiển thị catalog/sao chép caption).
+- Giá trị trạng thái: `con_hang`, `giu_cho`, `da_ban`, `preorder` (item đang trong giai đoạn pre-order, chưa về hàng; hiển thị trên trang `/preorders` công khai) (lưu ý khi hiển thị catalog/sao chép caption).
 - Ảnh cover lấy từ `ItemImage.is_cover = true`, fallback ảnh đầu tiên theo `display_order`.
 
 ### ItemImage

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -80,7 +80,7 @@
 - Public catalog: chỉ hiển thị item `is_public = true` và chưa bị soft delete; trạng thái hiển thị nguyên giá trị (`con_hang/giu_cho/da_ban/preorder`). Production yêu cầu `shop_id` hoặc JWT có active shop để tránh aggregate nhiều shop.
 - Social selling: UI cần cung cấp thao tác copy caption/link dựa trên dữ liệu item (không thay đổi dữ liệu gốc).
 - Pre-order: lifecycle phải đi qua state machine; không cập nhật trạng thái tùy ý.
-- Item status transition rules: `con_hang`/`giu_cho` → `preorder` (được phép); `da_ban` → `con_hang` (được phép, dùng khi nhập lại hàng từ seller khác); `da_ban` → `preorder`/`giu_cho` không được phép; `preorder` → `con_hang` (chỉ được chuyển về `con_hang`). Quantity không bị ép về 0 khi chuyển sang `preorder` (khác với `da_ban`). Inventory transactions được phép trên item `preorder`.
+- Item status transition rules: `con_hang`/`giu_cho` → `preorder`/`da_ban`/nhau (được phép); `da_ban` → `con_hang` (nhập lại hàng, server tự set quantity=1 nếu không gửi); `da_ban` → `preorder`/`giu_cho` không được phép; `preorder` → `con_hang` (hàng về, tự động cập nhật các đơn `WAITING_FOR_GOODS → ARRIVED`); `preorder` → `da_ban` (nhà cung cấp hủy mẫu, đặt quantity=0). Quantity không bị ép về 0 khi chuyển sang `preorder`. Inventory transactions được phép trên item `preorder`.
 - Member points: mọi thay đổi điểm phải đi qua ledger để có audit trail.
 - QR code:
   - Token chỉ được tạo nếu item thuộc về tenant đang request (TenantGuard enforcement).

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -77,7 +77,7 @@
 - Ảnh thường:
   - Upload nhiều ảnh; có thể đổi cover và sắp xếp thứ tự.
   - Xóa ảnh phải cập nhật cover nếu ảnh cover bị xóa (chọn ảnh đầu tiên còn lại).
-- Public catalog: chỉ hiển thị item `is_public = true` và chưa bị soft delete; trạng thái hiển thị nguyên giá trị (`con_hang/giu_cho/da_ban`). Production yêu cầu `shop_id` hoặc JWT có active shop để tránh aggregate nhiều shop.
+- Public catalog: chỉ hiển thị item `is_public = true` và chưa bị soft delete; trạng thái hiển thị nguyên giá trị (`con_hang/giu_cho/da_ban/preorder`). Production yêu cầu `shop_id` hoặc JWT có active shop để tránh aggregate nhiều shop.
 - Social selling: UI cần cung cấp thao tác copy caption/link dựa trên dữ liệu item (không thay đổi dữ liệu gốc).
 - Pre-order: lifecycle phải đi qua state machine; không cập nhật trạng thái tùy ý.
 - Item status transition rules: `con_hang`/`giu_cho` → `preorder` (được phép); `da_ban` → `con_hang` (được phép, dùng khi nhập lại hàng từ seller khác); `da_ban` → `preorder`/`giu_cho` không được phép; `preorder` → `con_hang` (chỉ được chuyển về `con_hang`). Quantity không bị ép về 0 khi chuyển sang `preorder` (khác với `da_ban`). Inventory transactions được phép trên item `preorder`.

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -81,6 +81,10 @@
 - Social selling: UI cần cung cấp thao tác copy caption/link dựa trên dữ liệu item (không thay đổi dữ liệu gốc).
 - Pre-order: lifecycle phải đi qua state machine; không cập nhật trạng thái tùy ý.
 - Item status transition rules: `con_hang`/`giu_cho` → `preorder`/`da_ban`/nhau (được phép); `da_ban` → `con_hang` (nhập lại hàng, server tự set quantity=1 nếu không gửi); `da_ban` → `preorder`/`giu_cho` không được phép; `preorder` → `con_hang` (hàng về, tự động cập nhật các đơn `WAITING_FOR_GOODS → ARRIVED`); `preorder` → `da_ban` (nhà cung cấp hủy mẫu, đặt quantity=0). Quantity không bị ép về 0 khi chuyển sang `preorder`. Inventory transactions được phép trên item `preorder`.
+- Item status transition decisions:
+  - `PENDING_CONFIRMATION` khi `preorder → con_hang`: **không** tự động advance. Lý do: đơn chưa được shop xác nhận nên admin phải xem xét thủ công. Response trả `preorders_pending_count` để UI cảnh báo.
+  - Đơn đã cọc (`paid_amount > 0`) khi `preorder → da_ban`: **không** tự động hủy. Lý do: đã thu tiền khách, phải liên hệ hoàn tiền thủ công. Nếu sau đó admin làm `da_ban → con_hang`, các đơn này giữ nguyên trạng thái.
+  - `giu_cho → preorder`: được phép. Admin có thể mở campaign cho item đang reserved. Không có guard tự động — admin tự kiểm tra holds trước khi chuyển.
 - Member points: mọi thay đổi điểm phải đi qua ledger để có audit trail.
 - QR code:
   - Token chỉ được tạo nếu item thuộc về tenant đang request (TenantGuard enforcement).

--- a/docs/ROLLBACK_PREORDER_STATUS.md
+++ b/docs/ROLLBACK_PREORDER_STATUS.md
@@ -1,0 +1,38 @@
+# Rollback Plan: preorder ItemStatus
+
+## Bối cảnh
+
+Migration `20260522000000_add_preorder_item_status` đã chạy lệnh:
+```sql
+ALTER TYPE "ItemStatus" ADD VALUE 'preorder';
+```
+
+## Giới hạn kỹ thuật
+
+`ALTER TYPE ... ADD VALUE` **không thể rollback** bằng down migration trên PostgreSQL.
+PostgreSQL không có lệnh `DROP VALUE` từ enum đã có dữ liệu.
+
+## Phương án A — Feature flag (nhanh, không cần DB change, khuyến nghị trước)
+
+1. Deploy hotfix ẩn `preorder` khỏi status dropdown trong `ItemDetailPage.tsx` và `ItemsTable.tsx`
+2. Xóa `preorder` khỏi `ALLOWED_STATUS_TRANSITIONS` trong `items.service.ts`
+3. Kết quả: không có item mới nào có thể reach trạng thái `preorder`
+4. Thời gian deploy: ~10 phút
+
+## Phương án B — Data migration + type recreation (triệt để, cần maintenance window)
+
+1. Chạy data migration: `UPDATE "Item" SET status = 'con_hang' WHERE status = 'preorder'`
+2. `ALTER TABLE "Item" ALTER COLUMN status TYPE text`
+3. `DROP TYPE "ItemStatus"`
+4. `CREATE TYPE "ItemStatus" AS ENUM ('con_hang', 'giu_cho', 'da_ban')`
+5. `ALTER TABLE "Item" ALTER COLUMN status TYPE "ItemStatus" USING status::"ItemStatus"`
+6. Tạo Prisma migration mới phản ánh schema sau khi drop `preorder`
+7. Ước tính downtime: 5–15 phút tuỳ table size
+
+## Khuyến nghị
+
+Áp **Phương án A** trước để mua thời gian điều tra, sau đó lên kế hoạch **Phương án B** có maintenance window được thông báo.
+
+## Liên hệ
+
+Nếu có item đang ở `preorder` status khi incident xảy ra, phải notify admin của shop trước khi force-migrate về `con_hang`.

--- a/frontend/src/components/catalog/ItemCard.tsx
+++ b/frontend/src/components/catalog/ItemCard.tsx
@@ -18,7 +18,7 @@ interface ItemCardProps {
 
 export const ItemCard = ({ item, index = 0, shopSearch = '' }: ItemCardProps) => {
   const statusText =
-    item.status === 'con_hang' ? 'Còn hàng' : item.status === 'giu_cho' ? 'Giữ chỗ' : 'Đã bán';
+    item.status === 'con_hang' ? 'Còn hàng' : item.status === 'giu_cho' ? 'Giữ chỗ' : item.status === 'preorder' ? 'Pre-order' : 'Đã bán';
 
   const conditionText = item.condition === 'new' ? 'Mới' : item.condition === 'old' ? 'Cũ' : null;
 

--- a/frontend/src/constants/item.ts
+++ b/frontend/src/constants/item.ts
@@ -2,10 +2,11 @@
  * Shared item status labels and colors
  * Used in ItemsTable, FacebookPostsPage, etc.
  */
-export type ItemStatus = 'con_hang' | 'giu_cho' | 'da_ban';
+export type ItemStatus = 'con_hang' | 'giu_cho' | 'da_ban' | 'preorder';
 
 export const ITEM_STATUS_LABELS: Record<ItemStatus, { text: string; color: string }> = {
   con_hang: { text: 'Còn hàng', color: '#28a745' },
   giu_cho: { text: 'Giữ chỗ', color: '#ffc107' },
   da_ban: { text: 'Đã bán', color: '#6c757d' },
+  preorder: { text: 'Pre-order', color: '#0d6efd' },
 };

--- a/frontend/src/pages/PublicItemDetailPage.tsx
+++ b/frontend/src/pages/PublicItemDetailPage.tsx
@@ -260,13 +260,17 @@ export const PublicItemDetailPage = () => {
                         ? "#d4edda"
                         : item.status === "giu_cho"
                           ? "#fff3cd"
-                          : "#f8d7da",
+                          : item.status === "preorder"
+                            ? "#cfe2ff"
+                            : "#f8d7da",
                     color:
                       item.status === "con_hang"
                         ? "#155724"
                         : item.status === "giu_cho"
                           ? "#856404"
-                          : "#721c24",
+                          : item.status === "preorder"
+                            ? "#084298"
+                            : "#721c24",
                     borderRadius: "6px",
                     fontSize: "14px",
                     fontWeight: "600",
@@ -276,7 +280,9 @@ export const PublicItemDetailPage = () => {
                     ? "Còn hàng"
                     : item.status === "giu_cho"
                       ? "Giữ chỗ"
-                      : "Đã bán"}
+                      : item.status === "preorder"
+                        ? "Pre-order"
+                        : "Đã bán"}
                 </span>
               </div>
 

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -1382,7 +1382,7 @@ export const ItemDetailPage = () => {
               <ArrowLeft size={18} />
               <span>Quay lại danh sách</span>
             </button>
-            {id !== "new" && (
+            {id && id !== "new" && (
               <Link
                 to={`/admin/preorders/create?item_id=${encodeURIComponent(id)}`}
                 style={{

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -479,6 +479,30 @@ export const ItemDetailPage = () => {
     enabled: Boolean(activeShopId),
   });
 
+  // Campaign summary: active preorders for this item (fetch only for existing items)
+  const { data: campaignData } = useQuery({
+    queryKey: ["preorder-campaign", id],
+    queryFn: async () => {
+      const response = (await apiClient.get(
+        `/preorders?item_id=${encodeURIComponent(id!)}&page_size=200`,
+      )) as ApiResponse<{ preorders: { status: string }[]; total: number }>;
+      return response.data;
+    },
+    enabled: Boolean(id && id !== "new"),
+    staleTime: 30_000,
+  });
+
+  const campaignCounts = useMemo(() => {
+    const orders = campaignData?.preorders ?? [];
+    return {
+      pending: orders.filter((o) => o.status === "PENDING_CONFIRMATION").length,
+      waiting: orders.filter((o) => o.status === "WAITING_FOR_GOODS").length,
+      arrived: orders.filter((o) => o.status === "ARRIVED").length,
+    };
+  }, [campaignData]);
+
+  const hasCampaignOrders = campaignCounts.pending + campaignCounts.waiting + campaignCounts.arrived > 0;
+
   // Derive active-only lists for dropdowns (in-memory filter, no extra API call)
   const activeCarBrands = useMemo(
     () => (carBrandsData?.categories || []).filter((c) => c.is_active),
@@ -726,6 +750,22 @@ export const ItemDetailPage = () => {
             }
           }, 300);
         }, 3000);
+      }
+
+      // Show preorder auto-trigger feedback
+      const respData = (response as { data?: Record<string, number> })?.data;
+      const arrivedCount = respData?.preorders_arrived_count ?? 0;
+      const autoCancelledCount = respData?.preorders_auto_cancelled_count ?? 0;
+      const withDepositCount = respData?.preorders_with_deposit_count ?? 0;
+
+      if (arrivedCount > 0) {
+        showToast(`Đã tự động chuyển ${arrivedCount} đơn pre-order sang "Hàng về"`);
+      }
+      if (autoCancelledCount > 0 || withDepositCount > 0) {
+        const parts: string[] = [];
+        if (autoCancelledCount > 0) parts.push(`tự động hủy ${autoCancelledCount} đơn chưa cọc`);
+        if (withDepositCount > 0) parts.push(`${withDepositCount} đơn đã cọc cần hủy thủ công`);
+        showToast(`Pre-order: ${parts.join(" · ")}.`);
       }
 
       if (id === "new" && variables?.navigateAfterCreate) {
@@ -2012,6 +2052,38 @@ export const ItemDetailPage = () => {
               mobile={isMobile}
               fullWidthOnMobile
             />
+            {hasCampaignOrders && (
+              <div
+                style={{
+                  marginTop: "8px",
+                  padding: "8px 12px",
+                  background: "#f0f7ff",
+                  border: "1px solid #b6d4fe",
+                  borderRadius: "6px",
+                  fontSize: "13px",
+                  color: "#084298",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: "8px",
+                }}
+              >
+                <span>
+                  📋 Chiến dịch:{" "}
+                  {campaignCounts.pending > 0 && <strong>{campaignCounts.pending} chờ xác nhận</strong>}
+                  {campaignCounts.pending > 0 && campaignCounts.waiting > 0 && " · "}
+                  {campaignCounts.waiting > 0 && <strong>{campaignCounts.waiting} chờ hàng</strong>}
+                  {(campaignCounts.pending > 0 || campaignCounts.waiting > 0) && campaignCounts.arrived > 0 && " · "}
+                  {campaignCounts.arrived > 0 && <strong>{campaignCounts.arrived} hàng về</strong>}
+                </span>
+                <Link
+                  to={`/admin/preorders?item_id=${encodeURIComponent(id!)}`}
+                  style={{ color: "#0d6efd", textDecoration: "none", whiteSpace: "nowrap", fontWeight: 500 }}
+                >
+                  Quản lý →
+                </Link>
+              </div>
+            )}
           </div>
           <div style={{ marginBottom: "16px" }}>
             <label

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -770,16 +770,16 @@ export const ItemDetailPage = () => {
       const withDepositCount = respData?.preorders_with_deposit_count ?? 0;
 
       if (arrivedCount > 0) {
-        showToast(`Đã tự động chuyển ${arrivedCount} đơn pre-order sang "Hàng về".`);
+        showToast(`Đã tự động chuyển ${arrivedCount} đơn pre-order sang "Hàng về"`);
       }
       if (pendingCount > 0) {
         showToast(`Còn ${pendingCount} đơn chờ xác nhận cần xử lý thủ công.`);
       }
-      if (autoCancelledCount > 0) {
-        showToast(`Đã hủy ${autoCancelledCount} đơn pre-order chưa cọc.`);
-      }
-      if (withDepositCount > 0) {
-        showToast(`${withDepositCount} đơn đã cọc đang chờ xử lý hoàn tiền.`);
+      if (autoCancelledCount > 0 || withDepositCount > 0) {
+        const parts: string[] = [];
+        if (autoCancelledCount > 0) parts.push(`tự động hủy ${autoCancelledCount} đơn chưa cọc`);
+        if (withDepositCount > 0) parts.push(`${withDepositCount} đơn đã cọc cần hủy thủ công`);
+        showToast(`Pre-order: ${parts.join(' · ')}.`);
       }
 
       if (id === "new" && variables?.navigateAfterCreate) {

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -6,7 +6,7 @@ import {
   useCallback,
   type KeyboardEvent,
 } from "react";
-import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams, Link } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient, uploadFile } from "../../api/client";
 import { ArrowLeft, Edit, Plus, X, Star, Sparkles } from "lucide-react";
@@ -1382,6 +1382,37 @@ export const ItemDetailPage = () => {
               <ArrowLeft size={18} />
               <span>Quay lại danh sách</span>
             </button>
+            {id !== "new" && (
+              <Link
+                to={`/admin/preorders/create?item_id=${encodeURIComponent(id)}`}
+                style={{
+                  padding: "8px 16px",
+                  border: "1px solid #ddd",
+                  borderRadius: "8px",
+                  background: "white",
+                  color: "#333",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  fontSize: "14px",
+                  fontWeight: "500",
+                  textDecoration: "none",
+                  transition: "all 0.2s",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = "#f5f5f5";
+                  e.currentTarget.style.borderColor = "#f59e0b";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = "white";
+                  e.currentTarget.style.borderColor = "#ddd";
+                }}
+              >
+                <span aria-hidden>⏳</span>
+                <span>Chiến dịch Pre-order</span>
+              </Link>
+            )}
           </div>
           <div
             className="item-detail-header-row"

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -673,6 +673,7 @@ export const ItemDetailPage = () => {
       const itemId = id === "new" ? extractItemIdFromResponse(response) : id;
       if (itemId) {
         queryClient.invalidateQueries({ queryKey: ["item", itemId] });
+        queryClient.invalidateQueries({ queryKey: ["preorder-campaign", itemId] });
       }
       if (id === "new" && !itemId) {
         showToast("Không thể tạo sản phẩm. Vui lòng thử lại.");

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -1599,6 +1599,7 @@ export const ItemDetailPage = () => {
                   Hủy bỏ
                 </button>
                 <button
+                  disabled={saveMutation.isPending}
                   onClick={() => {
                     setConfirmDaBanOpen(false);
                     void saveCurrentItem(false, true);
@@ -1609,9 +1610,10 @@ export const ItemDetailPage = () => {
                     borderRadius: "8px",
                     background: "#dc3545",
                     color: "white",
-                    cursor: "pointer",
+                    cursor: saveMutation.isPending ? "not-allowed" : "pointer",
                     fontSize: "14px",
                     fontWeight: 600,
+                    opacity: saveMutation.isPending ? 0.6 : 1,
                   }}
                 >
                   Xác nhận chuyển Đã bán

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -179,7 +179,7 @@ interface SpinSet {
 interface ItemData {
   name: string;
   description?: string;
-  status?: "con_hang" | "giu_cho" | "da_ban";
+  status?: "con_hang" | "giu_cho" | "da_ban" | "preorder";
   is_public?: boolean;
   car_brand?: string;
   model_brand?: string;
@@ -739,7 +739,7 @@ export const ItemDetailPage = () => {
     const itemData: ItemData = {
       name,
       description,
-      status: status as "con_hang" | "giu_cho" | "da_ban",
+      status: status as "con_hang" | "giu_cho" | "da_ban" | "preorder",
       is_public: isPublic,
     };
 
@@ -2004,8 +2004,9 @@ export const ItemDetailPage = () => {
                 { value: "con_hang", label: "Còn hàng", minWidth: "70px" },
                 { value: "giu_cho", label: "Giữ chỗ", minWidth: "70px" },
                 { value: "da_ban", label: "Đã bán", minWidth: "70px" },
+                { value: "preorder", label: "Pre-order", minWidth: "70px" },
               ]}
-              value={status as "con_hang" | "giu_cho" | "da_ban"}
+              value={status as "con_hang" | "giu_cho" | "da_ban" | "preorder"}
               onChange={(next) => setStatus(next)}
               mobile={isMobile}
               fullWidthOnMobile

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -763,7 +763,7 @@ export const ItemDetailPage = () => {
       }
 
       // Show preorder auto-trigger feedback
-      const respData = (response as ApiResponse<UpdateItemResponse>)?.data;
+      const respData = (response as unknown as ApiResponse<UpdateItemResponse>)?.data;
       const arrivedCount = respData?.preorders_arrived_count ?? 0;
       const pendingCount = respData?.preorders_pending_count ?? 0;
       const autoCancelledCount = respData?.preorders_auto_cancelled_count ?? 0;

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -15,7 +15,7 @@ import { CategoryQuickManage } from "../../components/admin/CategoryQuickManage"
 import { InventoryTimeline } from "../../components/admin/InventoryTimeline";
 import type { CategoryItem, ApiResponse } from "../../types/category";
 import { showToast } from "../../utils/toast";
-import type { FacebookPost } from "../../types/item.types";
+import type { FacebookPost, ItemStatus } from "../../types/item.types";
 import {
   jumpToStepWithAutoSave,
   navigateStepWithAutoSave,
@@ -179,7 +179,7 @@ interface SpinSet {
 interface ItemData {
   name: string;
   description?: string;
-  status?: "con_hang" | "giu_cho" | "da_ban" | "preorder";
+  status?: ItemStatus;
   is_public?: boolean;
   car_brand?: string;
   model_brand?: string;
@@ -739,7 +739,7 @@ export const ItemDetailPage = () => {
     const itemData: ItemData = {
       name,
       description,
-      status: status as "con_hang" | "giu_cho" | "da_ban" | "preorder",
+      status: status as ItemStatus,
       is_public: isPublic,
     };
 
@@ -2006,7 +2006,7 @@ export const ItemDetailPage = () => {
                 { value: "da_ban", label: "Đã bán", minWidth: "70px" },
                 { value: "preorder", label: "Pre-order", minWidth: "70px" },
               ]}
-              value={status as "con_hang" | "giu_cho" | "da_ban" | "preorder"}
+              value={status as ItemStatus}
               onChange={(next) => setStatus(next)}
               mobile={isMobile}
               fullWidthOnMobile

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -15,7 +15,8 @@ import { CategoryQuickManage } from "../../components/admin/CategoryQuickManage"
 import { InventoryTimeline } from "../../components/admin/InventoryTimeline";
 import type { CategoryItem, ApiResponse } from "../../types/category";
 import { showToast } from "../../utils/toast";
-import type { FacebookPost, ItemStatus } from "../../types/item.types";
+import type { FacebookPost } from "../../types/item.types";
+import type { ItemStatus } from "../../constants/item";
 import {
   jumpToStepWithAutoSave,
   navigateStepWithAutoSave,

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -484,7 +484,7 @@ export const ItemDetailPage = () => {
     queryKey: ["preorder-campaign", id],
     queryFn: async () => {
       const response = (await apiClient.get(
-        `/preorders?item_id=${encodeURIComponent(id!)}&page_size=200`,
+        `/preorders/admin?item_id=${encodeURIComponent(id!)}&page_size=200`,
       )) as ApiResponse<{ preorders: { status: string }[]; total: number }>;
       return response.data;
     },

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -177,6 +177,23 @@ interface SpinSet {
   updated_at: string;
 }
 
+interface CampaignSummary {
+  pending: number;
+  waiting: number;
+  arrived: number;
+  total: number;
+  cancelable: number;
+  with_deposit: number;
+}
+
+interface UpdateItemResponse {
+  item: Record<string, unknown>;
+  preorders_arrived_count?: number;
+  preorders_pending_count?: number;
+  preorders_auto_cancelled_count?: number;
+  preorders_with_deposit_count?: number;
+}
+
 interface ItemData {
   name: string;
   description?: string;
@@ -416,6 +433,7 @@ export const ItemDetailPage = () => {
   const isLoadingQrRef = useRef(false);
   const [qrError, setQrError] = useState<string | null>(null);
   const [qrRetryKey, setQrRetryKey] = useState(0);
+  const [confirmDaBanOpen, setConfirmDaBanOpen] = useState(false);
 
   const socialSellingRef = useRef<HTMLDivElement>(null);
   const stepNavInFlightRef = useRef(false);
@@ -479,29 +497,20 @@ export const ItemDetailPage = () => {
     enabled: Boolean(activeShopId),
   });
 
-  // Campaign summary: active preorders for this item (fetch only for existing items)
-  const { data: campaignData } = useQuery({
-    queryKey: ["preorder-campaign", id],
+  const { data: campaignSummary } = useQuery({
+    queryKey: ["preorder-campaign-summary", id],
     queryFn: async () => {
-      const response = (await apiClient.get(
-        `/preorders/admin?item_id=${encodeURIComponent(id!)}&page_size=200`,
-      )) as ApiResponse<{ preorders: { status: string }[]; total: number }>;
-      return response.data;
+      const res = (await apiClient.get(
+        `/preorders/admin/campaigns/${encodeURIComponent(id!)}/summary`,
+      )) as ApiResponse<CampaignSummary>;
+      return res.data;
     },
-    enabled: Boolean(id && id !== "new"),
+    enabled: Boolean(id && id !== "new" && data?.item?.status === "preorder"),
     staleTime: 30_000,
   });
 
-  const campaignCounts = useMemo(() => {
-    const orders = campaignData?.preorders ?? [];
-    return {
-      pending: orders.filter((o) => o.status === "PENDING_CONFIRMATION").length,
-      waiting: orders.filter((o) => o.status === "WAITING_FOR_GOODS").length,
-      arrived: orders.filter((o) => o.status === "ARRIVED").length,
-    };
-  }, [campaignData]);
-
-  const hasCampaignOrders = campaignCounts.pending + campaignCounts.waiting + campaignCounts.arrived > 0;
+  const hasCampaignOrders =
+    data?.item?.status === "preorder" && (campaignSummary?.total ?? 0) > 0;
 
   // Derive active-only lists for dropdowns (in-memory filter, no extra API call)
   const activeCarBrands = useMemo(
@@ -673,7 +682,7 @@ export const ItemDetailPage = () => {
       const itemId = id === "new" ? extractItemIdFromResponse(response) : id;
       if (itemId) {
         queryClient.invalidateQueries({ queryKey: ["item", itemId] });
-        queryClient.invalidateQueries({ queryKey: ["preorder-campaign", itemId] });
+        queryClient.invalidateQueries({ queryKey: ["preorder-campaign-summary", itemId] });
       }
       if (id === "new" && !itemId) {
         showToast("Không thể tạo sản phẩm. Vui lòng thử lại.");
@@ -754,19 +763,23 @@ export const ItemDetailPage = () => {
       }
 
       // Show preorder auto-trigger feedback
-      const respData = (response as { data?: Record<string, number> })?.data;
+      const respData = (response as ApiResponse<UpdateItemResponse>)?.data;
       const arrivedCount = respData?.preorders_arrived_count ?? 0;
+      const pendingCount = respData?.preorders_pending_count ?? 0;
       const autoCancelledCount = respData?.preorders_auto_cancelled_count ?? 0;
       const withDepositCount = respData?.preorders_with_deposit_count ?? 0;
 
       if (arrivedCount > 0) {
-        showToast(`Đã tự động chuyển ${arrivedCount} đơn pre-order sang "Hàng về"`);
+        showToast(`Đã tự động chuyển ${arrivedCount} đơn pre-order sang "Hàng về".`);
       }
-      if (autoCancelledCount > 0 || withDepositCount > 0) {
-        const parts: string[] = [];
-        if (autoCancelledCount > 0) parts.push(`tự động hủy ${autoCancelledCount} đơn chưa cọc`);
-        if (withDepositCount > 0) parts.push(`${withDepositCount} đơn đã cọc cần hủy thủ công`);
-        showToast(`Pre-order: ${parts.join(" · ")}.`);
+      if (pendingCount > 0) {
+        showToast(`Còn ${pendingCount} đơn chờ xác nhận cần xử lý thủ công.`);
+      }
+      if (autoCancelledCount > 0) {
+        showToast(`Đã hủy ${autoCancelledCount} đơn pre-order chưa cọc.`);
+      }
+      if (withDepositCount > 0) {
+        showToast(`${withDepositCount} đơn đã cọc đang chờ xử lý hoàn tiền.`);
       }
 
       if (id === "new" && variables?.navigateAfterCreate) {
@@ -839,12 +852,21 @@ export const ItemDetailPage = () => {
     return true;
   };
 
-  const saveCurrentItem = async (silent = false): Promise<boolean> => {
+  const saveCurrentItem = async (silent = false, skipDaBanConfirm = false): Promise<boolean> => {
     if (!name.trim()) {
       showToast("Vui lòng nhập tên sản phẩm trước khi chuyển bước.");
       return false;
     }
     if (!validateInventoryBeforeSave()) {
+      return false;
+    }
+    if (
+      !skipDaBanConfirm &&
+      data?.item?.status === "preorder" &&
+      status === "da_ban" &&
+      (campaignSummary?.total ?? 0) > 0
+    ) {
+      setConfirmDaBanOpen(true);
       return false;
     }
     try {
@@ -1512,6 +1534,92 @@ export const ItemDetailPage = () => {
             </div>
           </div>
         </div>
+        {confirmDaBanOpen && campaignSummary && (
+          <div
+            style={{
+              position: "fixed",
+              inset: 0,
+              background: "rgba(0,0,0,0.45)",
+              zIndex: 9999,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <div
+              style={{
+                background: "white",
+                borderRadius: "12px",
+                padding: "24px",
+                maxWidth: "440px",
+                width: "90%",
+                boxShadow: "0 20px 60px rgba(0,0,0,0.25)",
+              }}
+            >
+              <h3 style={{ margin: "0 0 12px", fontSize: "17px", fontWeight: 700 }}>
+                Xác nhận chuyển sang "Đã bán"
+              </h3>
+              <p style={{ margin: "0 0 12px", fontSize: "14px", color: "#444" }}>
+                Hành động này sẽ:
+              </p>
+              <ul style={{ margin: "0 0 16px", paddingLeft: "20px", fontSize: "14px", lineHeight: "1.8" }}>
+                {campaignSummary.cancelable > 0 && (
+                  <li>
+                    Tự động hủy{" "}
+                    <strong>{campaignSummary.cancelable} đơn chưa cọc</strong>
+                  </li>
+                )}
+                {campaignSummary.with_deposit > 0 && (
+                  <li>
+                    <strong style={{ color: "#dc3545" }}>
+                      {campaignSummary.with_deposit} đơn đã cọc
+                    </strong>{" "}
+                    — cần liên hệ hoàn tiền thủ công
+                  </li>
+                )}
+                {campaignSummary.arrived > 0 && (
+                  <li>{campaignSummary.arrived} đơn "Hàng về" giữ nguyên</li>
+                )}
+              </ul>
+              <p style={{ margin: "0 0 20px", fontSize: "13px", color: "#888" }}>
+                Hành động này <strong>không thể hoàn tác</strong>. Tiếp tục?
+              </p>
+              <div style={{ display: "flex", gap: "10px", justifyContent: "flex-end" }}>
+                <button
+                  onClick={() => setConfirmDaBanOpen(false)}
+                  style={{
+                    padding: "8px 18px",
+                    border: "1px solid #ddd",
+                    borderRadius: "8px",
+                    background: "white",
+                    cursor: "pointer",
+                    fontSize: "14px",
+                  }}
+                >
+                  Hủy bỏ
+                </button>
+                <button
+                  onClick={() => {
+                    setConfirmDaBanOpen(false);
+                    void saveCurrentItem(false, true);
+                  }}
+                  style={{
+                    padding: "8px 18px",
+                    border: "none",
+                    borderRadius: "8px",
+                    background: "#dc3545",
+                    color: "white",
+                    cursor: "pointer",
+                    fontSize: "14px",
+                    fontWeight: 600,
+                  }}
+                >
+                  Xác nhận chuyển Đã bán
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         <div className="product-stepper">
           {PRODUCT_STEPS.map((step) => {
             const disabled = isNewItem && step.id > 1;
@@ -2053,7 +2161,7 @@ export const ItemDetailPage = () => {
               mobile={isMobile}
               fullWidthOnMobile
             />
-            {hasCampaignOrders && (
+            {hasCampaignOrders && campaignSummary && (
               <div
                 style={{
                   marginTop: "8px",
@@ -2065,24 +2173,37 @@ export const ItemDetailPage = () => {
                   color: "#084298",
                   display: "flex",
                   alignItems: "center",
-                  justifyContent: "space-between",
                   gap: "8px",
+                  flexWrap: "wrap",
                 }}
               >
-                <span>
-                  📋 Chiến dịch:{" "}
-                  {campaignCounts.pending > 0 && <strong>{campaignCounts.pending} chờ xác nhận</strong>}
-                  {campaignCounts.pending > 0 && campaignCounts.waiting > 0 && " · "}
-                  {campaignCounts.waiting > 0 && <strong>{campaignCounts.waiting} chờ hàng</strong>}
-                  {(campaignCounts.pending > 0 || campaignCounts.waiting > 0) && campaignCounts.arrived > 0 && " · "}
-                  {campaignCounts.arrived > 0 && <strong>{campaignCounts.arrived} hàng về</strong>}
-                </span>
-                <Link
-                  to={`/admin/preorders?item_id=${encodeURIComponent(id!)}`}
-                  style={{ color: "#0d6efd", textDecoration: "none", whiteSpace: "nowrap", fontWeight: 500 }}
-                >
-                  Quản lý →
-                </Link>
+                <span style={{ marginRight: "4px" }}>📋 Chiến dịch:</span>
+                {campaignSummary.pending > 0 && (
+                  <Link
+                    to={`/admin/preorders?item_id=${encodeURIComponent(id!)}&status=PENDING_CONFIRMATION`}
+                    style={{ color: "#084298", fontWeight: 600, textDecoration: "none" }}
+                  >
+                    {campaignSummary.pending} chờ xác nhận
+                  </Link>
+                )}
+                {campaignSummary.pending > 0 && campaignSummary.waiting > 0 && <span> · </span>}
+                {campaignSummary.waiting > 0 && (
+                  <Link
+                    to={`/admin/preorders?item_id=${encodeURIComponent(id!)}&status=WAITING_FOR_GOODS`}
+                    style={{ color: "#084298", fontWeight: 600, textDecoration: "none" }}
+                  >
+                    {campaignSummary.waiting} chờ hàng
+                  </Link>
+                )}
+                {(campaignSummary.pending > 0 || campaignSummary.waiting > 0) && campaignSummary.arrived > 0 && <span> · </span>}
+                {campaignSummary.arrived > 0 && (
+                  <Link
+                    to={`/admin/preorders?item_id=${encodeURIComponent(id!)}&status=ARRIVED`}
+                    style={{ color: "#084298", fontWeight: 600, textDecoration: "none" }}
+                  >
+                    {campaignSummary.arrived} hàng về
+                  </Link>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/pages/admin/components/ItemsTable.tsx
+++ b/frontend/src/pages/admin/components/ItemsTable.tsx
@@ -7,7 +7,7 @@ import {
   X,
   Package,
   Clock,
-  Timer,
+  AlarmClock,
   CheckCircle2,
   Copy,
   Share2,
@@ -61,7 +61,7 @@ export const ItemsTable = ({
   const renderStatusIcon = (status: ItemStatus) => {
     if (status === 'con_hang') return <Package size={18} color="#28a745" />;
     if (status === 'giu_cho') return <Clock size={18} color="#ffc107" />;
-    if (status === 'preorder') return <Timer size={18} color="#0d6efd" />;
+    if (status === 'preorder') return <AlarmClock size={18} color="#0d6efd" />;
     return <CheckCircle2 size={18} color="#6c757d" />;
   };
 

--- a/frontend/src/pages/admin/components/ItemsTable.tsx
+++ b/frontend/src/pages/admin/components/ItemsTable.tsx
@@ -7,6 +7,7 @@ import {
   X,
   Package,
   Clock,
+  Timer,
   CheckCircle2,
   Copy,
   Share2,
@@ -60,7 +61,7 @@ export const ItemsTable = ({
   const renderStatusIcon = (status: ItemStatus) => {
     if (status === 'con_hang') return <Package size={18} color="#28a745" />;
     if (status === 'giu_cho') return <Clock size={18} color="#ffc107" />;
-    if (status === 'preorder') return <Clock size={18} color="#0d6efd" />;
+    if (status === 'preorder') return <Timer size={18} color="#0d6efd" />;
     return <CheckCircle2 size={18} color="#6c757d" />;
   };
 

--- a/frontend/src/pages/admin/components/ItemsTable.tsx
+++ b/frontend/src/pages/admin/components/ItemsTable.tsx
@@ -60,6 +60,7 @@ export const ItemsTable = ({
   const renderStatusIcon = (status: ItemStatus) => {
     if (status === 'con_hang') return <Package size={18} color="#28a745" />;
     if (status === 'giu_cho') return <Clock size={18} color="#ffc107" />;
+    if (status === 'preorder') return <Clock size={18} color="#0d6efd" />;
     return <CheckCircle2 size={18} color="#6c757d" />;
   };
 

--- a/frontend/src/types/item.types.ts
+++ b/frontend/src/types/item.types.ts
@@ -12,7 +12,7 @@ export type ItemAttributesPayload = Record<string, string | number | boolean | n
 export interface BaseItem {
   id: string;
   name: string;
-  status: 'con_hang' | 'giu_cho' | 'da_ban';
+  status: 'con_hang' | 'giu_cho' | 'da_ban' | 'preorder';
   car_brand?: string;
   model_brand?: string;
   condition?: string;

--- a/frontend/tests/e2e/items.spec.ts
+++ b/frontend/tests/e2e/items.spec.ts
@@ -78,3 +78,77 @@ test.describe('Admin items list smoke', () => {
     await expect(authenticatedPage.locator('table tbody tr')).toHaveCount(0);
   });
 });
+
+const itemDetailResponse = apiOk({
+  item: {
+    id: 'item-1',
+    name: 'Lamborghini Huracán 1:18',
+    description: '',
+    status: 'con_hang',
+    is_public: false,
+    condition: 'new',
+    price: 3_500_000,
+    original_price: null,
+    scale: '1:18',
+    brand: 'AUTOart',
+    quantity: 5,
+    attributes: {},
+    fb_post_content: '',
+  },
+  images: [],
+  spin_sets: [],
+  facebook_posts: [],
+});
+
+test.describe('Admin item detail — Pre-order campaign button', () => {
+  test.beforeEach(async ({ authenticatedPage }) => {
+    await authenticatedPage.route('**/api/v1/items/item-1*', (route: Route) =>
+      route.fulfill({ json: itemDetailResponse }),
+    );
+    await authenticatedPage.route('**/api/v1/categories*', (route: Route) =>
+      route.fulfill({ json: apiOk({ categories: [] }) }),
+    );
+    await authenticatedPage.route('**/api/v1/items/item-1/qr*', (route: Route) =>
+      route.fulfill({
+        json: apiOk({
+          token: 'tok123',
+          resolve_url: 'https://example.com/qr/tok123',
+          image_data_url: 'data:image/png;base64,MOCK',
+        }),
+      }),
+    );
+  });
+
+  test('shows Pre-order campaign button on existing item detail page', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/admin/items/item-1');
+
+    await expect(authenticatedPage.getByText(/Chiến dịch Pre-order/i)).toBeVisible();
+  });
+
+  test('Pre-order campaign button points to correct create URL', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/admin/items/item-1');
+
+    const link = authenticatedPage.getByText(/Chiến dịch Pre-order/i);
+    await expect(link).toBeVisible();
+    const href = await link.evaluate((el) => el.closest('a')?.getAttribute('href') ?? '');
+    expect(href).toContain('/admin/preorders/create');
+    expect(href).toContain('item_id=item-1');
+  });
+
+  test('Pre-order campaign button is not shown on new item form', async ({ authenticatedPage }) => {
+    await authenticatedPage.route('**/api/v1/categories*', (route: Route) =>
+      route.fulfill({ json: apiOk({ categories: [] }) }),
+    );
+
+    await authenticatedPage.goto('/admin/items/new');
+
+    await expect(authenticatedPage.getByText(/Tạo sản phẩm mới/i)).toBeVisible();
+    await expect(authenticatedPage.getByText(/Chiến dịch Pre-order/i)).toHaveCount(0);
+  });
+
+  test('status selector includes Pre-order option on item detail page', async ({ authenticatedPage }) => {
+    await authenticatedPage.goto('/admin/items/item-1');
+
+    await expect(authenticatedPage.getByText('Pre-order')).toBeVisible();
+  });
+});

--- a/frontend/tests/e2e/items.spec.ts
+++ b/frontend/tests/e2e/items.spec.ts
@@ -108,6 +108,10 @@ test.describe('Admin item detail — Pre-order campaign button', () => {
     await authenticatedPage.route('**/api/v1/categories*', (route: Route) =>
       route.fulfill({ json: apiOk({ categories: [] }) }),
     );
+    await authenticatedPage.route('**/api/v1/inventory/items/item-1/transactions*', (route: Route) =>
+      route.fulfill({ json: apiOk({ transactions: [], current_quantity: 5 }) }),
+    );
+    // LIFO: QR mock overrides the general items/item-1* mock for QR requests
     await authenticatedPage.route('**/api/v1/items/item-1/qr*', (route: Route) =>
       route.fulfill({
         json: apiOk({

--- a/frontend/tests/e2e/items.spec.ts
+++ b/frontend/tests/e2e/items.spec.ts
@@ -126,15 +126,15 @@ test.describe('Admin item detail — Pre-order campaign button', () => {
   test('shows Pre-order campaign button on existing item detail page', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/admin/items/item-1');
 
-    await expect(authenticatedPage.getByText(/Chiến dịch Pre-order/i)).toBeVisible();
+    await expect(authenticatedPage.getByRole('link', { name: /Chiến dịch Pre-order/i })).toBeVisible();
   });
 
   test('Pre-order campaign button points to correct create URL', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/admin/items/item-1');
 
-    const link = authenticatedPage.getByText(/Chiến dịch Pre-order/i);
+    const link = authenticatedPage.getByRole('link', { name: /Chiến dịch Pre-order/i });
     await expect(link).toBeVisible();
-    const href = await link.evaluate((el) => el.closest('a')?.getAttribute('href') ?? '');
+    const href = await link.getAttribute('href');
     expect(href).toContain('/admin/preorders/create');
     expect(href).toContain('item_id=item-1');
   });
@@ -147,12 +147,12 @@ test.describe('Admin item detail — Pre-order campaign button', () => {
     await authenticatedPage.goto('/admin/items/new');
 
     await expect(authenticatedPage.getByText(/Tạo sản phẩm mới/i)).toBeVisible();
-    await expect(authenticatedPage.getByText(/Chiến dịch Pre-order/i)).toHaveCount(0);
+    await expect(authenticatedPage.getByRole('link', { name: /Chiến dịch Pre-order/i })).toHaveCount(0);
   });
 
   test('status selector includes Pre-order option on item detail page', async ({ authenticatedPage }) => {
     await authenticatedPage.goto('/admin/items/item-1');
 
-    await expect(authenticatedPage.getByText('Pre-order')).toBeVisible();
+    await expect(authenticatedPage.getByRole('radio', { name: 'Pre-order' })).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/public-item-detail-shop.spec.ts
+++ b/frontend/tests/e2e/public-item-detail-shop.spec.ts
@@ -102,6 +102,6 @@ test.describe('Public item detail — preorder status badge', () => {
   test('shows Pre-order badge for a preorder item', async ({ page }) => {
     await page.goto(`/items/${PREORDER_ITEM_ID}?shop_id=shop-a`);
     await expect(page.getByText('Ferrari F40 Pre-order')).toBeVisible();
-    await expect(page.getByText('Pre-order')).toBeVisible();
+    await expect(page.getByText('Pre-order', { exact: true })).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/public-item-detail-shop.spec.ts
+++ b/frontend/tests/e2e/public-item-detail-shop.spec.ts
@@ -60,3 +60,48 @@ test.describe('Public item detail — shop scope', () => {
     await expect(page.getByText('E2E Public Detail')).toBeVisible();
   });
 });
+
+test.describe('Public item detail — preorder status badge', () => {
+  const PREORDER_ITEM_ID = 'pub-preorder-1';
+
+  test.beforeEach(async ({ page }) => {
+    await routePublicShopContact(page);
+    await page.route(`**/api/v1/public/items/${PREORDER_ITEM_ID}**`, (route: Route) => {
+      const url = new URL(route.request().url());
+      if (!url.searchParams.get('shop_id')) {
+        return route.fulfill({
+          status: 422,
+          json: { ok: false, error: { code: 'PUBLIC_SHOP_REQUIRED', details: [] }, message: '' },
+        });
+      }
+      return route.fulfill({
+        json: apiOk({
+          item: {
+            id: PREORDER_ITEM_ID,
+            name: 'Ferrari F40 Pre-order',
+            description: '',
+            scale: '1:64',
+            brand: 'MiniGT',
+            car_brand: null,
+            model_brand: null,
+            condition: 'new',
+            price: 500000,
+            original_price: null,
+            status: 'preorder',
+            is_public: true,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+          },
+          images: [],
+          spinner: null,
+        }),
+      });
+    });
+  });
+
+  test('shows Pre-order badge for a preorder item', async ({ page }) => {
+    await page.goto(`/items/${PREORDER_ITEM_ID}?shop_id=shop-a`);
+    await expect(page.getByText('Ferrari F40 Pre-order')).toBeVisible();
+    await expect(page.getByText('Pre-order')).toBeVisible();
+  });
+});

--- a/frontend/tests/unit/ItemDetailPage.flow.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.flow.test.tsx
@@ -71,6 +71,8 @@ function createBaseItemData() {
 vi.mock('react-router-dom', () => ({
   useParams: () => h.params,
   useNavigate: () => h.mockNavigate,
+  Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode; [key: string]: unknown }) =>
+    React.createElement('a', { href: String(to), ...rest }, children),
   useSearchParams: () => {
     const [params, setParams] = React.useState(() => new URLSearchParams(h.search));
     const setSearchParams = React.useCallback(

--- a/frontend/tests/unit/ItemDetailPage.integration.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.integration.test.tsx
@@ -23,6 +23,8 @@ const h = vi.hoisted(() => ({
 vi.mock('react-router-dom', () => ({
   useParams: () => h.params,
   useNavigate: () => h.mockNavigate,
+  Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode; [key: string]: unknown }) =>
+    React.createElement('a', { href: String(to), ...rest }, children),
   useSearchParams: () => {
     const [params, setParams] = React.useState(() => new URLSearchParams(h.search));
     const setSearchParams = React.useCallback(

--- a/frontend/tests/unit/ItemDetailPage.integration.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.integration.test.tsx
@@ -404,3 +404,201 @@ describe('Pre-order auto-trigger toasts', () => {
     );
   });
 });
+
+function createPreorderItemData() {
+  return {
+    item: {
+      id: '1',
+      name: 'Ferrari F40',
+      description: '',
+      status: 'preorder',
+      is_public: false,
+      condition: 'new',
+      scale: '1:64',
+      brand: 'MiniGT',
+      price: 1000000,
+      original_price: 1200000,
+    },
+    images: [],
+    spin_sets: [],
+    facebook_posts: [],
+  };
+}
+
+function mockGetWithSummary(summary: {
+  pending: number; waiting: number; arrived: number;
+  total: number; cancelable: number; with_deposit: number;
+}) {
+  h.apiClient.get.mockImplementation(async (...args: unknown[]) => {
+    const urlStr = typeof args[0] === 'string' ? args[0] : '';
+    if (urlStr.includes('/campaigns/') && urlStr.includes('/summary')) {
+      return { data: summary };
+    }
+    if (urlStr.startsWith('/items/')) {
+      return { data: createPreorderItemData() };
+    }
+    if (urlStr.startsWith('/categories?type=')) {
+      return { data: { categories: [] } };
+    }
+    return { data: {} };
+  });
+}
+
+describe('Campaign widget', () => {
+  afterEach(() => { cleanup(); });
+
+  beforeEach(() => {
+    h.params = { id: '1' };
+    h.search = '';
+    h.mockNavigate.mockReset();
+    h.mockShowToast.mockReset();
+    h.apiClient.patch.mockReset();
+    h.apiClient.post.mockReset();
+  });
+
+  it('renders campaign widget with correct counts when item is preorder', async () => {
+    mockGetWithSummary({ pending: 2, waiting: 1, arrived: 0, total: 3, cancelable: 1, with_deposit: 1 });
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 chờ xác nhận/i)).toBeTruthy();
+      expect(screen.getByText(/1 chờ hàng/i)).toBeTruthy();
+    });
+  });
+
+  it('does not render campaign widget when all counts are zero', async () => {
+    mockGetWithSummary({ pending: 0, waiting: 0, arrived: 0, total: 0, cancelable: 0, with_deposit: 0 });
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect((screen.getAllByRole('textbox')[0] as HTMLInputElement).value).toBe('Ferrari F40');
+    });
+
+    expect(screen.queryByText(/📋 Chiến dịch/)).toBeNull();
+  });
+
+  it('campaign widget count links point to filtered preorders URL', async () => {
+    mockGetWithSummary({ pending: 2, waiting: 0, arrived: 0, total: 2, cancelable: 2, with_deposit: 0 });
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      const link = screen.getByText(/2 chờ xác nhận/i).closest('a');
+      expect(link).toBeTruthy();
+      expect((link as HTMLAnchorElement).href).toContain('status=PENDING_CONFIRMATION');
+      expect((link as HTMLAnchorElement).href).toContain('item_id=1');
+    });
+  });
+});
+
+describe('Confirmation modal — preorder → da_ban', () => {
+  afterEach(() => { cleanup(); });
+
+  beforeEach(() => {
+    h.params = { id: '1' };
+    h.search = '';
+    h.mockNavigate.mockReset();
+    h.mockShowToast.mockReset();
+    h.apiClient.patch.mockReset();
+    h.apiClient.post.mockReset();
+    mockGetWithSummary({ pending: 1, waiting: 1, arrived: 0, total: 2, cancelable: 2, with_deposit: 0 });
+  });
+
+  it('shows confirmation modal when transitioning preorder → da_ban with active orders', async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'Pre-order' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Đã bán' }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Hình ảnh/i })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Xác nhận chuyển sang "Đã bán"/i)).toBeTruthy();
+    });
+
+    expect(h.apiClient.patch).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call patch when modal is dismissed', async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'Pre-order' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Đã bán' }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Hình ảnh/i })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Hủy bỏ/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/Hủy bỏ/i));
+
+    expect(h.apiClient.patch).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Xác nhận chuyển sang "Đã bán"/i)).toBeNull();
+  });
+
+  it('calls patch after confirming modal', async () => {
+    h.apiClient.patch.mockResolvedValueOnce({
+      ok: true,
+      data: { item: { id: '1' }, preorders_auto_cancelled_count: 2, preorders_with_deposit_count: 0 },
+    });
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: 'Pre-order' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Đã bán' }));
+    fireEvent.click(screen.getAllByRole('button', { name: /Hình ảnh/i })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Xác nhận chuyển Đã bán/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/Xác nhận chuyển Đã bán/i));
+
+    await waitFor(() => {
+      expect(h.apiClient.patch).toHaveBeenCalledWith(
+        '/items/1',
+        expect.objectContaining({ status: 'da_ban' }),
+      );
+    });
+  });
+});

--- a/frontend/tests/unit/ItemDetailPage.integration.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.integration.test.tsx
@@ -287,3 +287,120 @@ describe('Pre-order campaign button', () => {
     expect(screen.queryByText(/Chiến dịch Pre-order/i)).toBeNull();
   });
 });
+
+describe('Pre-order auto-trigger toasts', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    h.params = { id: '1' };
+    h.search = '';
+    h.mockNavigate.mockReset();
+    h.mockShowToast.mockReset();
+    h.apiClient.patch.mockReset();
+    h.apiClient.post.mockReset();
+    h.apiClient.get.mockImplementation(async (...args: unknown[]) => {
+      const urlStr = typeof args[0] === 'string' ? args[0] : '';
+      if (urlStr.startsWith('/items/')) {
+        return { data: createItemData() };
+      }
+      if (urlStr.startsWith('/categories?type=')) {
+        return { data: { categories: [] } };
+      }
+      return { data: {} };
+    });
+  });
+
+  it('shows "hàng về" toast when preorders_arrived_count > 0', async () => {
+    h.apiClient.patch.mockResolvedValueOnce({
+      ok: true,
+      data: { item: { id: '1' }, preorders_arrived_count: 3 },
+    });
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect((screen.getAllByRole('textbox')[0] as HTMLInputElement).value).toBe('Ferrari F40');
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Hình ảnh/i })[0]);
+
+    await waitFor(() => {
+      expect(h.mockShowToast).toHaveBeenCalledWith(
+        'Đã tự động chuyển 3 đơn pre-order sang "Hàng về"',
+      );
+    });
+  });
+
+  it('shows cancel summary toast when auto-cancelled and deposit counts are present', async () => {
+    h.apiClient.patch.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        item: { id: '1' },
+        preorders_auto_cancelled_count: 2,
+        preorders_with_deposit_count: 1,
+      },
+    });
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect((screen.getAllByRole('textbox')[0] as HTMLInputElement).value).toBe('Ferrari F40');
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Hình ảnh/i })[0]);
+
+    await waitFor(() => {
+      expect(h.mockShowToast).toHaveBeenCalledWith(
+        'Pre-order: tự động hủy 2 đơn chưa cọc · 1 đơn đã cọc cần hủy thủ công.',
+      );
+    });
+  });
+
+  it('does not show preorder toast when all counts are zero', async () => {
+    h.apiClient.patch.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        item: { id: '1' },
+        preorders_arrived_count: 0,
+        preorders_auto_cancelled_count: 0,
+        preorders_with_deposit_count: 0,
+      },
+    });
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect((screen.getAllByRole('textbox')[0] as HTMLInputElement).value).toBe('Ferrari F40');
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Hình ảnh/i })[0]);
+
+    await waitFor(() => {
+      expect(h.apiClient.patch).toHaveBeenCalled();
+    });
+
+    expect(h.mockShowToast).not.toHaveBeenCalledWith(
+      expect.stringContaining('Đã tự động chuyển'),
+    );
+    expect(h.mockShowToast).not.toHaveBeenCalledWith(
+      expect.stringContaining('Pre-order:'),
+    );
+  });
+});

--- a/frontend/tests/unit/ItemDetailPage.integration.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.integration.test.tsx
@@ -210,3 +210,80 @@ describe('ItemDetailPage integration (real React Query)', () => {
     });
   });
 });
+
+describe('Pre-order campaign button', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    h.params = { id: '1' };
+    h.search = '';
+    h.mockNavigate.mockReset();
+    h.mockShowToast.mockReset();
+    h.apiClient.patch.mockReset();
+    h.apiClient.post.mockReset();
+    h.apiClient.get.mockImplementation(async (...args: unknown[]) => {
+      const urlStr = typeof args[0] === 'string' ? args[0] : '';
+      if (urlStr.startsWith('/items/')) {
+        return { data: createItemData() };
+      }
+      if (urlStr.startsWith('/categories?type=')) {
+        return { data: { categories: [] } };
+      }
+      return { data: {} };
+    });
+  });
+
+  it('renders the Pre-order campaign button for an existing item', async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Chiến dịch Pre-order/i)).toBeTruthy();
+    });
+  });
+
+  it('Pre-order campaign button links to /admin/preorders/create?item_id=1', async () => {
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      const btn = screen.getByText(/Chiến dịch Pre-order/i).closest('a');
+      expect(btn).toBeTruthy();
+      expect((btn as HTMLAnchorElement).href).toContain('/admin/preorders/create?item_id=1');
+    });
+  });
+
+  it('does not render the Pre-order campaign button for a new item', async () => {
+    h.params = { id: 'new' };
+    h.apiClient.get.mockImplementation(async (...args: unknown[]) => {
+      const urlStr = typeof args[0] === 'string' ? args[0] : '';
+      if (urlStr.startsWith('/categories?type=')) {
+        return { data: { categories: [] } };
+      }
+      return { data: {} };
+    });
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ItemDetailPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Tạo sản phẩm mới/i)).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/Chiến dịch Pre-order/i)).toBeNull();
+  });
+});

--- a/frontend/tests/unit/ItemDetailPage.qr.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.qr.test.tsx
@@ -63,6 +63,8 @@ const QR_RESPONSE = {
 vi.mock("react-router-dom", () => ({
   useParams: () => h.params,
   useNavigate: () => h.mockNavigate,
+  Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode; [key: string]: unknown }) =>
+    React.createElement("a", { href: String(to), ...rest }, children),
   useSearchParams: () => {
     const [params, setParams] = React.useState(
       () => new URLSearchParams(h.search),


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/preorders/admin/campaigns/:itemId/summary` endpoint — parallel `groupBy` + 2 counts, replaces frontend `page_size=200` workaround
- Add confirmation modal before `preorder → da_ban` transition showing `cancelable` (no-deposit) and `with_deposit` counts so admins don't accidentally mass-cancel
- Report `preorders_pending_count` on `preorder → con_hang` so the UI can warn about `PENDING_CONFIRMATION` orders needing manual follow-up
- Fix `paid_amount: { lte: 0 }` → `{ equals: 0 }` to guard against negative deposit values
- Make campaign widget counts clickable `<Link>` components filtered by status
- Add `CampaignSummary` + `UpdateItemResponse` TypeScript interfaces
- Add 4 new service unit tests + 6 integration tests covering new flows
- Update `docs/API_CONTRACT.md` and `docs/DOMAIN.md`
- Add `docs/ROLLBACK_PREORDER_STATUS.md` runbook

## Dependencies

> **Merge [#212](https://github.com/nguyenhoangtin1404/Diecast360/pull/212) first**, then rebase this branch on `main` before merging.

## Test plan

- [ ] `preorder → con_hang`: all `WAITING_FOR_GOODS` orders advance to `ARRIVED`; toast shows arrived count + pending count (if any)
- [ ] `preorder → da_ban` with active orders: confirmation modal appears with cancelable + with_deposit breakdown; dismissing does not save; confirming proceeds
- [ ] `preorder → da_ban` with zero active orders: no modal, saves directly
- [ ] Campaign widget counts link to `/admin/preorders?item_id=X&status=Y`
- [ ] `GET /preorders/admin/campaigns/:itemId/summary` returns correct counts scoped to active shop
- [ ] Unit tests pass: `pnpm --filter backend test`
- [ ] Integration tests pass: `pnpm --filter frontend test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)