### PR TITLE
fix(preorder): proxy receipt logo for CORS-safe share image

### DIFF
--- a/backend/src/common/media/resolve-receipt-logo-url.spec.ts
+++ b/backend/src/common/media/resolve-receipt-logo-url.spec.ts
@@ -1,0 +1,53 @@
+import { ConfigService } from '@nestjs/config';
+import {
+  extractShopBrandingRelativePath,
+  resolveReceiptLogoUrl,
+} from './resolve-receipt-logo-url';
+import { buildSignedMediaFileUrl } from './signed-media.util';
+
+const secret = 'test-media-signing-secret-32chars!!';
+
+describe('extractShopBrandingRelativePath', () => {
+  it('extracts path from R2 presigned URL', () => {
+    const url =
+      'https://account.r2.cloudflarestorage.com/diecast360-media/shop-branding/shop_logo.jpg?X-Amz-Signature=abc';
+    expect(extractShopBrandingRelativePath(url)).toBe('shop-branding/shop_logo.jpg');
+  });
+
+  it('extracts path from signed API media URL', () => {
+    const signed = buildSignedMediaFileUrl(
+      'https://api.example.com/api/v1',
+      'shop-branding/logo.png',
+      secret,
+      60_000,
+    );
+    expect(extractShopBrandingRelativePath(signed, secret)).toBe('shop-branding/logo.png');
+  });
+
+  it('returns null for unrelated URLs', () => {
+    expect(extractShopBrandingRelativePath('https://cdn.example.com/logo.png')).toBeNull();
+  });
+});
+
+describe('resolveReceiptLogoUrl', () => {
+  const config = {
+    get: (key: string) => {
+      if (key === 'BACKEND_URL') return 'https://api.example.com';
+      if (key === 'JWT_SECRET') return secret;
+      return undefined;
+    },
+  } as ConfigService;
+
+  it('rewrites R2 URL to API signed media URL', () => {
+    const r2 =
+      'https://8410b9d76b04.r2.cloudflarestorage.com/diecast360-media/shop-branding/logo.jpg?sig=1';
+    const out = resolveReceiptLogoUrl(r2, config);
+    expect(out).toMatch(/^https:\/\/api\.example\.com\/api\/v1\/media\?/);
+    expect(extractShopBrandingRelativePath(out!, secret)).toBe('shop-branding/logo.jpg');
+  });
+
+  it('passes through external CDN URLs', () => {
+    const cdn = 'https://cdn.example.com/logo.png';
+    expect(resolveReceiptLogoUrl(cdn, config)).toBe(cdn);
+  });
+});

