### PR TITLE
docs: add uploads-wiped postmortem, runbooks, and deploy invariants (…

### DIFF
--- a/.cursor/rules/karpathy-guidelines.mdc
+++ b/.cursor/rules/karpathy-guidelines.mdc
@@ -146,6 +146,19 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 **Lint:** frontend has pre-existing lint errors — don't treat them as regressions, but don't add new ones.
 
+**Production data isolation:** `UPLOAD_DIR` (và mọi user state khác) **không bao giờ** được đặt trong `DEPLOY_REMOTE_PATH` (mặc định `/opt/diecast360-backend`). Default đã chuyển ra `/var/lib/diecast360/uploads`. Workflow Pi dùng `rsync --delete` ở mức gốc của `DEPLOY_REMOTE_PATH`; bất kỳ thứ gì không thuộc deploy bundle và không nằm trong exclude list sẽ bị xoá. Đây là invariant rút ra từ sự cố 2026-05-26 (xem `docs/POSTMORTEMS/2026-05-26-uploads-wiped.md`).
+
+**CI/CD touching deploy paths:** PR sửa `.github/workflows/deploy-*.yml` (đặc biệt phần `rsync`, `--delete`, `rm`, container image swap) phải:
+1. Kèm `--dry-run` output trong PR description, hoặc
+2. Verify trên staging Pi/VM trước, hoặc
+3. Scope hẹp 1 mục tiêu để dễ review từng dòng `--delete`/`--exclude`.
+
+Không gộp deploy changes với CI hygiene / dependency bumps / lockfile cleanup trong cùng PR.
+
+**Data loss response:** Nghi mất dữ liệu trên production → `systemctl stop diecast360-api` **TRƯỚC** khi điều tra (bảo toàn ext4 inode cho recovery). Quy trình: `docs/RUNBOOKS/data-loss-incident.md`.
+
+**Pi single-point-of-failure:** production chạy trên 1 Raspberry Pi với 1 SSD/SD card. Đã có 2 sự cố trong 2026 mất sạch `UPLOAD_DIR`: 1 do hardware (SSD chết, ~4h downtime), 1 do software (rsync wipe). Cùng root cause vận hành: **không có backup tự động**. Cho tới khi backup chạy + test restore quarterly thành công (xem `docs/RUNBOOKS/backup.md`), mọi feature đẩy thêm dữ liệu vào `UPLOAD_DIR` đều **tăng giá trị** thứ có thể mất lần tới. Cân nhắc: cutover sang R2 (`docs/DEPLOYMENT.md` §8) để loại Pi disk khỏi data path.
+
 ---
 
 **These guidelines are working if:** diffs are minimal, questions come before implementation, rewrites due to overcomplication are rare, and every changed line traces to the stated requirement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Pinned tooling: **`packageManager`** và **`engines`** trong `package.json` gố
 ### Key gotchas
 
 - **COOKIE_SECRET** must be at least 32 characters in `backend/.env` or the app will throw at startup.
+- **Production data layout:** `UPLOAD_DIR` (và mọi state khác như backup, log riêng, sqlite) **phải nằm ngoài** `DEPLOY_REMOTE_PATH` (mặc định `/opt/diecast360-backend`). Workflow Pi dùng `rsync --delete` để đồng bộ bundle: mọi thứ trong deploy root không thuộc bundle (trừ exclude) sẽ bị xoá khi deploy. Default đã chuyển sang `/var/lib/diecast360/uploads`. Postmortem chi tiết: [`docs/POSTMORTEMS/2026-05-26-uploads-wiped.md`](docs/POSTMORTEMS/2026-05-26-uploads-wiped.md).
+- **Pi single-point-of-failure + no backup:** đã có 2 sự cố mất sạch `UPLOAD_DIR` trong 2026 (hardware SSD chết + software rsync wipe). Backup tự động chưa được setup tại thời điểm các incident xảy ra. Trước khi đẩy code làm tăng giá trị state trên Pi (feature upload mới, cache lớn, …), kiểm tra [`docs/RUNBOOKS/backup.md`](docs/RUNBOOKS/backup.md) đã được implement chưa.
 - **Object storage (Cloudflare R2):** optional `STORAGE_DRIVER=r2` and `R2_*` variables — see [`docs/ENV.md`](docs/ENV.md) section **Object storage (Cloudflare R2)** and cutover notes in [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
 - **`onlyBuiltDependencies`** cho native deps (`sharp`, `bcrypt`, `prisma`, …) được khai báo trong [`pnpm-workspace.yaml`](pnpm-workspace.yaml).
 - After `pnpm install`, the backend `postinstall` runs `prisma generate` automatically.
@@ -37,7 +39,7 @@ Pinned tooling: **`packageManager`** và **`engines`** trong `package.json` gố
 | **`Commitlint`** | Pull requests | Conventional commits cho từng commit trong PR (`.commitlintrc.json`). |
 | **`PR Title Lint`** | PR opened/edited/… | Title semantic (squash-merge). Types giống commitlint (`feat`, `fix`, …). |
 | **`Labeler`** (`pull_request_target`) | Pull requests → `main`, `develop` | Label theo path (`.github/labeler.yml`); cần tạo sẵn labels `area:*`, `deps` trong repo. |
-| **`Deploy backend (Pi)`** | **`workflow_run` sau khi CI trên `main` success** (push event), hoặc `workflow_dispatch` | Migrate trên GitHub-hosted, build + **`pnpm deploy --prod --legacy`** trên runner Pi → rsync vào `/opt/diecast360-backend` (preserve `.env`), `prisma generate`, restart service. |
+| **`Deploy backend (Pi)`** | **`workflow_run` sau khi CI trên `main` success** (push event), hoặc `workflow_dispatch` | Migrate trên GitHub-hosted, build + **`pnpm deploy --prod --legacy`** trên runner Pi → rsync vào `/opt/diecast360-backend` (preserve `.env` + exclude `/uploads`), `prisma generate`, restart service. Trước khi sửa workflow phần `rsync`/`--delete`: review kèm `--dry-run` output trong PR description; nếu có thể, thử trên staging Pi/VM trước. Health check `/api/v1/health` hiện **không** touch storage — không tự phát hiện được "file mất nhưng app sống" (xem postmortem 2026-05-26). |
 
 **Pi (một lần):** bật pnpm khớp [`package.json`](package.json) `packageManager`, ví dụ:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,19 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 **Lint:** frontend has pre-existing lint errors — don't treat them as regressions, but don't add new ones.
 
+**Production data isolation:** `UPLOAD_DIR` (và mọi user state khác) **không bao giờ** được đặt trong `DEPLOY_REMOTE_PATH` (mặc định `/opt/diecast360-backend`). Default đã chuyển ra `/var/lib/diecast360/uploads`. Workflow Pi dùng `rsync --delete` ở mức gốc của `DEPLOY_REMOTE_PATH`; bất kỳ thứ gì không thuộc deploy bundle và không nằm trong exclude list sẽ bị xoá. Đây là invariant rút ra từ sự cố 2026-05-26 (xem [`docs/POSTMORTEMS/2026-05-26-uploads-wiped.md`](docs/POSTMORTEMS/2026-05-26-uploads-wiped.md)).
+
+**CI/CD touching deploy paths:** PR sửa `.github/workflows/deploy-*.yml` (đặc biệt phần `rsync`, `--delete`, `rm`, container image swap) phải:
+1. Kèm `--dry-run` output trong PR description, hoặc
+2. Verify trên staging Pi/VM trước, hoặc
+3. Scope hẹp 1 mục tiêu để dễ review từng dòng `--delete`/`--exclude`.
+
+Không gộp deploy changes với CI hygiene / dependency bumps / lockfile cleanup trong cùng PR.
+
+**Data loss response:** Nghi mất dữ liệu trên production → `systemctl stop diecast360-api` **TRƯỚC** khi điều tra (bảo toàn ext4 inode cho recovery). Quy trình: [`docs/RUNBOOKS/data-loss-incident.md`](docs/RUNBOOKS/data-loss-incident.md).
+
+**Pi single-point-of-failure:** production chạy trên 1 Raspberry Pi với 1 SSD/SD card. Đã có 2 sự cố trong 2026 mất sạch `UPLOAD_DIR`: 1 do hardware (SSD chết, ~4h downtime), 1 do software (rsync wipe). Cùng root cause vận hành: **không có backup tự động**. Cho tới khi backup chạy + test restore quarterly thành công (xem [`docs/RUNBOOKS/backup.md`](docs/RUNBOOKS/backup.md)), mọi feature đẩy thêm dữ liệu vào `UPLOAD_DIR` đều **tăng giá trị** thứ có thể mất lần tới. Cân nhắc: cutover sang R2 ([`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) §8) để loại Pi disk khỏi data path.
+
 ---
 
 **These guidelines are working if:** diffs are minimal, questions come before implementation, rewrites due to overcomplication are rare, and every changed line traces to the stated requirement.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -118,6 +118,39 @@ WantedBy=multi-user.target
 
 ---
 
+## 3.b. Production data layout rules
+
+**Invariant rút ra từ sự cố 2026-05-26** ([`POSTMORTEMS/2026-05-26-uploads-wiped.md`](POSTMORTEMS/2026-05-26-uploads-wiped.md)): state directory (uploads, backups, local caches) **phải nằm ngoài** `DEPLOY_REMOTE_PATH`. Workflow Pi dùng `rsync --delete` ở mức gốc của `DEPLOY_REMOTE_PATH`; mọi thứ trong đó không thuộc deploy bundle và không có trong exclude list sẽ bị xoá.
+
+**Bảng path chuẩn (FHS-aligned):**
+
+| Loại | Đường dẫn khuyến nghị | Owner | Lý do |
+|---|---|---|---|
+| Artifact deploy | `/opt/diecast360-backend/` | pi:pi | Bị `rsync --delete` đồng bộ mỗi deploy |
+| Config (secrets) | `/opt/diecast360-backend/.env` | pi:pi 600 | Excluded khỏi rsync (`--exclude=/.env`) |
+| **User state — uploads** | `/var/lib/diecast360/uploads/` | pi:pi 755 | **Phải ngoài artifact root.** Default mới. |
+| Backup local | `/mnt/usb-backup/diecast360-restic/` | pi:pi | USB external, ngoài Pi disk |
+| Log | journalctl (systemd) | system | Không ghi file trực tiếp |
+| Tmp / cache runtime | `/tmp/diecast360/` | pi:pi | Ephemeral, không cần backup |
+
+**Setup `/var/lib/diecast360/uploads` (1 lần per Pi):**
+
+```bash
+sudo mkdir -p /var/lib/diecast360/uploads
+sudo chown pi:pi /var/lib/diecast360/uploads
+sudo chmod 755 /var/lib/diecast360/uploads
+# Cập nhật /opt/diecast360-backend/.env: UPLOAD_DIR=/var/lib/diecast360/uploads
+sudo systemctl restart diecast360-api
+```
+
+**Khi nào hợp lệ để đặt state trong `DEPLOY_REMOTE_PATH`?** Chỉ khi state đó được **liệt kê tường minh** trong `--exclude` của rsync **và** được commit vào workflow review. Hiện tại workflow exclude `.env` + `/uploads`. Mọi state mới (ví dụ sqlite cache, vector store local) **phải đi qua quy trình:** thêm exclude → thêm bảng path → thêm gotcha vào AGENTS/CLAUDE.
+
+**Backup strategy** cho `UPLOAD_DIR`: xem [`RUNBOOKS/backup.md`](RUNBOOKS/backup.md). Tóm tắt: restic → R2 (offsite, encrypted, dedup, retention 7d/4w/12m) + USB external (offline, retention 14d) chạy nightly, alert nếu snapshot >26h.
+
+**Recovery** khi nghi mất data: xem [`RUNBOOKS/data-loss-incident.md`](RUNBOOKS/data-loss-incident.md). Quy tắc số 1: `systemctl stop` trước khi điều tra (bảo toàn ext4 inode).
+
+---
+
 ## 4. Biến môi trường tối thiểu (tóm tắt)
 
 | Nơi | Biến | Ghi chú |
@@ -128,7 +161,7 @@ WantedBy=multi-user.target
 | **Pi** | `BACKEND_URL` | URL public của API (HTTPS), dùng làm base cho signed media URL `/api/v1/media` |
 | **Pi** | `MEDIA_SIGNING_SECRET`, `MEDIA_URL_TTL_MS` | Tùy chọn cho signed media URL; nếu không set secret riêng, backend fallback sang `JWT_SECRET` |
 | **Pi** | `COOKIE_SECURE=true`, `COOKIE_SAME_SITE` | Production HTTPS — xem [`ENV.md`](ENV.md) |
-| **Pi** | `UPLOAD_DIR` | Bắt buộc khi `STORAGE_DRIVER=local` — đường dẫn ghi được. Với `STORAGE_DRIVER=r2` có thể giữ mặc định hoặc bỏ qua nhu cầu volume lớn cho media |
+| **Pi** | `UPLOAD_DIR` | Bắt buộc khi `STORAGE_DRIVER=local` — đường dẫn ghi được, **phải nằm ngoài `DEPLOY_REMOTE_PATH`** (xem mục 3.b). Default mới: `/var/lib/diecast360/uploads`. Với `STORAGE_DRIVER=r2` có thể bỏ qua nhu cầu volume lớn cho media |
 | **Pi** | `STORAGE_DRIVER`, `R2_*` | Khi dùng Cloudflare R2 — xem [`ENV.md`](ENV.md) |
 | **Vercel / Pages** (build) | `VITE_API_BASE_URL` | `https://<api-host>/api/v1` |
 

--- a/docs/POSTMORTEMS/2026-05-26-uploads-wiped.md
+++ b/docs/POSTMORTEMS/2026-05-26-uploads-wiped.md
@@ -1,0 +1,128 @@
+# 2026-05-26 — Production `uploads/` wiped by deploy workflow
+
+**Severity:** SEV-2 (user data loss, no auth/payment impact)
+**Status:** Mitigated by PR #280 (workflow fix). Data recovery in progress.
+**Authors:** Cursor Agent + nguyenhoangtin1404
+
+## TL;DR
+
+Sau khi PR #250 (`ci: pnpm-first pipelines, gated Pi deploy, and hygiene workflows`) merge, `deploy-backend.yml` chuyển sang `rsync -a --delete --exclude='.env'` ở mức **gốc** của `DEPLOY_REMOTE_PATH` (`/opt/diecast360-backend`). Vì `backend/.env.production.example` mặc định đặt `UPLOAD_DIR="/opt/diecast360-backend/uploads"` — **nằm trong** thư mục đó — bundle từ `pnpm deploy --prod --legacy` (không có `uploads/`) khiến rsync `--delete` xoá toàn bộ media người dùng trên mỗi lần backend deploy. 9 deploy chạy trước khi phát hiện. Database vẫn còn metadata + `file_path`, nhưng file ảnh/spinner/branding biến mất → public catalog 404 mọi signed media URL.
+
+> **Recurrence note:** Đây là lần **thứ hai** trong 2026 mất sạch `UPLOAD_DIR` vì không có backup. Lần trước: [`2026-pi-ssd-failure.md`](2026-pi-ssd-failure.md) (hardware fail). Cùng root cause vận hành (no automated backup) — 2 đường khác nhau cùng dẫn tới mất data. Action item "backup tự động + test restore" còn open từ sự cố SSD trước đó là **contributing factor lớn nhất** của thiệt hại lần này.
+
+## Impact
+
+- **Data lost:** mọi file dưới `UPLOAD_DIR` tại thời điểm deploy đầu tiên sau PR #250 (item images, thumbnails, 360° spinner frames, shop branding logo + favicon, drafts AI image import).
+- **Database:** không ảnh hưởng. Tất cả record (`item_images`, `spin_sets`, `spin_frames`, `shops.logo_url`, `shops.favicon_url`) còn nguyên `file_path`.
+- **User-facing:** trang public + admin hiển thị ảnh vỡ. Browser console:
+  ```
+  GET https://api.nhtin.name.vn/api/v1/media?d=…&s=… 404 (Not Found)
+  ```
+- **Time-to-detection:** ~10 giờ (PR #250 merged 04:11 UTC+7, phát hiện ~14:00 UTC+7).
+- **Time-to-mitigation:** ~30 phút sau khi phát hiện (PR #280).
+- **Financial:** chưa quantify được tại thời điểm viết. Cần input từ owner: số item có ảnh, doanh thu/ngày, chi phí tái upload. Framework tính ở dưới (section *Cost estimate framework*).
+
+## Cost estimate framework
+
+Khi có số liệu từ owner, tính theo công thức:
+
+```
+Loss_labor   = N_items_with_images * T_per_item_min   * (Rate_labor_per_hour / 60)
+             + N_spinner_sets      * T_per_spinner_min * (Rate_labor_per_hour / 60)
+             + N_shop_branding     * 5 min             * (Rate_labor_per_hour / 60)
+
+Loss_revenue = D_outage_days * Rev_daily * Drop_conv
+
+Loss_total   = Loss_labor + Loss_revenue
+```
+
+Inputs cần thu thập (chạy query trong [`../RUNBOOKS/data-loss-incident.md`](../RUNBOOKS/data-loss-incident.md) Step 2 để có 3 số đầu):
+
+- `N_items_with_images` — count `item_images` (file_path distinct)
+- `N_spinner_sets` — count `spin_sets`
+- `N_shop_branding` — count shops có `appearance_json -> 'logo_url'` hoặc `'favicon_url'`
+- `T_per_item_min` — thời gian chụp + upload lại 1 item (operator ước lượng, ~15 min)
+- `T_per_spinner_min` — thời gian quay lại 1 spinner 24-frame (~30 min)
+- `Rate_labor_per_hour` — chi phí nhân công (VND/giờ)
+- `D_outage_days` — số ngày ảnh hưởng tới sales (từ deploy đầu sau #250 tới khi recover xong)
+- `Rev_daily` — doanh thu trung bình/ngày
+- `Drop_conv` — % conversion drop khi ảnh vỡ (ước lượng 60–90% cho retail-by-image)
+
+Update bảng này khi có số liệu thật.
+
+## Timeline (UTC+7, 2026-05-26)
+
+| Time | Event |
+|---|---|
+| 04:11 | PR #250 merged to `main`. CI green. |
+| 04:14 | First `Deploy backend (Pi)` workflow run; `rsync --delete` wipes `/opt/diecast360-backend/uploads/` for the first time. App restarts, `/api/v1/health` green. |
+| 04:14 – 12:01 | 8 thêm deploy chạy (Dependabot bumps + #250 merge). Mỗi lần `rsync --delete` chạy lại trên thư mục rỗng + restart app, ghi đè inode đã giải phóng. |
+| ~14:00 | User phát hiện ảnh vỡ trên trang production, console log 401 (`/auth/me`, harmless) + 404 (`/media?...`). |
+| 14:10 | Investigation start. Pull main, đọc `deploy-backend.yml` + `signed-media.util.ts` + `media.controller.ts`. |
+| 14:18 | Root cause confirmed: `rsync --delete` xoá `uploads/` vì `UPLOAD_DIR` nằm trong `REDIR`. |
+| 14:23 | PR #280 mở (branch `cursor/fix-deploy-rsync-wipes-uploads`). |
+| 14:30 | PR #280 merged. Production deploy tiếp theo sẽ không xoá `uploads/` (qua `--exclude`) ngay cả khi operator chưa di chuyển `UPLOAD_DIR`. |
+| — | Recovery: ext4 `extundelete` / `testdisk` hoặc tái upload từ nguồn gốc (chưa kết thúc tại thời điểm viết). |
+
+## Root cause
+
+`rsync -a --delete --exclude='.env'` ở mức gốc của `DEPLOY_REMOTE_PATH`. Bundle nguồn (`pnpm deploy --prod --legacy`) chỉ chứa runtime files (`package.json`, `node_modules/`, `dist/`, `prisma/`). Thư mục `uploads/` nằm trong `DEPLOY_REMOTE_PATH` nhưng không có trong bundle → bị `--delete` xoá mỗi deploy.
+
+```yaml
+# .github/workflows/deploy-backend.yml (BEFORE PR #280)
+rsync -a --delete --exclude='.env' "${{ steps.bundle.outputs.path }}/" "${REDIR}/"
+```
+
+## Contributing factors
+
+1. **Layout coupling:** `backend/.env.production.example` đặt `UPLOAD_DIR` **trong** `DEPLOY_REMOTE_PATH`. Documentation drift — sample env và workflow assumption không khớp.
+2. **Workflow PR quá rộng:** PR #250 gộp 4–5 mục tiêu (pnpm-first, gated deploy, hygiene workflows, dependabot config, lockfile cleanup). Dòng rsync `--delete` mức gốc bị nuốt giữa hàng trăm dòng diff khó review.
+3. **Health check không touch storage:** `GET /api/v1/health` không kiểm `UPLOAD_DIR` non-empty hoặc fetch thử 1 signed media URL → deploy "thành công" theo CI dù dữ liệu mất.
+4. **Không có backup tự động** cho `UPLOAD_DIR`. Không có 3-2-1, không có offsite.
+5. **Không có staging** Pi giả lập để thử workflow thay đổi trước khi đụng production.
+6. **`workflow_run` trigger đa tầng:** Mỗi merge vào main (kể cả Dependabot) đều fire deploy → tần suất ghi đè cao → ext4 recovery khó hơn.
+
+## Detection
+
+User phát hiện qua DevTools console. Không có alert tự động.
+
+## Recovery
+
+(Đang triển khai — sẽ cập nhật vào section này.)
+
+Quy trình theo `docs/RUNBOOKS/data-loss-incident.md`:
+1. `sudo systemctl stop diecast360-api` ngừng ghi đĩa.
+2. Thử `extundelete` / `testdisk` trên ext4. Xác suất giảm do 9 deploy đã chạy.
+3. Khi không recover được: tái upload từ nguồn gốc; DB `file_path` vẫn dùng được nếu key trùng.
+
+## Action items
+
+| # | Action | Owner | Status | Reference |
+|---|---|---|---|---|
+| 1 | Workflow exclude `/uploads`, env example chuyển `UPLOAD_DIR` ra `/var/lib/diecast360/uploads` | Cursor Agent | ✅ Done | PR #280 |
+| 2 | Operator di chuyển `UPLOAD_DIR` thực tế trên Pi ra ngoài `REDIR` | nguyenhoangtin1404 | Pending | Section *Operator follow-up* trong PR #280 |
+| 3 | Defensive rsync guardrails (`--max-delete`, dry-run preview, sanity check UPLOAD_DIR) | Cursor Agent | Planned | PR `cursor/harden-deploy-rsync-guardrails` (sắp mở) |
+| 4 | Postmortem + runbook + invariants vào knowledge base | Cursor Agent | In PR | PR này |
+| 5 | Backup tự động `UPLOAD_DIR` (restic → R2 + USB), test restore quarterly | nguyenhoangtin1404 | Planned | `docs/RUNBOOKS/backup.md` |
+| 6 | Health check probe signed media URL thực tế trên Pi sau deploy | TBD | Planned | TBD |
+| 7 | Staging Pi (container/VM) để thử CI/CD trước production | TBD | Backlog | TBD |
+| 8 | Branch protection require 1 reviewer cho PR đụng `.github/workflows/deploy-*.yml` | nguyenhoangtin1404 | Planned | GitHub settings |
+
+## Lessons (xem chi tiết tại commit message PR #280 và phần "5. Diecast360-specific invariants" trong `CLAUDE.md`)
+
+1. **Tách artifact (`/opt/<app>`) khỏi state (`/var/lib/<app>`).** Không bao giờ đặt user data trong thư mục bị deploy ghi đè.
+2. **`rsync --delete` ở root là vũ khí.** Dùng kèm `--max-delete=N` hoặc giới hạn vào subdir đã biết.
+3. **Backup là không tuỳ chọn cho production.** 3-2-1, test restore.
+4. **CI/CD change đụng production phải staging hoặc dry-run trước.**
+5. **Health check phải đụng storage thực** — `/health` JSON không đủ.
+6. **PR đụng deploy phải hẹp scope** — dễ review từng dòng `rsync`/`rm`/`--delete`.
+7. **Nghi data loss → STOP service trước, điều tra sau** (bảo toàn inode ext4).
+
+## References
+
+- PR #250 (gây): https://github.com/nguyenhoangtin1404/Diecast360/pull/250
+- PR #280 (vá): https://github.com/nguyenhoangtin1404/Diecast360/pull/280
+- Postmortem trước (cùng pattern data loss): [`2026-pi-ssd-failure.md`](2026-pi-ssd-failure.md)
+- Runbook: [`docs/RUNBOOKS/data-loss-incident.md`](../RUNBOOKS/data-loss-incident.md)
+- Backup strategy: [`docs/RUNBOOKS/backup.md`](../RUNBOOKS/backup.md)
+- Invariants: [`CLAUDE.md`](../../CLAUDE.md) §5, [`AGENTS.md`](../../AGENTS.md) §Key gotchas

--- a/docs/POSTMORTEMS/2026-pi-ssd-failure.md
+++ b/docs/POSTMORTEMS/2026-pi-ssd-failure.md
@@ -1,0 +1,77 @@
+# 2026 — Pi SSD failure, full disk loss
+
+**Severity:** SEV-2 (full user-uploaded data loss, ~4h downtime)
+**Status:** Resolved (Pi rebuilt from scratch). Action items still partially open.
+**Date (approximate):** Mid 2026, sau khi DB đã chuyển sang Neon, trước sự cố [`2026-05-26-uploads-wiped`](2026-05-26-uploads-wiped.md). Date chính xác không ghi lại được tại thời điểm xảy ra — postmortem này viết hồi tố từ ký ức operator.
+
+## TL;DR
+
+Ổ SSD của Raspberry Pi production chết đột ngột (hardware failure, không phải lỗi software). Toàn bộ nội dung đĩa mất: OS, app artifact (`/opt/diecast360-backend`), `UPLOAD_DIR`, `.env`, cấu hình systemd/Cloudflare Tunnel/cron. Database trên **Neon** không bị ảnh hưởng nên giữ nguyên metadata. Không có backup tự động cho `UPLOAD_DIR` → toàn bộ ảnh/spinner/branding mất vĩnh viễn (phải tái upload từ nguồn gốc). Recovery kéo dài ~4h thủ công: flash OS mới, cài Node + pnpm + git, clone repo, build, viết lại `.env` từ trí nhớ + password manager, cấu hình lại Cloudflare Tunnel + systemd, khởi động lại API.
+
+## Impact
+
+- **Data lost:** mọi file dưới `UPLOAD_DIR` (item images, spinner frames, shop branding). Database không mất (đã ở Neon).
+- **Downtime:** ~4 giờ từ lúc Pi không phản hồi tới lúc `/api/v1/health` trả 200 trở lại.
+- **Cost (operator time):** 4h × labor rate. Re-upload sản phẩm sau đó tốn thêm nhiều giờ.
+- **User-facing:** trang public hoàn toàn không truy cập được trong khoảng downtime (không phải chỉ ảnh vỡ). Sau khi backup online: ảnh vỡ 404 như sự cố tháng 5.
+- **Brand:** mất uptime, có thể ảnh hưởng SEO / customer trust.
+
+## Root cause
+
+Hardware failure: ổ SSD trên Raspberry Pi ngừng phản hồi. Không có pre-failure indicator (SMART attributes không được monitor).
+
+## Contributing factors
+
+1. **Single point of failure:** toàn bộ production chạy trên 1 SD/SSD của 1 Pi, không có HA, không có hot standby.
+2. **No automated backup:** `UPLOAD_DIR` chỉ tồn tại trên đĩa Pi. Không có copy tới USB external, không có sync tới R2/B2, không có snapshot.
+3. **No SMART monitoring:** không có cảnh báo trước khi SSD chết. SSD trên consumer hardware có thể fail mà không warning, đặc biệt cheaper drives.
+4. **No infrastructure-as-code:** mọi setup Pi (Node version, systemd unit, Cloudflare Tunnel config, firewall rule, cron) đều được làm thủ công. Khi rebuild phải nhớ từng bước → tốn thời gian + dễ sai sót.
+5. **`.env` không có backup tách biệt:** secrets được viết lại từ trí nhớ + password manager, mất thời gian + rủi ro thiếu var.
+6. **Pi consumer-grade hardware không phù hợp production-critical:** SD/SSD trên Pi không có endurance rating đảm bảo, kế hoạch capacity không tính tới fail rate.
+
+## Timeline (approximate, reconstructed)
+
+| Thời điểm | Sự kiện |
+|---|---|
+| T+0 | Pi ngừng phản hồi `ping` + Cloudflare Tunnel báo offline. |
+| T+0:15 | Confirm bằng SSH thất bại + power-cycle không restart được. |
+| T+0:30 | Xác định SSD/SD card chết (không boot, không nhận trong reader khác). |
+| T+0:45 | Flash OS mới (Raspberry Pi OS 64-bit) lên SD/SSD thay thế. |
+| T+1:30 | Cài Node 20 + corepack + pnpm + git. |
+| T+2:00 | Clone repo, `pnpm install --frozen-lockfile`, `pnpm --filter ./backend build`. |
+| T+2:30 | Viết lại `backend/.env` từ password manager + trí nhớ. |
+| T+3:00 | Cấu hình lại systemd unit (`/etc/systemd/system/diecast360-api.service`). |
+| T+3:30 | Cấu hình lại Cloudflare Tunnel (`cloudflared`). |
+| T+3:45 | `prisma migrate deploy` (Neon đã có migration sẵn). |
+| T+4:00 | `systemctl start diecast360-api`, `curl /api/v1/health` → 200. Public catalog: metadata hiện, ảnh 404 (chưa tái upload). |
+
+## Lessons (reinforce + bổ sung so với sự cố 2026-05-26)
+
+Bài học trùng với sự cố tháng 5:
+- **Backup là không tuỳ chọn.** Hardware fail bất ngờ; software bug fail bất ngờ; cả hai cùng dẫn tới data loss nếu không có backup. 2 sự cố trong 1 năm vì cùng một thiếu sót.
+
+Bài học bổ sung từ sự cố này:
+- **Hardware single-point-of-failure phải có DR plan.** 1 Pi = 1 disk = 1 PSU = 1 SD/SSD chết là sập toàn bộ production.
+- **Rebuild process phải scripted, không manual.** 4h thủ công là quá nhiều. Mục tiêu: <30 phút từ flash OS tới `/health` 200, với 1 script Ansible/bash provisioning + secrets từ password manager.
+- **`.env` cần backup riêng** (mã hoá, offsite). Password manager (Bitwarden/1Password) lưu file attachment hoặc note multiline cho `.env` production.
+- **SMART monitoring** trên Pi: cron 1 lần/giờ check `smartctl`, alert nếu pre-failure attribute xuất hiện. Cảnh báo trước 24–48h cho hardware-degradation phổ biến.
+- **State migration sang R2** giảm dependency vào Pi disk: nếu uploads ở R2, Pi disk fail chỉ ảnh hưởng app process, không ảnh hưởng dữ liệu.
+
+## Action items
+
+| # | Action | Owner | Status | Reference |
+|---|---|---|---|---|
+| 1 | DB chuyển sang Neon | nguyenhoangtin1404 | ✅ Done (trước sự cố này) | — |
+| 2 | Backup tự động `UPLOAD_DIR` (restic → R2 + USB) | nguyenhoangtin1404 | **Open — chưa làm** | [`docs/RUNBOOKS/backup.md`](../RUNBOOKS/backup.md) |
+| 3 | `.env` production backup vào password manager (encrypted note/attachment) | nguyenhoangtin1404 | **Open** | TBD |
+| 4 | Pi rebuild runbook + provisioning script (Ansible/bash) | TBD | **Open — chưa có** | `docs/RUNBOOKS/pi-rebuild.md` (chưa tồn tại) |
+| 5 | SMART monitoring SSD + cron alert | TBD | **Open** | TBD |
+| 6 | Cân nhắc cutover state sang R2 (giảm SPOF Pi disk) | nguyenhoangtin1404 | Backlog | [`docs/DEPLOYMENT.md`](../DEPLOYMENT.md) §8 |
+| 7 | Cân nhắc hot standby / failover Pi | nguyenhoangtin1404 | Backlog (cost trade-off) | TBD |
+
+## References
+
+- Postmortem cùng category (data loss, cùng thiếu backup): [`2026-05-26-uploads-wiped.md`](2026-05-26-uploads-wiped.md)
+- Backup strategy: [`../RUNBOOKS/backup.md`](../RUNBOOKS/backup.md)
+- Recovery runbook (live disk, ext4): [`../RUNBOOKS/data-loss-incident.md`](../RUNBOOKS/data-loss-incident.md) — **không áp dụng** cho disk chết hoàn toàn; cần `pi-rebuild.md` riêng.
+- Invariants: [`../../CLAUDE.md`](../../CLAUDE.md) §5

--- a/docs/RUNBOOKS/backup-test-log.md
+++ b/docs/RUNBOOKS/backup-test-log.md
@@ -1,0 +1,24 @@
+# Backup restore-test log
+
+Append-only log of quarterly backup restore tests, per the checklist in [`backup.md`](backup.md) section *Test restore*.
+
+**Rule:** mỗi lần chạy checklist quarterly, append 1 entry. Không xoá entry cũ — lịch sử pass/fail là evidence cho audit + cho biết backup có ổn định không.
+
+## Template
+
+```
+## YYYY-MM-DD — <Tester name>
+
+- Target: <R2 | USB | both>
+- Snapshot ID: <restic snapshot id>
+- Source dir count: <find ... | wc -l>
+- Restored dir count: <find ... | wc -l>
+- Sample diff (5 file random): <PASS | FAIL — details>
+- Duration: <minutes>
+- Notes: <any anomaly, missing file, performance issue>
+- Status: ✅ PASS | ❌ FAIL — action required
+```
+
+## History
+
+_Chưa có lần test nào. Lần đầu chạy checklist sau khi backup setup theo `backup.md`._

--- a/docs/RUNBOOKS/backup.md
+++ b/docs/RUNBOOKS/backup.md
@@ -1,0 +1,253 @@
+# Runbook — Backup strategy & setup
+
+**Mục tiêu:** không bao giờ mất quá 24h dữ liệu user-uploaded; có thể restore trong 4h.
+
+## RPO / RTO
+
+| Loại data | Nguồn | RPO | RTO | Backup destination |
+|---|---|---|---|---|
+| User uploads (`UPLOAD_DIR`) | Pi local disk hoặc R2 | 24h | 4h | USB external + offsite (R2 hoặc Backblaze B2) |
+| Postgres (Neon) | Managed by Neon | Per Neon plan | Per Neon plan | Neon snapshots + optional `pg_dump` offsite |
+| `.env` production | Pi `/opt/diecast360-backend/.env` | Mỗi lần thay đổi | <1h | 1Password / Bitwarden (encrypted) |
+| Git repo | GitHub | Real-time | Real-time | GitHub clone |
+
+Tài liệu này tập trung vào **`UPLOAD_DIR`** — phần lớn nhất, dễ mất nhất, và mất rồi không tái tạo được từ code.
+
+## Strategy: 3-2-1
+
+- **3 bản sao**: bản gốc trên Pi + USB external trên Pi + offsite (R2/B2).
+- **2 phương tiện khác nhau**: ổ Pi (SD/SSD) + USB drive.
+- **1 offsite**: object storage cloud.
+
+## Tool choice
+
+| Tool | Khi dùng | Pros | Cons |
+|---|---|---|---|
+| `restic` | **Khuyến nghị** | Encrypted, dedup, incremental, snapshot rollback, hỗ trợ S3/B2/SFTP | Cần học cú pháp |
+| `rclone sync` | Mirror đơn giản tới R2/B2 | Quen thuộc, không state | Không versioning, nếu source bị xoá thì destination cũng |
+| `borgbackup` | Tương đương `restic`, mạnh | Encrypted, dedup, snapshot | Local-first; remote qua SSH |
+| `rsync --link-dest` | Hardlink-based snapshots local | Đơn giản, không cần install | Phức tạp khi nhiều snapshot |
+
+→ Doc này dùng **`restic`** làm reference. Adapt cho tool khác tương tự.
+
+## Setup (Pi + R2 + USB)
+
+### 1. Cài restic + jq
+
+`jq` được dùng bởi health-check script ở step 7 (parse `restic snapshots --json`). Cài cùng lúc để cron alert không silently fail.
+
+```bash
+sudo apt-get update
+sudo apt-get install -y restic jq
+restic version
+jq --version
+```
+
+### 2. Chuẩn bị credentials cho R2
+
+Tạo file `~/.restic.env` (chỉ user pi đọc được):
+
+```bash
+sudo -u pi tee /home/pi/.restic.env > /dev/null <<'EOF'
+# R2 access (tạo trong Cloudflare R2 console — Object Read & Write)
+export AWS_ACCESS_KEY_ID="<R2_ACCESS_KEY_ID>"
+export AWS_SECRET_ACCESS_KEY="<R2_SECRET_ACCESS_KEY>"
+export RESTIC_REPOSITORY="s3:https://<account-id>.r2.cloudflarestorage.com/<bucket-backup>"
+# Password >= 32 char, sinh random + lưu vào password manager
+export RESTIC_PASSWORD="<long-random-passphrase>"
+EOF
+sudo chown pi:pi /home/pi/.restic.env
+sudo chmod 600 /home/pi/.restic.env
+```
+
+> ⚠️ Bucket backup phải **khác** bucket media production (`R2_BUCKET`). Nếu chung bucket, một bug xoá media có thể đi qua restic và mất luôn snapshot.
+
+### 3. Init repository
+
+```bash
+source /home/pi/.restic.env
+restic init
+```
+
+### 4. First backup
+
+```bash
+restic backup /var/lib/diecast360/uploads --tag uploads --tag pi
+# Hoặc nếu UPLOAD_DIR vẫn ở legacy path:
+restic backup /opt/diecast360-backend/uploads --tag uploads --tag pi
+```
+
+Kiểm tra:
+
+```bash
+restic snapshots
+restic stats latest
+```
+
+### 5. USB backup (offline copy)
+
+Mount USB tại `/mnt/usb-backup`, tạo password file riêng (cron sẽ đọc), init repo:
+
+```bash
+sudo mkdir -p /mnt/usb-backup
+sudo mount /dev/sda1 /mnt/usb-backup
+sudo chown pi:pi /mnt/usb-backup
+
+# Tạo password file cho USB repo (khác password R2). Password >= 32 char,
+# sinh random + lưu vào password manager song song với file này.
+# File này được cron đọc qua RESTIC_PASSWORD_FILE — KHÔNG bỏ qua bước này.
+sudo -u pi tee /home/pi/.restic-usb-password > /dev/null <<'EOF'
+<long-random-passphrase-cho-USB-repo>
+EOF
+sudo chown pi:pi /home/pi/.restic-usb-password
+sudo chmod 600 /home/pi/.restic-usb-password
+
+# Init repo (đọc password từ file vừa tạo):
+RESTIC_REPOSITORY=/mnt/usb-backup/diecast360-restic \
+RESTIC_PASSWORD_FILE=/home/pi/.restic-usb-password \
+restic init
+
+# First backup (cùng env):
+RESTIC_REPOSITORY=/mnt/usb-backup/diecast360-restic \
+RESTIC_PASSWORD_FILE=/home/pi/.restic-usb-password \
+restic backup /var/lib/diecast360/uploads --tag uploads --tag usb
+```
+
+### 6. Cron job (nightly)
+
+> **Đừng pipe `restic backup && restic forget | logger` trực tiếp trong cron.** Bash trả exit code của lệnh **cuối cùng** trong pipeline trừ khi `pipefail` được set; nếu `restic forget` fail (retention/prune lỗi) mà `logger` thành công, cron sẽ coi như OK — bạn không biết retention hỏng. Bọc qua wrapper script với `set -o pipefail` để bắt được mọi lỗi.
+
+Wrapper script `/usr/local/bin/diecast360-backup.sh`:
+
+```bash
+#!/bin/bash
+# Backup wrapper: forward stdout/stderr vào syslog với tag, exit non-zero nếu
+# bất kỳ stage nào fail (kể cả forget/prune). Đọc env theo TARGET arg.
+set -euo pipefail
+
+TARGET="${1:?usage: $0 <r2|usb>}"
+case "$TARGET" in
+  r2)
+    source /home/pi/.restic.env
+    RETENTION=(--keep-daily 7 --keep-weekly 4 --keep-monthly 12)
+    TAG=pi
+    LOGTAG=restic-r2
+    ;;
+  usb)
+    export RESTIC_REPOSITORY=/mnt/usb-backup/diecast360-restic
+    export RESTIC_PASSWORD_FILE=/home/pi/.restic-usb-password
+    RETENTION=(--keep-daily 14)
+    TAG=usb
+    LOGTAG=restic-usb
+    ;;
+  *) echo "unknown target: $TARGET" >&2; exit 2 ;;
+esac
+
+{
+  restic backup /var/lib/diecast360/uploads --tag uploads --tag "$TAG" --quiet
+  restic forget "${RETENTION[@]}" --prune --quiet
+} 2>&1 | logger -t "$LOGTAG"
+
+# `set -o pipefail` ở trên đảm bảo exit code phản ánh lỗi của bất kỳ lệnh nào
+# trong block — kể cả forget/prune — không bị `logger` nuốt.
+```
+
+```bash
+sudo install -m 755 -o root -g root /dev/stdin /usr/local/bin/diecast360-backup.sh < diecast360-backup.sh
+```
+
+`/etc/cron.d/diecast360-backup`:
+
+```cron
+# Backup uploads tới R2 mỗi 03:00, USB mỗi 04:00. Pi user.
+# Wrapper script bắt lỗi qua pipefail; cron sẽ email/mail spool khi exit != 0
+# (cần MAILTO hoặc systemd OnFailure để forward — xem step 7 alert).
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+MAILTO=""
+
+0 3 * * * pi /usr/local/bin/diecast360-backup.sh r2
+0 4 * * * pi /usr/local/bin/diecast360-backup.sh usb
+```
+
+Retention example: 7 ngày + 4 tuần + 12 tháng trên R2; 14 ngày trên USB.
+
+### 7. Alert nếu backup không chạy >24h
+
+Đơn giản nhất: cron health-check + send Telegram khi snapshot cuối >24h.
+
+`/usr/local/bin/check-backup.sh`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+source /home/pi/.restic.env
+
+LAST=$(restic snapshots --tag uploads --tag pi --json | jq -r 'max_by(.time).time' | xargs -I{} date -d {} +%s)
+NOW=$(date +%s)
+AGE=$(( (NOW - LAST) / 3600 ))
+
+if [ "$AGE" -gt 26 ]; then
+  curl -sfS -X POST "https://api.telegram.org/bot$TG_TOKEN/sendMessage" \
+    -d "chat_id=$TG_CHAT_ID" \
+    -d "text=⚠️ Diecast360 backup STALE — last snapshot ${AGE}h ago"
+fi
+```
+
+Cron: `0 8 * * * pi /usr/local/bin/check-backup.sh`. Alert vào Telegram/email.
+
+Alternative: dùng [`healthchecks.io`](https://healthchecks.io) — backup cron `&&` curl ping URL, nếu URL không được ping trong N giờ thì service tự alert.
+
+## Test restore (quarterly checklist)
+
+> **Backup chưa restore thành công không phải backup.** Cài calendar reminder hằng quý (3 tháng/lần).
+
+```bash
+# 1. Restore vào /tmp (KHÔNG đụng production):
+source /home/pi/.restic.env
+restic restore latest --target /tmp/restore-test --include /var/lib/diecast360/uploads
+
+# 2. Verify file count + size:
+SRC_COUNT=$(find /var/lib/diecast360/uploads -type f | wc -l)
+DST_COUNT=$(find /tmp/restore-test/var/lib/diecast360/uploads -type f | wc -l)
+echo "Source: $SRC_COUNT, Restored: $DST_COUNT"
+
+# 3. Random sample diff:
+for f in $(find /var/lib/diecast360/uploads -type f | shuf -n 5); do
+  rel="${f#/var/lib/diecast360/uploads/}"
+  diff "$f" "/tmp/restore-test/var/lib/diecast360/uploads/$rel" && echo "OK: $rel" || echo "FAIL: $rel"
+done
+
+# 4. Cleanup test dir:
+rm -rf /tmp/restore-test
+```
+
+Cũng test restore từ **USB** ít nhất 1 lần/quý — đảm bảo ổ chưa hỏng.
+
+Log kết quả vào `docs/RUNBOOKS/backup-test-log.md` (append-only).
+
+## Recovery — point-in-time
+
+Trong sự cố:
+
+```bash
+source /home/pi/.restic.env
+restic snapshots --tag uploads          # list snapshots
+restic restore <snapshot-id> --target / # restore in-place
+
+# Hoặc restore subset:
+restic restore <snapshot-id> --target /tmp/recover \
+  --include "/var/lib/diecast360/uploads/shop-branding"
+sudo rsync -a /tmp/recover/var/lib/diecast360/uploads/ /var/lib/diecast360/uploads/
+```
+
+Xem `data-loss-incident.md` cho full incident workflow.
+
+## What NOT to back up
+
+- `node_modules/` — regenerate được, tốn dung lượng.
+- `dist/` — build từ source.
+- `*.log` files — quay lại qua journalctl/observability.
+- `.env` — backup riêng vào password manager (chứa secrets, mã hoá bằng OS-level keychain hoặc Bitwarden file attachment).
+- DB Postgres — Neon đã có managed snapshots. Nếu cần offsite, schedule `pg_dump` riêng vào restic repo khác.

--- a/docs/RUNBOOKS/data-loss-incident.md
+++ b/docs/RUNBOOKS/data-loss-incident.md
@@ -1,0 +1,293 @@
+# Runbook — Suspected production data loss
+
+**Use this runbook when:** files dưới `UPLOAD_DIR` (hoặc data dir khác) trên production server bị nghi xoá nhầm. Áp dụng cho Pi self-hosted + ext4. Cloud storage (R2) có path recovery riêng — xem section *Cloud storage recovery* phía cuối.
+
+> **Quy tắc số 1:** Dừng mọi process ghi đĩa **TRƯỚC KHI** điều tra. Mỗi giây app tiếp tục chạy là tăng xác suất ghi đè inode đã giải phóng → giảm khả năng recover của `extundelete`/`testdisk`.
+
+## Step 1 — STOP everything that writes
+
+```bash
+sudo systemctl stop diecast360-api          # ngừng backend
+sudo systemctl stop diecast360-deploy.timer 2>/dev/null || true  # nếu có cron deploy
+# Tạm tắt cron user nếu có job ghi /opt hoặc /var/lib:
+sudo systemctl stop cron                    # cân nhắc — chỉ khi cần
+```
+
+Đảm bảo không có job CI nào đang/sắp chạy:
+
+```bash
+# Trên máy dev:
+gh run list --workflow=deploy-backend.yml --limit 5
+# Nếu có run đang queue: cancel
+gh run cancel <run-id>
+```
+
+Tạm thời disable workflow để không tự deploy lại trong lúc điều tra:
+
+```bash
+gh workflow disable "Deploy backend (Pi)"
+```
+
+## Step 2 — Đánh giá phạm vi
+
+Lưu ý: tránh ghi đĩa đáng kể vào partition đang điều tra ở bước này. Các lệnh dưới đây là **read-only** đối với `UPLOAD_DIR` (ls/find/df) — an toàn.
+
+Trên Pi:
+
+```bash
+# UPLOAD_DIR đang là gì?
+grep -E '^UPLOAD_DIR=' /opt/diecast360-backend/.env
+
+# Còn lại gì trong UPLOAD_DIR?
+UD=$(grep -E '^UPLOAD_DIR=' /opt/diecast360-backend/.env | sed 's/^UPLOAD_DIR=//; s/^"//; s/"$//')
+ls -la "$UD" 2>/dev/null
+find "$UD" -type f | wc -l
+
+# Disk usage thay đổi đột ngột?
+df -h /opt /var/lib
+```
+
+Từ DB (chạy **trên máy dev** với `DIRECT_URL`, không trên Pi):
+
+```sql
+-- Tổng số file kỳ vọng. Shop branding (logo/favicon) lưu trong
+-- shops.appearance_json (Json), không phải column riêng — xem schema.prisma.
+SELECT
+  (SELECT COUNT(*) FROM item_images)                                          AS item_images_expected,
+  (SELECT COUNT(*) FROM spin_frames)                                          AS spin_frames_expected,
+  (SELECT COUNT(*) FROM shops
+     WHERE appearance_json ? 'logo_url'    AND appearance_json ->> 'logo_url'    <> '') AS shop_logos,
+  (SELECT COUNT(*) FROM shops
+     WHERE appearance_json ? 'favicon_url' AND appearance_json ->> 'favicon_url' <> '') AS shop_favicons;
+
+-- File paths để verify từng cái:
+SELECT file_path FROM item_images;
+SELECT file_path FROM spin_frames;
+-- Branding paths (URL signed — extract relative key bằng app code hoặc parse thủ công):
+SELECT id, appearance_json ->> 'logo_url'    AS logo_url,
+           appearance_json ->> 'favicon_url' AS favicon_url
+FROM shops
+WHERE appearance_json ? 'logo_url' OR appearance_json ? 'favicon_url';
+```
+
+Đối chiếu số file thực tế trên đĩa với số kỳ vọng.
+
+## Step 3 — Kiểm tra backup trước khi cố ext4 recovery
+
+Backup là cách phục hồi rẻ nhất + chắc chắn nhất. Xem [`backup.md`](backup.md) cho chiến lược chuẩn.
+
+```bash
+# Restic (nếu đã setup theo backup.md):
+restic -r <repo> snapshots
+restic -r <repo> ls latest | head -20
+# Thử restore vào /tmp trước, KHÔNG ghi đè production trực tiếp:
+restic -r <repo> restore latest --target /tmp/restore-test --include /var/lib/diecast360/uploads
+```
+
+```bash
+# Rclone (nếu sync R2):
+rclone ls r2remote:diecast360-uploads/ | head
+rclone sync r2remote:diecast360-uploads /tmp/restore-test --dry-run
+```
+
+```bash
+# USB backup:
+sudo mount /dev/sda1 /mnt/usb
+ls /mnt/usb/diecast360-backup/
+```
+
+Nếu **có backup khả dụng** → bỏ qua Step 4, đi thẳng Step 5 (restore).
+
+## Step 4 — ext4 recovery (last resort)
+
+Dùng khi không có backup. Hiệu quả giảm theo thời gian và lượng ghi đĩa kể từ lúc xoá.
+
+> **Hai ràng buộc bắt buộc trước khi recover:**
+> 1. **Không ghi vào partition chứa `UPLOAD_DIR`.** `apt-get install`, tạo `WORK=/tmp/...` trên cùng partition, hoặc bất kỳ ghi nào (kể cả pacman / npm cache / log) đều có thể overwrite inode chưa bị reclaim → phá cơ hội recover.
+> 2. **`extundelete` chỉ hoạt động đúng trên partition đã `umount`.** Chạy trên partition còn mounted (đặc biệt root) sẽ làm metadata thay đổi giữa chừng → recovery dở dang.
+>
+> Vì root filesystem của Pi gần như luôn mounted khi đang chạy, **không recover in-place**. Dùng một trong hai cách dưới đây:
+
+### Cách A — Image partition ra ổ ngoài, recover trên máy khác (khuyến nghị)
+
+An toàn nhất cho Pi: tắt Pi, rút SD/SSD, làm trên máy desktop/laptop có ổ trống.
+
+**Trên máy desktop/laptop có tooling sẵn:**
+
+```bash
+# 1. Cài tooling TRƯỚC khi đụng tới SD/SSD của Pi (ghi đĩa local của desktop, không phải Pi):
+sudo apt-get update
+sudo apt-get install -y extundelete testdisk e2fsprogs
+
+# 2. Cắm SD/SSD của Pi vào reader. Xác định device (ví dụ /dev/sdb):
+lsblk
+# Giả sử partition cần là /dev/sdb2 (root) — KHÔNG mount.
+
+DEV=/dev/sdb2
+EXT_DISK=/mnt/external        # ổ ngoài KHÁC SD/SSD của Pi, đủ chỗ chứa image
+mkdir -p "$EXT_DISK"
+
+# 3. Image partition ra ổ ngoài (chỉ đọc từ Pi disk, ghi vào ổ ngoài):
+sudo dd if="$DEV" of="$EXT_DISK/pi-image.img" bs=4M status=progress conv=noerror,sync
+
+# 4. (Tuỳ chọn) Mount image read-only để inspect:
+sudo mkdir -p /mnt/pi-ro
+sudo mount -o loop,ro "$EXT_DISK/pi-image.img" /mnt/pi-ro
+sudo umount /mnt/pi-ro
+
+# 5. Recover từ image (KHÔNG đụng tới SD/SSD gốc nữa — image là "snapshot"):
+WORK="$EXT_DISK/recover"
+mkdir -p "$WORK" && cd "$WORK"
+sudo extundelete --restore-directory var/lib/diecast360/uploads "$EXT_DISK/pi-image.img"
+# Hoặc legacy layout (path tương đối từ root partition):
+sudo extundelete --restore-directory opt/diecast360-backend/uploads "$EXT_DISK/pi-image.img"
+
+ls -la RECOVERED_FILES/
+```
+
+Nếu lần đầu thất bại, có thể chạy lại với option khác hoặc `testdisk` mà không sợ làm hỏng image — image là bản copy.
+
+### Cách B — Boot Pi bằng rescue media, recover device chưa mount
+
+Nếu không có máy desktop tiện hoặc ổ Pi gắn trong (không tháo được):
+
+1. Chuẩn bị 1 SD/USB live chứa Raspberry Pi OS hoặc Debian ARM rescue, có sẵn `extundelete` + `testdisk` (cài trước khi boot vào Pi).
+2. Tắt Pi, swap sang SD/USB rescue.
+3. Boot Pi từ rescue media. KHÔNG mount root partition của ổ gốc.
+4. Cắm thêm ổ ngoài (USB) đủ chỗ cho `RECOVERED_FILES`.
+5. Chạy:
+   ```bash
+   DEV=/dev/mmcblk0p2          # partition gốc của Pi (chưa mount)
+   EXT_DISK=/media/usb-recover
+   mkdir -p "$EXT_DISK/recover" && cd "$EXT_DISK/recover"
+
+   # Verify DEV chưa mount:
+   mount | grep "$DEV" && { echo "DEV đang mount — abort"; exit 1; }
+
+   sudo extundelete --restore-directory var/lib/diecast360/uploads "$DEV"
+   ```
+6. Copy `RECOVERED_FILES/` ra ổ ngoài rồi shutdown rescue.
+
+### Phương án phụ — `testdisk` (interactive)
+
+`testdisk` hoạt động tốt cả trên image lẫn device unmounted, có UI menu dễ dùng cho operator chưa quen CLI `extundelete`:
+
+```bash
+# Trên máy desktop với image:
+sudo testdisk "$EXT_DISK/pi-image.img"
+# Hoặc rescue mode với device chưa mount:
+sudo testdisk "$DEV"
+# Menu: [No Log] -> chọn partition -> [Advanced] -> [Undelete]
+# Đánh dấu file (a = all) -> [c] copy ra ngoài (chọn đường dẫn trên $EXT_DISK).
+```
+
+**Cấm tuyệt đối:**
+- Chạy `extundelete`/`testdisk` trực tiếp trên Pi đang chạy với root partition còn mount.
+- Ghi `RECOVERED_FILES/` xuống chính ổ đang recover (lặp lại lỗi gây mất data).
+- `apt-get install` / `npm install` / tạo thư mục mới trên root partition của Pi sau khi phát hiện data loss.
+
+## Step 5 — Verify + đặt file về đúng vị trí
+
+```bash
+# Đối chiếu file recover được vs DB.
+# Chạy verify trên MÁY DESKTOP (nơi đang giữ RECOVERED_FILES/), không trên Pi.
+RECDIR="$EXT_DISK/recover/RECOVERED_FILES"
+
+# 1. Lấy danh sách file_path từ DB:
+psql "$DATABASE_URL" -At -c \
+  "SELECT file_path FROM item_images UNION ALL SELECT file_path FROM spin_frames" \
+  | sort -u > /tmp/db-paths.txt
+
+# 2. Liệt kê file recover được — DÙNG `find`, không `ls -1`, vì file nằm dưới subfolder
+#    (images/, spinner/, shop-branding/, drafts/). `ls -1` chỉ hiện top-level → false miss.
+( cd "$RECDIR" && find . -type f -printf '%P\n' | sort -u ) > /tmp/disk-paths.txt
+
+# 3. So sánh — path trong DB nhưng KHÔNG có trên đĩa = vẫn mất:
+comm -23 /tmp/db-paths.txt /tmp/disk-paths.txt > /tmp/still-missing.txt
+echo "Vẫn mất: $(wc -l < /tmp/still-missing.txt) file"
+head /tmp/still-missing.txt
+```
+
+Đặt lại file dưới `UPLOAD_DIR` đúng cấu trúc key (tham chiếu `file_path` trong DB). Có 2 ngữ cảnh:
+
+```bash
+# A. Nếu bạn đã rebuild Pi và mount lại SD/SSD bình thường:
+#    Copy từ ổ desktop trở lại Pi qua scp/rsync over SSH:
+rsync -av --owner --group "$RECDIR"/ "pi@<pi-host>:$UD/"
+ssh "pi@<pi-host>" "sudo chown -R pi:pi $UD && \
+  sudo find $UD -type d -exec chmod 755 {} \\; && \
+  sudo find $UD -type f -exec chmod 644 {} \\;"
+
+# B. Nếu bạn đã gắn lại SD/SSD vào Pi và boot lên rồi (`UPLOAD_DIR` mount sẵn),
+#    có thể copy local từ ổ ngoài USB cắm trên Pi:
+sudo rsync -a --owner --group /media/usb-recover/recover/RECOVERED_FILES/ "$UD/"
+sudo chown -R pi:pi "$UD"
+sudo find "$UD" -type d -exec chmod 755 {} \;
+sudo find "$UD" -type f -exec chmod 644 {} \;
+```
+
+## Step 6 — Restart + smoke test
+
+> **Đừng quên** bật lại các service đã tắt ở Step 1, đặc biệt `cron` (nếu tắt) — nếu không bật lại thì backup nightly sẽ im lặng không chạy → mở ra window cho data loss kế tiếp.
+
+```bash
+# Bật lại các service đã tắt ở Step 1:
+sudo systemctl start cron                          # nếu Step 1 đã stop
+sudo systemctl status cron                         # verify active
+sudo systemctl start diecast360-deploy.timer 2>/dev/null || true
+gh workflow enable "Deploy backend (Pi)"           # nếu Step 1 đã disable workflow
+
+# Khởi động app:
+sudo systemctl start diecast360-api
+sudo systemctl status diecast360-api
+curl -sfS http://127.0.0.1:3000/api/v1/health
+
+# Verify backup cron sẽ chạy đúng lịch (kiểm trước khi rời tay):
+sudo crontab -l -u pi | grep restic
+sudo systemctl list-timers --all | grep -E 'cron|diecast'
+
+# Lấy 1 signed media URL từ public API (qua frontend hoặc tự sign):
+# Kỳ vọng 200 + Content-Type: image/...
+curl -sI 'https://api.nhtin.name.vn/api/v1/media?d=...&s=...'
+```
+
+Mở browser → trang public → check ảnh hiển thị bình thường.
+
+Trước khi đóng incident, theo dõi 1 chu kỳ backup (24h) → confirm snapshot mới xuất hiện (`restic snapshots`).
+
+## Step 7 — Files vẫn không có sau recovery
+
+Với file không recover được, chấp nhận và tái upload:
+
+1. Query DB lấy `file_path` còn thiếu.
+2. Ưu tiên theo doanh thu: item bán chạy, pre-order đang mở (status `PENDING_CONFIRMATION` / `WAITING_FOR_GOODS` / `ARRIVED`) → tái chụp trước.
+3. Khi upload, **dùng cùng key** (`file_path` cũ) nếu admin UI có cơ chế "upload to specific path" — nếu không, set new path + update DB. Coordinate với schema để không phá unique constraints (`(spin_set_id, frame_index)`).
+4. Spinner sets: ưu tiên set có nhiều view (nếu có analytics) — vì 24–48 frame/spinner rất tốn công.
+
+## Cloud storage recovery (R2)
+
+Nếu production dùng `STORAGE_DRIVER=r2`:
+
+```bash
+# R2 có bucket-level versioning nếu enabled trước đó:
+aws s3api list-object-versions \
+  --bucket "$R2_BUCKET" \
+  --endpoint-url "https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com" \
+  --query 'Versions[?IsLatest!=`true`].[Key,VersionId,LastModified]'
+
+# Restore object version cụ thể:
+aws s3api copy-object \
+  --copy-source "$R2_BUCKET/<key>?versionId=<ver>" \
+  --bucket "$R2_BUCKET" \
+  --key "<key>" \
+  --endpoint-url "..."
+```
+
+Nếu versioning chưa bật từ trước → tương đương "đã xoá vĩnh viễn" trên R2. Chỉ còn cách phục hồi từ backup ngoài (xem [`backup.md`](backup.md)).
+
+## Post-incident
+
+1. Viết postmortem trong `docs/POSTMORTEMS/YYYY-MM-DD-<slug>.md` (template: copy file `2026-05-26-uploads-wiped.md`).
+2. Cập nhật action items vào tracking issue.
+3. Verify rằng action item "backup tự động + test restore" đã chạy thành công.
+4. Cập nhật invariants trong `CLAUDE.md` / `AGENTS.md` nếu rút được pattern mới.


### PR DESCRIPTION
…#282)

Captures the 2026-05-26 incident where the Pi deploy workflow's `rsync --delete` wiped the production `uploads/` directory, plus the operational knowledge needed so it cannot recur silently in another form.

- docs/POSTMORTEMS/2026-05-26-uploads-wiped.md: full incident timeline, root cause, contributing factors, action items.
- docs/RUNBOOKS/data-loss-incident.md: stop-service-first procedure, ext4 recovery (extundelete/testdisk), R2 versioning recovery, verification, and re-upload plan.
- docs/RUNBOOKS/backup.md: restic + R2 + USB 3-2-1 strategy with cron, retention, alerting, and a quarterly restore-test checklist.
- docs/DEPLOYMENT.md: new section 3.b "Production data layout rules" with FHS path table and rsync-safety contract for new state dirs; UPLOAD_DIR row updated to point at /var/lib/diecast360/uploads.
- AGENTS.md, CLAUDE.md, .cursor/rules/karpathy-guidelines.mdc: add "Production data isolation", "CI/CD touching deploy paths", and "Data loss response" invariants so future agent sessions read this context up front.

No code changes; safe to merge ahead of any operational follow-up.