### PR TITLE
feat: In trực tiếp QR code ở trang tạo sản phẩm (bước 5) và danh sách sản phẩm

### DIFF
--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -15,6 +15,7 @@ import { CategoryQuickManage } from "../../components/admin/CategoryQuickManage"
 import { InventoryTimeline } from "../../components/admin/InventoryTimeline";
 import type { CategoryItem, ApiResponse } from "../../types/category";
 import { showToast } from "../../utils/toast";
+import { printQrCode } from "../../utils/printQr";
 import type { FacebookPost } from "../../types/item.types";
 import type { ItemStatus } from "../../constants/item";
 import {
@@ -4109,6 +4110,28 @@ export const ItemDetailPage = () => {
                 >
                   ⬇ Tải PNG
                 </a>
+                <button
+                  type="button"
+                  onClick={() =>
+                    printQrCode(
+                      qrData.image_data_url,
+                      data?.item?.name ?? "",
+                      qrData.resolve_url,
+                    )
+                  }
+                  style={{
+                    padding: "9px 16px",
+                    background: "#059669",
+                    color: "#fff",
+                    border: "none",
+                    borderRadius: "8px",
+                    fontSize: "13px",
+                    fontWeight: "500",
+                    cursor: "pointer",
+                  }}
+                >
+                  🖨 In QR
+                </button>
               </div>
 
               {!data?.item?.is_public && (

--- a/frontend/src/pages/admin/components/ItemsTable.tsx
+++ b/frontend/src/pages/admin/components/ItemsTable.tsx
@@ -12,12 +12,15 @@ import {
   Copy,
   Share2,
   ExternalLink,
+  Printer,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { ITEM_STATUS_LABELS, type ItemStatus } from '../../../constants/item';
 import type { AdminItem } from '../../../types/item.types';
 import styles from '../ItemsPage.module.css';
+import { apiClient } from '../../../api/client';
+import { openPrintWindow, fillPrintWindow } from '../../../utils/printQr';
 
 interface ItemsTableProps {
   items: AdminItem[];
@@ -36,6 +39,29 @@ export const ItemsTable = ({
 }: ItemsTableProps) => {
   const navigate = useNavigate();
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [printingQrId, setPrintingQrId] = useState<string | null>(null);
+
+  const handlePrintQr = async (item: AdminItem) => {
+    // Open the popup synchronously within the click gesture — before any await —
+    // because browsers block window.open called after an async boundary.
+    const printWindow = openPrintWindow();
+    if (!printWindow) {
+      alert('Vui lòng cho phép cửa sổ pop-up để in QR.');
+      return;
+    }
+    setPrintingQrId(item.id);
+    try {
+      const res = (await apiClient.get(`/items/${item.id}/qr`)) as {
+        data: { image_data_url: string; resolve_url: string };
+      };
+      fillPrintWindow(printWindow, res.data.image_data_url, item.name, res.data.resolve_url);
+    } catch {
+      printWindow.close();
+      alert('Không thể tải mã QR. Vui lòng thử lại.');
+    } finally {
+      setPrintingQrId(null);
+    }
+  };
 
   const handleCopy = async (item: AdminItem) => {
     if (!item.fb_post_content) {
@@ -218,6 +244,16 @@ export const ItemsTable = ({
                     aria-label={`Sửa ${item.name}`}
                   >
                     <Pencil size={18} />
+                  </button>
+                  <button
+                    onClick={() => handlePrintQr(item)}
+                    title="In QR"
+                    disabled={printingQrId === item.id}
+                    className={styles.iconButton}
+                    style={{ opacity: printingQrId === item.id ? 0.5 : 1 }}
+                    aria-label={`In QR ${item.name}`}
+                  >
+                    <Printer size={18} />
                   </button>
                   <button
                     onClick={() => onDelete(item.id, item.name)}

--- a/frontend/src/utils/printQr.ts
+++ b/frontend/src/utils/printQr.ts
@@ -1,0 +1,108 @@
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function writeQrContent(
+  printWindow: Window,
+  imageDataUrl: string,
+  productName: string,
+  resolveUrl?: string,
+): void {
+  printWindow.document.write(`<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>QR - ${escapeHtml(productName)}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 12px 8px;
+      font-family: Arial, sans-serif;
+      width: 100%;
+    }
+    .name {
+      font-size: 11pt;
+      font-weight: bold;
+      text-align: center;
+      margin-bottom: 6pt;
+      max-width: 100%;
+      word-break: break-word;
+      line-height: 1.3;
+    }
+    img {
+      width: 160px;
+      height: 160px;
+      max-width: 90%;
+      display: block;
+    }
+    .url {
+      margin-top: 6pt;
+      font-size: 6pt;
+      color: #555;
+      word-break: break-all;
+      text-align: center;
+      max-width: 100%;
+    }
+    @page {
+      /* Minimal margins so content is not clipped on narrow thermal/POS paper */
+      margin: 3mm;
+    }
+    @media print {
+      body { padding: 0; }
+      img {
+        /* Physical mm size: fits 58mm roll (52mm printable) and larger */
+        width: 44mm;
+        height: 44mm;
+        max-width: 90%;
+      }
+      .name { font-size: 8pt; margin-bottom: 3mm; }
+      .url  { font-size: 5pt; margin-top: 2mm; }
+    }
+  </style>
+</head>
+<body>
+  <div class="name">${escapeHtml(productName)}</div>
+  <img src="${imageDataUrl}" alt="QR Code" />
+  ${resolveUrl ? `<div class="url">${escapeHtml(resolveUrl)}</div>` : ''}
+  <script>
+    window.onload = function () {
+      window.onafterprint = function () { window.close(); };
+      window.print();
+    };
+  </script>
+</body>
+</html>`);
+  printWindow.document.close();
+}
+
+// For synchronous use (QR data already cached, e.g. Step 5)
+export function printQrCode(imageDataUrl: string, productName: string, resolveUrl?: string): void {
+  const printWindow = window.open('', '_blank', 'width=320,height=480');
+  if (!printWindow) {
+    alert('Vui lòng cho phép cửa sổ pop-up để in QR.');
+    return;
+  }
+  writeQrContent(printWindow, imageDataUrl, productName, resolveUrl);
+}
+
+// Open the print window synchronously (must be called within a click handler, before any await)
+export function openPrintWindow(): Window | null {
+  return window.open('', '_blank', 'width=320,height=480');
+}
+
+// Write QR content into a pre-opened window (use after async data fetch)
+export function fillPrintWindow(
+  printWindow: Window,
+  imageDataUrl: string,
+  productName: string,
+  resolveUrl?: string,
+): void {
+  writeQrContent(printWindow, imageDataUrl, productName, resolveUrl);
+}


### PR DESCRIPTION
## Summary

- Tạo `printQr.ts` utility: mở popup in với layout tên sản phẩm → QR 200×200 → URL, tự động gọi `window.print()` và đóng sau khi in
- Thêm nút **"🖨 In QR"** vào Step 5 của trang tạo/chỉnh sửa sản phẩm (bên cạnh nút "Tải PNG"), sử dụng `image_data_url` đã fetch sẵn
- Thêm nút **Printer icon** vào cột "Thao tác" của danh sách sản phẩm: fetch QR on-demand khi bấm, hiển thị loading per-row trong lúc chờ

Closes #224

## Test plan

- [ ] Vào trang sửa sản phẩm → Step 5 → bấm "In QR" → popup in mở ra với tên SP, QR và URL
- [ ] Vào danh sách sản phẩm → bấm icon Printer ở một dòng → loading hiện trên nút đó → popup in xuất hiện
- [ ] Kiểm tra trường hợp popup bị chặn (browser block pop-up) → alert hướng dẫn hiện ra
- [ ] Tên sản phẩm có ký tự đặc biệt (`<`, `>`, `&`, `"`) → hiển thị đúng trong popup in, không bị XSS

https://claude.ai/code/session_01EJA67HM5MCXpqdfXWTMmXx

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJA67HM5MCXpqdfXWTMmXx)_