### PR TITLE
ci: add Fly.io launch config files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,68 @@
+# Dependencies
+node_modules/
+package-lock.json
+**/package-lock.json
+.pnp/
+.pnp.js
+
+# Build outputs
+dist/
+build/
+.next/
+out/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+*.env
+
+# IDE and editors
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Testing
+coverage/
+.nyc_output/
+frontend/test-results/
+**/test-results/
+
+# Uploads
+uploads/
+**/uploads/
+
+# Database
+*.sqlite
+*.sqlite3
+
+# Prisma
+backend/src/generated/
+
+# Cache
+.cache/
+.turbo/
+.parcel-cache/
+
+# TypeScript
+*.tsbuildinfo
+
+# Misc
+*.pid
+*.seed
+*.pid.lock
+.eslintcache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# syntax = docker/dockerfile:1
+
+# Adjust NODE_VERSION as desired
+ARG NODE_VERSION=22.21.1
+FROM node:${NODE_VERSION}-slim AS base
+
+LABEL fly_launch_runtime="Node.js"
+
+# Node.js app lives here
+WORKDIR /app
+
+# Set production environment
+ENV NODE_ENV="production"
+
+# Install pnpm
+ARG PNPM_VERSION=latest
+RUN npm install -g pnpm@$PNPM_VERSION
+
+
+# Throw-away build stage to reduce size of final image
+FROM base AS build
+
+# Install packages needed to build node modules
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
+
+# Install node modules
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Copy application code
+COPY . .
+
+
+# Final stage for app image
+FROM base
+
+# Copy built application
+COPY --from=build /app /app
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 3000
+CMD [ "pnpm", "run", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,59 @@
-# syntax = docker/dockerfile:1
+# syntax=docker/dockerfile:1
 
-# Adjust NODE_VERSION as desired
+# Match engines in root package.json (see AGENTS.md).
 ARG NODE_VERSION=22.21.1
 FROM node:${NODE_VERSION}-slim AS base
 
 LABEL fly_launch_runtime="Node.js"
 
-# Node.js app lives here
 WORKDIR /app
 
-# Set production environment
-ENV NODE_ENV="production"
+ARG PNPM_VERSION=10.33.4
+RUN npm install -g pnpm@${PNPM_VERSION}
 
-# Install pnpm
-ARG PNPM_VERSION=latest
-RUN npm install -g pnpm@$PNPM_VERSION
-
-
-# Throw-away build stage to reduce size of final image
+# -----------------------------------------------------------------------------
+# Build: install full workspace (devDeps needed for nest build), compile backend
+# -----------------------------------------------------------------------------
 FROM base AS build
 
-# Install packages needed to build node modules
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
+# Install and compile need devDependencies (@nestjs/cli, typescript, prisma CLI).
+ENV NODE_ENV=development
 
-# Install node modules
-COPY package.json pnpm-lock.yaml ./
+RUN apt-get update -qq && apt-get install --no-install-recommends -y \
+    build-essential node-gyp pkg-config python-is-python3 openssl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY backend/package.json ./backend/
+COPY frontend/package.json ./frontend/
+
 RUN pnpm install --frozen-lockfile
 
-# Copy application code
-COPY . .
+COPY backend ./backend
 
+ENV NODE_ENV=production
+RUN pnpm --filter ./backend run build
 
-# Final stage for app image
-FROM base
+# -----------------------------------------------------------------------------
+# Runtime: API only (frontend is deployed separately, e.g. Vercel — see docs/DEPLOYMENT.md)
+# -----------------------------------------------------------------------------
+FROM base AS production
 
-# Copy built application
-COPY --from=build /app /app
+ENV NODE_ENV=production
 
-# Start the server by default, this can be overwritten at runtime
-EXPOSE 3000
-CMD [ "pnpm", "run", "start" ]
+# Prisma engines need OpenSSL; Sharp ships prebuilt libs for glibc on this image.
+RUN apt-get update -qq && apt-get install --no-install-recommends -y \
+    openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=build /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build /app/backend ./backend
+COPY --from=build /app/frontend/package.json ./frontend/package.json
+
+# Fly sets PORT to match http_service.internal_port (default 8080).
+EXPOSE 8080
+
+CMD ["pnpm", "--filter", "./backend", "run", "start:prod"]

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -118,6 +118,18 @@ WantedBy=multi-user.target
 
 ---
 
+## 3b. Fly.io (tùy chọn — container chỉ API)
+
+`Dockerfile` ở **root** monorepo: cài workspace qua `pnpm-lock.yaml`, **`pnpm --filter ./backend run build`**, runtime chạy **`pnpm --filter ./backend run start:prod`** (một process HTTP). Frontend tĩnh vẫn trên Vercel/Pages; `VITE_API_BASE_URL` trỏ tới hostname API Fly (HTTPS, `/api/v1`).
+
+- **`fly.toml`**: `http_service.internal_port = 8080` khớp `PORT` mà Fly gán cho máy; có health check `GET /api/v1/health`.
+- **Biến / secrets**: cùng nhóm bắt buộc như backend trên Pi — xem [`ENV.md`](ENV.md); đặt bằng `fly secrets set` / `[env]` trong `fly.toml` (không commit secret).
+- **Migration:** dùng `[deploy] release_command` (ví dụ `pnpm --filter ./backend exec prisma migrate deploy`) hoặc chạy tay sau deploy, tương tự Neon + Pi.
+
+Kiểm tra image cục bộ: `docker build -t diecast360-api:fly .` rồi `docker run` với `-e PORT=8080` và đủ biến để ứng dụng boot (ít nhất `DATABASE_URL`, `JWT_SECRET`, `COOKIE_SECRET` ≥ 32 ký tự).
+
+---
+
 ## 4. Biến môi trường tối thiểu (tóm tắt)
 
 | Nơi | Biến | Ghi chú |

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,23 @@
+# fly.toml app configuration file generated for diecast360 on 2026-05-26T08:27:17Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'diecast360'
+primary_region = 'sin'
+
+[build]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 256

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,8 @@ app = 'diecast360'
 primary_region = 'sin'
 
 [build]
+  dockerfile = 'Dockerfile'
+  build-target = 'production'
 
 [http_service]
   internal_port = 8080
@@ -16,8 +18,14 @@ primary_region = 'sin'
   min_machines_running = 0
   processes = ['app']
 
+[[http_service.checks]]
+  grace_period = '15s'
+  interval = '30s'
+  method = 'GET'
+  timeout = '5s'
+  path = '/api/v1/health'
+
 [[vm]]
-  memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 256
+  memory = '1gb'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds Fly Launch files and follow-up fixes from code review.

**Changes in this update**
- Dockerfile: multi-stage build installs the pnpm workspace (lockfile + package manifests), runs `pnpm --filter ./backend run build`, and starts `start:prod` only (no root `pnpm start` / dev stack).
- Runtime installs OpenSSL for Prisma; `EXPOSE 8080` matches Fly `internal_port` / injected `PORT`.
- `fly.toml`: remove conflicting `memory_mb` vs `memory`; add `[[http_service.checks]]` for `GET /api/v1/health`; set `[build] build-target = production`.
- `docs/DEPLOYMENT.md`: short Fly.io section (API-only container; frontend stays on Vercel).

**Verify locally** (when Docker is available): `docker build -t diecast360-api:fly .` and run with required env (see `docs/ENV.md`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acc7775f-1370-467c-bdd0-0b13d2d3f214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acc7775f-1370-467c-bdd0-0b13d2d3f214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

