### PR TITLE
chore(db): migrate UUID v4 → v7 across all models and services

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,6 @@
         "@nestjs/throttler": "^6.5.0",
         "@pinecone-database/pinecone": "^7.0.0",
         "@prisma/client": "^6.19.1",
-        "@types/qrcode": "^1.5.6",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
@@ -38,7 +37,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "sharp": "^0.34.5",
-        "uuid": "^9.0.1"
+        "uuid": "^11.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -51,6 +50,7 @@
         "@types/multer": "^2.0.0",
         "@types/node": "^25.0.3",
         "@types/passport-jwt": "^4.0.1",
+        "@types/qrcode": "^1.5.6",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "@typescript-eslint/parser": "^8.56.0",
@@ -4987,6 +4987,7 @@
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
       "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -12310,16 +12311,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -62,7 +62,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "sharp": "^0.34.5",
-    "uuid": "^9.0.1"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/backend/prisma/migrations/20260523000000_upgrade_uuid_v7_defaults/migration.sql
+++ b/backend/prisma/migrations/20260523000000_upgrade_uuid_v7_defaults/migration.sql
@@ -1,0 +1,4 @@
+-- UUID v4 → v7: no SQL changes required.
+-- Prisma generates UUIDs at the application layer (client-side), not via a
+-- database DEFAULT expression. Changing uuid() to uuid(7) in schema.prisma
+-- only affects the Prisma Client generator — existing rows are unaffected.

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -65,7 +65,7 @@ enum MemberPointsMutationType {
 }
 
 model Shop {
-  id         String         @id @default(uuid())
+  id         String         @id @default(uuid(7))
   name       String
   slug       String         @unique
   is_active  Boolean        @default(true)
@@ -106,7 +106,7 @@ model UserShopRole {
 }
 
 model User {
-  id            String         @id @default(uuid())
+  id            String         @id @default(uuid(7))
   email         String         @unique
   password_hash String
   full_name     String?
@@ -127,7 +127,7 @@ model User {
 }
 
 model ShopAuditLog {
-  id            String          @id @default(uuid())
+  id            String          @id @default(uuid(7))
   shop_id       String
   actor_user_id String?
   action        ShopAuditAction
@@ -145,7 +145,7 @@ model ShopAuditLog {
 }
 
 model RefreshToken {
-  id         String    @id @default(uuid())
+  id         String    @id @default(uuid(7))
   user_id    String
   token_hash String    @unique
   expires_at DateTime
@@ -159,7 +159,7 @@ model RefreshToken {
 }
 
 model Item {
-  id             String      @id @default(uuid())
+  id             String      @id @default(uuid(7))
   name           String
   description    String?
   scale          String      @default("1:64")
@@ -202,7 +202,7 @@ model Item {
 }
 
 model InventoryTransaction {
-  id                String                   @id @default(uuid())
+  id                String                   @id @default(uuid(7))
   shop_id           String
   item_id           String
   actor_user_id     String?
@@ -228,7 +228,7 @@ model InventoryTransaction {
 }
 
 model PreOrder {
-  id                   String         @id @default(uuid())
+  id                   String         @id @default(uuid(7))
   shop_id              String
   item_id              String
   user_id              String?
@@ -262,7 +262,7 @@ model PreOrder {
 }
 
 model MembershipTier {
-  id         String   @id @default(uuid())
+  id         String   @id @default(uuid(7))
   shop_id    String
   name       String
   rank       Int
@@ -280,7 +280,7 @@ model MembershipTier {
 }
 
 model Member {
-  id             String   @id @default(uuid())
+  id             String   @id @default(uuid(7))
   shop_id        String
   full_name      String
   email          String?
@@ -304,7 +304,7 @@ model Member {
 }
 
 model MemberPointsLedger {
-  id            String                   @id @default(uuid())
+  id            String                   @id @default(uuid(7))
   member_id     String
   shop_id       String
   actor_user_id String?
@@ -330,7 +330,7 @@ model MemberPointsLedger {
 }
 
 model FacebookPost {
-  id         String   @id @default(uuid())
+  id         String   @id @default(uuid(7))
   item_id    String
   post_url   String
   content    String?
@@ -344,7 +344,7 @@ model FacebookPost {
 }
 
 model ItemImage {
-  id             String   @id @default(uuid())
+  id             String   @id @default(uuid(7))
   item_id        String
   file_path      String
   thumbnail_path String?
@@ -360,7 +360,7 @@ model ItemImage {
 }
 
 model SpinSet {
-  id         String       @id @default(uuid())
+  id         String       @id @default(uuid(7))
   item_id    String
   label      String?
   is_default Boolean      @default(false)
@@ -376,7 +376,7 @@ model SpinSet {
 }
 
 model SpinFrame {
-  id             String   @id @default(uuid())
+  id             String   @id @default(uuid(7))
   spin_set_id    String
   frame_index    Int
   file_path      String
@@ -392,7 +392,7 @@ model SpinFrame {
 }
 
 model Category {
-  id            String   @id @default(uuid())
+  id            String   @id @default(uuid(7))
   /** Global seed rows use null; per-shop rows set to shop id (AI import, shop admin). */
   shop_id       String?
   name          String
@@ -412,7 +412,7 @@ model Category {
 }
 
 model AiItemDraft {
-  id              String   @id @default(uuid())
+  id              String   @id @default(uuid(7))
   images_json     String   // JSON string of image paths
   extracted_text  String?
   ai_json         String   // JSON string of structured item data

--- a/backend/src/image-processor/image-processor.service.ts
+++ b/backend/src/image-processor/image-processor.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import * as path from 'path';
 import * as sharp from 'sharp';
-import { v4 as uuidv4 } from 'uuid';
+import { v7 as uuidv7 } from 'uuid';
 
 export class WatermarkProcessingError extends Error {
   constructor(message: string, public readonly cause?: Error) {
@@ -92,7 +92,7 @@ export class ImageProcessorService {
     const ext = originalName
       ? path.extname(originalName) || '.jpg'
       : '.jpg';
-    return `${uuidv4()}${ext}`;
+    return `${uuidv7()}${ext}`;
   }
 
   validateImage(buffer: Buffer): boolean {

--- a/backend/src/images/dto/reorder-images.dto.ts
+++ b/backend/src/images/dto/reorder-images.dto.ts
@@ -2,7 +2,7 @@ import { IsArray, IsUUID } from 'class-validator';
 
 export class ReorderImagesDto {
   @IsArray()
-  @IsUUID('4', { each: true })
+  @IsUUID('all', { each: true })
   image_ids: string[];
 }
 

--- a/backend/src/shops/shops.service.ts
+++ b/backend/src/shops/shops.service.ts
@@ -22,7 +22,7 @@ import { parseShopLoyaltyJson } from './shop-loyalty-json.util';
 import { UploadSupportService } from '../common/upload/upload-support.service';
 import { verifySignedMediaParams } from '../common/media/signed-media.util';
 import { resolveMediaSigningSecret } from '../common/media/media-signing-secret';
-import { v4 as uuidv4 } from 'uuid';
+import { v7 as uuidv7 } from 'uuid';
 import * as sharp from 'sharp';
 
 const SHOP_BRANDING_MIME_ALLOWLIST = ['image/jpeg', 'image/png', 'image/webp'] as const;
@@ -498,7 +498,7 @@ export class ShopsService {
       payloadBuffer = await this.normalizeFavicon(file.buffer);
       ext = '.png';
     }
-    const filename = `${tenantId}_${kind}_${uuidv4()}${ext}`;
+    const filename = `${tenantId}_${kind}_${uuidv7()}${ext}`;
     const relativePath = await this.storage.saveFile(payloadBuffer, filename, 'shop-branding');
     const publicUrl = await this.storage.getFileUrl(relativePath);
 

--- a/backend/src/spinner/dto/reorder-frames.dto.ts
+++ b/backend/src/spinner/dto/reorder-frames.dto.ts
@@ -2,7 +2,7 @@ import { IsArray, IsUUID } from 'class-validator';
 
 export class ReorderFramesDto {
   @IsArray()
-  @IsUUID('4', { each: true })
+  @IsUUID('all', { each: true })
   frame_ids: string[];
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^0.34.5
         version: 0.34.5
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.0.0
+        version: 11.1.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.2
@@ -4771,8 +4771,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -10296,7 +10296,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@9.0.1: {}
+  uuid@11.1.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Summary

- `schema.prisma`: đổi `@default(uuid())` → `@default(uuid(7))` trên 16 models
- `package.json`: nâng `uuid ^9.0.1` → `^11.0.0` (v7 support có từ v10)
- `image-processor.service.ts`, `shops.service.ts`: `v4 as uuidv4` → `v7 as uuidv7` cho upload filenames
- `reorder-frames.dto.ts`, `reorder-images.dto.ts`: `@IsUUID('4')` → `@IsUUID('all')` để không reject ID v7

## Không thay đổi

- Existing v4 IDs giữ nguyên — chỉ record **mới** mới là v7
- Không có migration SQL destructive
- API contract không đổi (UUID vẫn là string `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`)

## Closes

#222

https://claude.ai/code/session_015QjRDNmF2uaT3iyUhcbQXZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015QjRDNmF2uaT3iyUhcbQXZ)_