### PR TITLE
fix(deploy): prevent rsync --delete from wiping UPLOAD_DIR on Pi

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -194,7 +194,16 @@ jobs:
           set -euo pipefail
           REDIR="${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
           mkdir -p "$REDIR"
-          rsync -a --delete --exclude='.env' "${{ steps.bundle.outputs.path }}/" "${REDIR}/"
+          # Excludes protect operator state that lives in REDIR but is NOT part of
+          # the deploy bundle. Without these, `--delete` wipes user data each deploy.
+          # - .env: secrets configured per-host
+          # - /uploads: legacy default UPLOAD_DIR (./uploads -> $REDIR/uploads). New
+          #   installs should set UPLOAD_DIR outside REDIR (see backend/.env.production.example).
+          rsync -a --delete \
+            --exclude='/.env' \
+            --exclude='/uploads' \
+            --exclude='/uploads/' \
+            "${{ steps.bundle.outputs.path }}/" "${REDIR}/"
 
       - name: Prisma generate & restart API
         run: |

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -22,8 +22,14 @@ FRONTEND_URL="https://CHANGE_ME_YOUR_FRONTEND_HOST"
 # URL public của API (HTTPS, không dấu / cuối) — dùng ký link /api/v1/media
 BACKEND_URL="https://CHANGE_ME_YOUR_API_HOST"
 
-# Thư mục upload trên server (tuyệt đối, tồn tại và ghi được)
-UPLOAD_DIR="/opt/diecast360-backend/uploads"
+# Thư mục upload trên server (tuyệt đối, tồn tại và ghi được).
+# ⚠️ PHẢI nằm NGOÀI thư mục deploy (DEPLOY_REMOTE_PATH, mặc định /opt/diecast360-backend),
+# vì workflow Pi dùng `rsync --delete` để đồng bộ bundle: mọi thứ trong deploy root không thuộc
+# bundle (trừ .env / uploads đã được exclude) sẽ bị xoá khi deploy.
+# Setup một lần:
+#   sudo mkdir -p /var/lib/diecast360/uploads
+#   sudo chown pi:pi /var/lib/diecast360/uploads
+UPLOAD_DIR="/var/lib/diecast360/uploads"
 # MAX_UPLOAD_MB=10
 # MAX_SPINNER_FRAMES=48
 # ALLOWED_MIME="image/jpeg,image/png,image/webp"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -75,6 +75,7 @@ Lợi ích: không cần mở cổng inbound trên router, không phụ thuộc 
 - **pnpm**: `corepack enable` và version khớp trường `packageManager` ở `package.json` gốc (xem `.github/workflows/deploy-backend.yml` hoặc `AGENTS.md`).
 - **Chỉ chạy backend trên Pi**; database để trên Neon để tránh Postgres + Nest tranh RAM.
 - **`UPLOAD_DIR` / thư mục uploads:** Cần khi `STORAGE_DRIVER=local` (đủ dung lượng, có thể USB). Khi `STORAGE_DRIVER=r2`, có thể **không** cần volume lớn trên Pi cho media; vẫn cần bucket R2 + biến `R2_*` — xem [`ENV.md`](ENV.md) mục Object storage và mục cutover trong tài liệu này.
+  - **⚠️ `UPLOAD_DIR` phải nằm ngoài `DEPLOY_REMOTE_PATH`** (mặc định `/opt/diecast360-backend`). Workflow Pi dùng `rsync --delete` để đồng bộ bundle: bất kỳ thứ gì trong deploy root mà không nằm trong bundle (trừ `.env` và `uploads` đã được exclude) sẽ bị xoá ở mỗi deploy. Khuyến nghị `/var/lib/diecast360/uploads` (`sudo mkdir -p` + `sudo chown` cho user chạy systemd).
 - Giới hạn `MAX_UPLOAD_MB` hợp lý — xử lý ảnh (Sharp) có thể tốn RAM khi upload đồng thời.
 - Nếu deploy thủ công, cài dependency, build, migrate rồi restart:
 


### PR DESCRIPTION
## Summary

- Pi deploy workflow (introduced in #250) runs `rsync -a --delete --exclude='.env'` at the root of `DEPLOY_REMOTE_PATH` (default `/opt/diecast360-backend`). The default `UPLOAD_DIR` in `backend/.env.production.example` was `/opt/diecast360-backend/uploads`, i.e. inside `REDIR`. The deploy bundle from `pnpm deploy --prod --legacy` does not contain `uploads/`, so `--delete` silently wiped all stored media (item images, spinner frames, shop branding) on every backend deploy → production 404s on `/api/v1/media?...` while DB metadata stayed intact.
- This PR stops the bleed in two layers:
  - Workflow now also excludes `/uploads` (legacy default) so existing installs survive even if `UPLOAD_DIR` still points inside `REDIR`.
  - Env template moves `UPLOAD_DIR` to `/var/lib/diecast360/uploads` (outside `REDIR`, FHS-correct) with a warning + setup commands.
  - `docs/DEPLOYMENT.md` documents the placement constraint.

## Root cause

Before #250 the workflow used `rsync -a --delete` only on `./dist/` and `./prisma/` subdirectories — `uploads/` at the root was never touched. #250 switched to a single top-level rsync of the `pnpm deploy` bundle which, combined with the default `UPLOAD_DIR` inside `REDIR`, deletes user data each deploy.

## Operator follow-up (NOT in this PR)

After merge, on the Pi:

```bash
sudo mkdir -p /var/lib/diecast360/uploads
sudo chown pi:pi /var/lib/diecast360/uploads
# Edit /opt/diecast360-backend/.env: UPLOAD_DIR=/var/lib/diecast360/uploads
sudo systemctl restart diecast360-api
```

Restoring already-deleted files is out of scope here — needs ext4 recovery (extundelete/testdisk) or a backup.

## Test plan

- [ ] `actionlint .github/workflows/deploy-backend.yml` passes (or CI workflow lint job is green).
- [ ] On next deploy after merge: `ls /opt/diecast360-backend/uploads/` (if still using legacy path) is NOT empty after the workflow run.
- [ ] After operator moves `UPLOAD_DIR` to `/var/lib/diecast360/uploads`: deploy completes, `curl -sfS http://127.0.0.1:3000/api/v1/health` returns ok, a sample image URL returns 200 (once files are re-uploaded or restored).