--- a/backend/src/common/media/resolve-receipt-logo-url.ts
+++ b/backend/src/common/media/resolve-receipt-logo-url.ts
@@ -1,0 +1,84 @@
+import { ConfigService } from '@nestjs/config';
+import { buildSignedMediaFileUrl, verifySignedMediaParams } from './signed-media.util';
+import { resolveMediaSigningSecret } from './media-signing-secret';
+import { parseMediaUrlTtlMs } from './media-url-ttl.util';
+
+const SHOP_BRANDING_PREFIX = 'shop-branding/';
+
+/**
+ * Extract DB-relative path (e.g. shop-branding/foo.jpg) from a stored appearance URL.
+ * Supports signed /api/v1/media links and direct R2 presigned URLs.
+ */
+export function extractShopBrandingRelativePath(
+  storedUrl: string,
+  mediaSigningSecret?: string,
+): string | null {
+  const trimmed = storedUrl.trim();
+  if (!trimmed) return null;
+
+  if (mediaSigningSecret) {
+    try {
+      const u = new URL(trimmed);
+      const payload = verifySignedMediaParams(
+        u.searchParams.get('d') ?? undefined,
+        u.searchParams.get('s') ?? undefined,
+        mediaSigningSecret,
+      );
+      if (payload?.p.startsWith(SHOP_BRANDING_PREFIX)) {
+        return payload.p;
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  try {
+    const u = new URL(trimmed);
+    const pathname = decodeURIComponent(u.pathname);
+    const idx = pathname.indexOf(SHOP_BRANDING_PREFIX);
+    if (idx >= 0) {
+      return pathname.slice(idx).replace(/^\/+/, '');
+    }
+  } catch {
+    const idx = trimmed.indexOf(SHOP_BRANDING_PREFIX);
+    if (idx >= 0) {
+      const tail = trimmed.slice(idx);
+      const q = tail.indexOf('?');
+      return (q >= 0 ? tail.slice(0, q) : tail).replace(/^\/+/, '');
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Receipt/share flows need a same-origin API media URL (CORS-safe for canvas export),
+ * not a direct R2 presigned URL.
+ */
+export function resolveReceiptLogoUrl(
+  stored: string | undefined,
+  config: ConfigService,
+): string | undefined {
+  if (!stored?.trim()) return undefined;
+
+  let secret: string | undefined;
+  try {
+    secret = resolveMediaSigningSecret(config);
+  } catch {
+    secret = undefined;
+  }
+
+  const relative = extractShopBrandingRelativePath(stored, secret);
+  if (!relative) {
+    return stored.trim();
+  }
+
+  if (!secret) {
+    return stored.trim();
+  }
+
+  const backend = (config.get<string>('BACKEND_URL') || 'http://localhost:3000').replace(/\/$/, '');
+  const apiBase = `${backend}/api/v1`;
+  const ttlMs = parseMediaUrlTtlMs(config);
+  return buildSignedMediaFileUrl(apiBase, relative, secret, ttlMs);
+}

--- a/backend/src/preorders/preorders.service.spec.ts
+++ b/backend/src/preorders/preorders.service.spec.ts
@@ -1,9 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { PlatformRole, PreOrderStatus, ShopRole } from '../generated/prisma/client';
 import { AppException } from '../common/exceptions/http-exception.filter';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { PreordersService } from './preorders.service';
 import { MembersService } from '../members/members.service';
+
+const testJwtSecret = 'test-jwt-secret-for-preorders-spec-32';
 
 describe('PreordersService', () => {
   let service: PreordersService;
@@ -39,6 +42,16 @@ describe('PreordersService', () => {
         { provide: PrismaService, useValue: prisma },
         { provide: 'IStorageService', useValue: storage },
         { provide: MembersService, useValue: membersService },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'BACKEND_URL') return 'https://api.example.com';
+              if (key === 'JWT_SECRET') return testJwtSecret;
+              return undefined;
+            },
+          },
+        },
       ],
     }).compile();
 
@@ -552,6 +565,21 @@ describe('PreordersService', () => {
         platformRole: null,
       });
       expect(result.shop.address).toBe('123 ABC');
+    });
+
+    it('rewrites shop-branding R2 logo to API signed media URL for CORS-safe export', async () => {
+      prisma.shop.findFirst.mockResolvedValue({
+        ...shopRow,
+        appearance_json: {
+          logo_url:
+            'https://acct.r2.cloudflarestorage.com/bucket/shop-branding/tenant_logo.jpg?X-Amz-Signature=x',
+        },
+      });
+      const result = await service.getReceipt(preorderId, tenantId, {
+        userId: ownerUserId,
+        platformRole: null,
+      });
+      expect(result.shop.logo_url).toMatch(/^https:\/\/api\.example\.com\/api\/v1\/media\?/);
     });
   });
 });

--- a/backend/src/preorders/preorders.service.ts
+++ b/backend/src/preorders/preorders.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PlatformRole, PreOrderStatus, Prisma, ShopRole } from '../generated/prisma/client';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { AppException, ErrorCode } from '../common/exceptions/http-exception.filter';
@@ -14,6 +15,7 @@ import { MembersService } from '../members/members.service';
 import { parseShopLoyaltyJson } from '../shops/shop-loyalty-json.util';
 import { parseShopContactJson } from '../shops/types/shop-contact.types';
 import { parseShopAppearanceJson } from '../shops/types/shop-appearance.types';
