### PR TITLE
docs(planning):  phase 28 voucher integration plan

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -33,6 +33,7 @@ This roadmap organizes Diecast360 delivery from core product foundations to oper
 - [x] **Phase 25: Backend Staging Deploy on Vercel** - Separate staging workflow gated on build success; automated migrate + deploy to Vercel staging environment; aligned deploy checks. *(completed 2026-05-27)*
 - [ ] **Phase 26: Issue #232/#237/#243/#244/#246 - Auth Security Hardening Wave 1** - Login audit log + X-Trace-Id; per-email rate limit + account lockout (PostgreSQL-backed, survive restart); admin UI to view audit log and unlock accounts; Google reCAPTCHA v3 on admin login.
 - [ ] **Phase 27: Issue #238/#242/#245/#289 - Auth Security Wave 2 — Alerting, E2E & Ops** - Telegram security alerts with dedupe; Playwright E2E for lockout/CAPTCHA/rate-limit flows; production ops security checklist; staging pipeline completion.
+- [ ] **Phase 28: Voucher** - Shop-scoped promotional codes applied to pre-orders; optional linkage to member; receipt `discount_amount` populated from applied voucher; admin CRUD + validation (dates, usage caps, min order).
 ## Phase Details
 
 ### Phase 1: Inventory Foundation
@@ -215,6 +216,7 @@ Plans:
 | 25. Staging Deploy | 1/1 | Complete | 2026-05-27 |
 | 26. Auth Security Hardening Wave 1 | 0/3 | Planned | — |
 | 27. Auth Security Wave 2 | 0/3 | Planned | — |
+| 28. Voucher | 0/3 | Planned | — |
 
 ## Execution Update (2026-03-04)
 
@@ -346,6 +348,7 @@ All phases through Phase 25 are complete as of 2026-05-27. Phase 26 and Phase 27
 Partially executed phases (still pending full completion):
 - **Phase 26: Auth Security Hardening Wave 1** (Planned, 0/3 plans complete)
 - **Phase 27: Auth Security Wave 2** (Planned, 0/3 plans complete)
+- **Phase 28: Voucher** (Planned, 0/3 plans complete)
 
 
 ---