+import { resolveReceiptLogoUrl } from '../common/media/resolve-receipt-logo-url';
 
 @Injectable()
 export class PreordersService {
@@ -26,6 +28,7 @@ export class PreordersService {
     private readonly prisma: PrismaService,
     @Inject('IStorageService') private readonly storage: IStorageService,
     private readonly membersService: MembersService,
+    private readonly config: ConfigService,
   ) {}
 
   private requireActiveShopId(tenantId: string | undefined | null): string {
@@ -811,7 +814,7 @@ export class PreordersService {
         phone_label: contact.phone?.label,
         phone_tel: contact.phone?.tel,
         address: contact.address,
-        logo_url: appearance.logo_url,
+        logo_url: resolveReceiptLogoUrl(appearance.logo_url, this.config),
       },
       preorder: this.mapReceiptPreorder(row),
     };

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -580,7 +580,7 @@ Các route admin yêu cầu JWT + `active_shop_id`; `shop_admin` ghi được, `
 ### GET /api/v1/preorders/:id/receipt
 - Auth: JWT + active shop.
 - Quyền: `shop_admin` / `shop_staff` xem mọi đơn trong tenant; user thường chỉ xem đơn có `user_id` trùng JWT.
-- Response 200: `data: { shop: { name, phone_label?, phone_tel?, address?, logo_url? }, preorder: { id, status, quantity, unit_price, total_amount, deposit_amount, paid_amount, remaining_amount, discount_amount, note, created_at, item, member?, user? } }` — dùng cho in phiếu nhiệt và xuất ảnh PNG.
+- Response 200: `data: { shop: { name, phone_label?, phone_tel?, address?, logo_url? }, preorder: { ... } }` — dùng cho in phiếu nhiệt và xuất ảnh PNG. `shop.logo_url` với file `shop-branding/*` được trả dạng signed `GET /api/v1/media?d=...&s=...` (CORS-safe cho xuất PNG từ frontend khác domain), không trả presigned R2 trực tiếp.
 
 ## Inventory
 Các route yêu cầu JWT + active shop; `shop_admin` ghi được, `shop_staff` chỉ đọc theo guard chung.

--- a/frontend/src/utils/exportPreorderReceiptImage.ts
+++ b/frontend/src/utils/exportPreorderReceiptImage.ts
@@ -1,3 +1,4 @@
+import { API_CONFIG } from '../config/api';
 import type { PreorderReceiptPayload } from '../types/preorderReceipt';
 import { buildPreorderReceiptHtml } from './preorderReceiptHtml';
 
@@ -39,10 +40,18 @@ const rasterizeBody = async (body: HTMLElement): Promise<Blob> => {
  * CORS taint khi rasterize bằng html-to-image.
  * Trả về null nếu fetch thất bại (logo sẽ bị bỏ qua thay vì crash).
  */
+const toAbsoluteMediaUrl = (logoUrl: string): string => {
+  if (/^https?:\/\//i.test(logoUrl)) {
+    return logoUrl;
+  }
+  const base = API_CONFIG.BASE_URL.replace(/\/$/, '');
+  return logoUrl.startsWith('/') ? `${base}${logoUrl}` : `${base}/${logoUrl}`;
+};
+
 const fetchLogoDataUrl = async (logoUrl: string | undefined): Promise<string | undefined> => {
   if (!logoUrl) return undefined;
   try {
-    const res = await fetch(logoUrl, { mode: 'cors', credentials: 'omit' });
+    const res = await fetch(toAbsoluteMediaUrl(logoUrl), { mode: 'cors', credentials: 'omit' });
     if (!res.ok) return undefined;
     const blob = await res.blob();
     return await new Promise<string>((resolve, reject) => {
@@ -82,7 +91,7 @@ export const exportPreorderReceiptImage = async (
 ): Promise<Blob> => {
   // Fetch logo trước → data URL để tránh canvas bị CORS taint
   const logoDataUrl = await fetchLogoDataUrl(data.shop.logo_url ?? undefined);
-  const html = buildPreorderReceiptHtml(data, 'share', { logoDataUrl });
+  const html = buildPreorderReceiptHtml(data, 'share', { logoDataUrl: logoDataUrl ?? null });
   const iframe = mountOffscreenReceipt(html);
   try {
     const body = iframe.contentDocument?.body;

--- a/frontend/src/utils/preorderReceiptHtml.ts
+++ b/frontend/src/utils/preorderReceiptHtml.ts
@@ -47,9 +47,10 @@ export type ReceiptRenderMode = 'thermal' | 'share';
 export interface BuildReceiptOptions {
   /**
    * Data URL (base64) của logo đã fetch sẵn — dùng cho share/export mode để
-   * tránh canvas bị taint do CORS. Nếu không truyền, dùng `shop.logo_url` trực tiếp.
+   * tránh canvas bị taint do CORS. `null` = không hiển thị logo (không fallback URL ngoài).
+   * Không truyền = dùng `shop.logo_url` (in nhiệt).
    */
-  logoDataUrl?: string;
+  logoDataUrl?: string | null;
 }
 
 export const buildPreorderReceiptHtml = (
@@ -77,7 +78,11 @@ export const buildPreorderReceiptHtml = (
   // Ưu tiên dùng logoDataUrl (data URL đã fetch — không bị CORS taint khi rasterize);
   // fallback về logo_url gốc kèm crossorigin cho thermal print.
   const resolvedLogoSrc: string | null =
-    options.logoDataUrl ?? (shop.logo_url ? sanitizeLogoUrl(shop.logo_url) : null);
+    options.logoDataUrl !== undefined
+      ? options.logoDataUrl || null
+      : shop.logo_url
+        ? sanitizeLogoUrl(shop.logo_url)
+        : null;
   if (resolvedLogoSrc) {
     const corsAttr = options.logoDataUrl ? '' : ' crossorigin="anonymous"';
     headerParts.push(


### PR DESCRIPTION
﻿## Summary
- Receipt API rewrites shop-branding logos to signed GET /api/v1/media URLs so PNG export from www.dhtoys.store is not blocked by R2 CORS.
- Share/export flow skips falling back to external logo URLs when fetch fails (receipt still generates without logo).

## Test plan
- [ ] Deploy backend; confirm GET /preorders/:id/receipt returns logo_url under api.nhtin.name.vn/api/v1/media, not r2.cloudflarestorage.com.
- [ ] Admin pre-orders: Tạo ảnh / Chia sẻ succeeds with shop logo visible.
- [ ] In phiếu still works.
- [ ] pnpm --filter ./backend test (resolve-receipt-logo-url + preorders.service.spec)