@@ -581,8 +584,6 @@ Plans:
 - [ ] 26-02: Email rate limit + account lockout (PostgreSQL-backed, survive restart) (#237, #246)
 - [ ] 26-03: Admin UI: login audit log & account unlock + reCAPTCHA v3 (#243, #244)
 
----
-
 ### Phase 27: Issue #238/#242/#245/#289 - Auth Security Wave 2 — Alerting, E2E & Ops
 
 **Goal**: Complete security incident detection and response with Telegram alerts, Playwright E2E security flows, production ops checklist, and staging pipeline completion.
@@ -594,4 +595,16 @@ Plans:
 - [ ] 27-01: Telegram security alerts (dedupe + threshold) (#238)
 - [ ] 27-02: Playwright E2E security flows (lockout, CAPTCHA, rate limit) (#242)
 - [ ] 27-03: Production ops security checklist & staging pipeline completion (#245, #289)
+
+### Phase 28: Voucher
+
+**Goal:** Cho phép shop tạo mã giảm giá (voucher) theo tenant; áp dụng khi tạo/cập nhật pre-order; lưu snapshot chiết khấu trên đơn; hiển thị trên phiếu in (`discount_amount`); kiểm soát hạn dùng, ngân sách lần dùng, và giá trị tối thiểu đơn hàng.
+**Depends on:** Phase 9 (pre-orders), Phase 14 (multi-tenant), Phase 24 (receipt contract có `discount_amount` placeholder)
+**Requirements:** VOCH-01 (proposed)
+**Plans:** 3 plans
+
+Plans:
+- [ ] 28-01: Schema + domain — `Voucher`, `VoucherRedemption` (hoặc tương đương), quy tắc tính giảm (fixed VND / percent cap), snapshot trên `PreOrder`
+- [ ] 28-02: Nest APIs — CRUD voucher (shop_admin), validate/apply trên pre-order create/update; TenantGuard; `docs/API_CONTRACT.md` + `docs/DOMAIN.md`
+- [ ] 28-03: Admin UI + receipt wiring — form mã, picker trên pre-order, receipt hiển thị chiết khấu; Playwright/E2E tối thiểu cho flow áp dụng + phiếu
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,9 +5,9 @@ milestone_name: milestone
 status: planning
 last_updated: "2026-05-27T11:00:00.000Z"
 progress:
-  total_phases: 27
+  total_phases: 28
   completed_phases: 25
-  total_plans: 59
+  total_plans: 62
   completed_plans: 53
 ---
 
@@ -27,7 +27,7 @@ Plan: **26-01** Login audit log + X-Trace-Id tracing
 Status: Planned — Ready to initiate execution after user approval.
 Last activity: 2026-05-27 — Created Context and Plan documents for Phase 26 & 27; updated ROADMAP.md and STATE.md.
 
-Progress: [#########################  ] 25/27 phases shipped.
+Progress: [#########################  ] 25/28 phases shipped.
 
 ## Performance Metrics
 
@@ -82,11 +82,13 @@ Progress: [#########################  ] 25/27 phases shipped.
 - Phase 18 added: Issue #59 Category Tenant Guard Hardening (2026-05-12).
 - Phase 19-25 completed: Pre-order points, QR Gateway, Security Hardening, Pre-order UX, CI/CD Overhaul, Thermal Receipt, and Staging Deploy (2026-05-20 to 2026-05-27).
 - Phase 26 & 27 planned: Auth Security Hardening Wave 1 & Wave 2 (2026-05-27).
+- Phase 28 added: Voucher (GSD planning: CONTEXT + plans 28-01…28-03) (2026-05-27).
 
 ### Pending Todos
 
 - Obtain user feedback on Phase 26 & 27 plans.
 - Initiate Phase 26-01 execution once approved.
+- Review Phase 28 voucher CONTEXT and plan breakdown (`28-01` → `28-03`); start `28-01` when ready.
 
 ### Blockers/Concerns
 

--- a/.planning/phases/28-voucher/28-01-PLAN.md
+++ b/.planning/phases/28-voucher/28-01-PLAN.md
@@ -1,0 +1,51 @@
+# Phase 28-01 Plan: Schema + domain (voucher + pre-order snapshot)
+
+**Phase:** 28 — Voucher  
+**Plan:** 28-01  
+**Status:** Not started
+
+---
+
+## Goal
+
+Thêm mô hình dữ liệu voucher **scoped `shop_id`**, quan hệ tới pre-order, và quy tắc tính giảm có kiểm chứng tại service (chưa cần UI).
+
+---
+
+## Implementation steps
+
+### Prisma / DB
+
+1. Model **`Voucher`** (gợi ý): `id`, `shop_id`, `code` (unique per shop, thường `citext` hoặc normalize upper), `type` enum (`FIXED_VND` | `PERCENT`), `fixed_amount`, `percent_bps` hoặc `percent` Decimal, `max_discount_vnd` (bắt buộc khi PERCENT), `min_order_total_vnd`, `starts_at`, `ends_at`, `max_redemptions`, `redemption_count`, `is_active`, timestamps.
+2. **`PreOrder`:** thêm `voucher_id` nullable FK; `discount_amount` Decimal nullable (snapshot); optional `voucher_code_snapshot` string để receipt ổn định nếu code đổi sau.
+3. Migration **additive only**; backfill `discount_amount = null` cho đơn hiện có.
+4. Index: `(shop_id, code)`, `(shop_id, is_active, ends_at)`.
+
+### Domain service
+
+5. **`VoucherPricingService`** (hoặc static helpers trong module):  
+   - Input: voucher row, `basis_amount` (Decimal), `quantity` nếu cần.  
+   - Output: `discount_vnd` (integer VND hoặc Decimal theo convention hiện có của pre-order).  
+   - Validate: percent + cap; fixed không vượt basis; discount ≥ 0; floor rules documented.
+6. **Eligibility:** `now` trong window; `redemption_count < max` nếu set; `basis_amount >= min_order_total`.
+
+### Docs
+
+7. **`docs/DB_SCHEMA.md`:** mô tả bảng + FK.  
+8. **`docs/DOMAIN.md`:** định nghĩa voucher, basis tính `min_order_total`, rule “không đổi sau PAID”.
+
+---
+
+## Tests
+
+- Unit: pricing matrix (fixed, percent+cap, min order fail, expired, exhausted cap).
+- Unit: unique constraint behavior shop+code (mock hoặc integration tùy hiện trạng repo).
+
+---
+
+## Definition of done
+
+- [ ] Migration applied locally via `prisma migrate deploy`
+- [ ] `PreOrder` có cột snapshot discount + FK voucher (nếu dùng FK)
+- [ ] Service tính discount thuần — chưa wire HTTP (sang 28-02)
+- [ ] `DB_SCHEMA.md` + `DOMAIN.md` cập nhật

--- a/.planning/phases/28-voucher/28-02-PLAN.md
+++ b/.planning/phases/28-voucher/28-02-PLAN.md
@@ -1,0 +1,55 @@
+# Phase 28-02 Plan: Nest APIs — vouchers + apply on pre-order
+
+**Phase:** 28 — Voucher  
+**Plan:** 28-02  
+**Status:** Not started
+
+---
+
+## Goal
+
+Expose REST **`/api/v1`** (snake_case) cho CRUD voucher và cho phép gắn/gỡ voucher trên pre-order thông qua create/update flow hiện có, với **TenantGuard**, **CSRF** trên mutate, RBAC **shop_admin** mutate / **shop_staff** read-only.
+
+---
+
+## Implementation steps
+
+### Vouchers module
+
+1. `VouchersController` + `VouchersService`:  
+   - `GET /vouchers` (list + filter active)  
+   - `POST /vouchers`, `PATCH /vouchers/:id`, `DELETE` hoặc `PATCH` deactivate (không hard-delete nếu đã có redemption — prefer soft `is_active`).
+2. DTO validation: code format, percent range, cap khi percent, dates consistency, non-negative money.
+
+### Preorders integration
+
+3. Extend **create/update pre-order DTO** với optional `voucher_code: string | null`.  
+   - `null` hoặc empty: clear `voucher_id` + `discount_amount` nếu trạng thái cho phép.  
+   - Non-empty: resolve voucher by shop + code; chạy eligibility + pricing; trong **transaction** cập nhật `voucher.redemption_count` (hoặc insert redemption) và snapshot trên pre-order.  
+4. **Trạng thái:** reject apply/clear khi status là terminal hoặc `PAID` (theo 28-CONTEXT).
+5. **Race:** transaction + row lock trên voucher khi increment redemption để tránh vượt `max_redemptions`.
+
+### Errors
+
+6. Map lỗi nghiệp vụ sang envelope hiện có (`docs/ERROR_HANDLING.md`): ví dụ `VOUCHER_NOT_FOUND`, `VOUCHER_EXPIRED`, `VOUCHER_EXHAUSTED`, `VOUCHER_MIN_NOT_MET`, `VOUCHER_IMMUTABLE_ON_ORDER`.
+
+### Docs
+
+7. **`docs/API_CONTRACT.md`:** endpoints voucher + field `voucher_code` trên pre-order write.
+
+---
+
+## Tests
+
+- Jest: `VouchersService` validation edge cases.
+- Integration: apply voucher on preorder create; clear; forbidden after PAID.
+- Cross-tenant: shop A cannot resolve shop B code (404 hoặc generic not found — chọn một và document).
+
+---
+
+## Definition of done
+
+- [ ] CRUD voucher endpoints live behind auth + tenant
+- [ ] Pre-order create/update accepts `voucher_code` và persists snapshot
+- [ ] `API_CONTRACT.md` + `ERROR_HANDLING.md` (mã lỗi mới nếu có) synced
+- [ ] `pnpm --filter ./backend test` passes for touched suites

--- a/.planning/phases/28-voucher/28-03-PLAN.md
+++ b/.planning/phases/28-voucher/28-03-PLAN.md
@@ -1,0 +1,39 @@
+# Phase 28-03 Plan: Admin UI + receipt + E2E
+
+**Phase:** 28 — Voucher  
+**Plan:** 28-03  
+**Status:** Not started
+
+---
+
+## Goal
+
+Shop quản trị quản lý voucher và áp dụng trên màn pre-order; phiếu in / PNG receipt hiển thị **chiết khấu** khi `discount_amount` có giá trị; E2E tối thiểu chứng minh flow.
+
+---
+
+## Implementation steps
+
+### Admin frontend
+
+1. **Trang hoặc panel `Vouchers`:** list, create/edit form (type, amounts, window, caps), deactivate; dùng TanStack Query + pattern API snake_case hiện có.
+2. **Pre-order form:** field “Mã voucher” (autocomplete hoặc text + validate on save); hiển thị discount preview sau khi save thành công (đọc từ response `discount_amount` nếu API trả).
+3. **shop_staff:** UI ẩn nút tạo/sửa voucher; chỉ xem nếu được phép theo capability pattern Phase 15.
+
+### Receipt
+
+4. **`getReceipt` / frontend receipt template:** khi `discount_amount` != null, render dòng chiết khấu (đồng bộ copy tiếng Việt với phần còn lại của receipt).  
+5. Gỡ comment / test cũ “discount luôn null” trong `preorders.service.spec.ts` — thay bằng case có snapshot.
+
+### E2E
+
+6. Playwright: stub auth+CSRF; tạo voucher fixture qua API hoặc seed; tạo pre-order với mã; assert receipt API hoặc UI có dòng discount (theo pattern test receipt hiện có).
+
+---
+
+## Definition of done
+
+- [ ] Admin có thể tạo voucher và thấy trong list
+- [ ] Pre-order lưu mã và receipt hiển thị chiết khấu đúng
+- [ ] E2E mới hoặc mở rộng spec receipt/preorder **không** xoá assertion cũ vô lý
+- [ ] `pnpm --filter ./frontend test:e2e` (hoặc subset được CI chạy) pass locally

--- a/.planning/phases/28-voucher/28-CONTEXT.md
+++ b/.planning/phases/28-voucher/28-CONTEXT.md
@@ -1,0 +1,47 @@
+# Phase 28: Voucher — Context
+
+**Gathered:** 2026-05-27  
+**Status:** Ready for execution (plans 28-01 … 28-03)  
+**Source:** PR “Voucher” + codebase audit (`pre_orders` money fields; receipt `discount_amount` placeholder trong `PreordersService.getReceipt`).
+
+---
+
+## Phase boundary
+
+**Trong scope:** Mã giảm giá **theo shop** (`shop_id`), tạo/sửa/xoá (soft-deactivate) bởi **shop_admin**; áp dụng lên **pre-order** tại create/update; lưu **snapshot** số tiền giảm và tham chiếu voucher trên đơn để lịch sử không đổi khi shop sửa rule sau; **phiếu / receipt** hiển thị dòng chiết khấu khi có snapshot (thay `discount_amount: null` hiện tại).
+
+**Ngoài scope (defer):** Voucher công khai tự nhập trên public checkout (chưa có cart thanh toán tổng quát); stack nhiều voucher trên một đơn; voucher theo **item** hoặc **category**; tích hợp Shopee/Grab; marketing referral codes.
+
+---
+
+## Decisions (locked cho MVP)
+
+1. **Đối tượng áp dụng:** chỉ **PreOrder** (đã có `total_amount`, `paid_amount`, `deposit_amount`, `quantity`, `unit_price`).
+2. **Tenant:** mọi query/mutation voucher và redemption **bắt buộc** `shop_id` khớp `TenantGuard` / active shop — không leak cross-shop.
+3. **Kiểu giảm (MVP):** hỗ trợ đúng hai loại — **`fixed_amount_vnd`** (số tiền cố định, làm tròn theo quy tắc VND nguyên) và **`percent`** với **trần tối đa VND** (`max_discount_vnd`) bắt buộc để tránh chiết khấu vô hạn.
+4. **Stacking:** tối đa **một** voucher active trên một pre-order tại mọi thời điểm; đổi mã = tính lại discount và ghi snapshot mới (ghi log audit optional — defer).
+5. **Điều kiện áp dụng:** `starts_at` / `ends_at` (nullable = không giới hạn phía đó), `max_redemptions` toàn cửa hàng (nullable = không giới hạn), `min_order_total_vnd` so với basis do shop chọn (`total_amount` sau quantity — document rõ trong DOMAIN).
+6. **Trạng thái đơn:** chỉ cho phép apply/replace voucher khi pre-order ở trạng thái **chưa terminal** và chưa **PAID** nếu business quyết “không đổi giá sau thanh toán” — **MVP: không cho đổi mã sau `PAID`** (align với immutability expectations trên receipt).
+7. **Member:** voucher **không** bắt buộc gắn member; nếu sau này có “chỉ dành cho tier X” thì defer — không làm trong phase này.
+8. **Receipt:** `getReceipt` trả `discount_amount` từ snapshot trên `PreOrder` (Decimal), không đọc live rule từ bảng voucher (tránh lệch lịch sử).
+
+---
+
+## Claude's discretion
+
+- Tên bảng: `vouchers` + `voucher_redemptions` **hoặc** chỉ `vouchers` + cột nullable `pre_orders.voucher_id` + các cột snapshot (`discount_amount`, `voucher_code_snapshot`) — chọn cách ít join nhất nhưng vẫn audit được lần dùng (redemption row mỗi lần apply hợp lệ).
+- Sinh mã: `crypto.randomBytes` + charset dễ đọc **hoặc** cho admin nhập code + unique per `shop_id` (case-insensitive unique index).
+- Module placement: `VouchersModule` mới + hook từ `PreordersService` khi create/update payload có `voucher_code`.
+
+---
+
+## Deferred ideas
+
+- Multi-voucher stack và thứ tự ưu tiên.
+- Voucher giới hạn theo member / tier.
+- Public self-apply và rate-limit theo IP.
+- Tự động sync lại `MemberPointsLedger` khi discount làm thay đổi `paid_amount` (Phase 19 basis) — cần phase riêng nếu điều chỉnh công thức points.
+
+---
+
+*Phase: 28-voucher*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delivers the **GSD-style integration plan** requested on the Voucher PR: Phase **28** added to `.planning/ROADMAP.md`, **`28-CONTEXT.md`** (scope, locked MVP decisions, deferrals), and three executable plans **`28-01` → `28-03`** (schema/domain → Nest APIs → admin UI + receipt + E2E). `.planning/STATE.md` counts and roadmap evolution updated.

## Notes for implementers

- Backend already documents receipt `discount_amount` as intentionally null until voucher business exists (`preorders.service.ts`); Phase 28 wires real snapshot amounts and receipt display.
- Phase directory is **`.planning/phases/28-voucher/`** (short slug after rename from the auto-generated folder name).

## Next steps (GSD)

1. Run **`$gsd-execute-phase`** or start manually with **`28-01-PLAN.md`** (Prisma + domain pricing).
2. Optional: **`$gsd-discuss-phase 28`** if product wants to change MVP rules (e.g. allow voucher change after `PAID`) before coding.

## How to reply on the original PR

You can paste a short pointer to this PR or to `28-CONTEXT.md` and the three PLAN files for @nguyenhoangtin1404.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08435c24-cadf-4c8d-888f-7720b66ecda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08435c24-cadf-4c8d-888f-7720b66ecda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

