### PR TITLE
ci(deploy): show Pi deploy in same CI run on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,41 @@ env:
 
 jobs:
   # ============================================
+  # CD gate (main push only) — deploy jobs appear only when this is true
+  # ============================================
+  detect-backend-deploy:
+    name: Backend deploy gate
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.filter.outputs.deploy }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - name: Detect backend-relevant changes
+        id: filter
+        run: |
+          set -euo pipefail
+          if ! git rev-parse HEAD^ >/dev/null 2>&1; then
+            echo "::notice::No parent commit; enabling deploy."
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed=$(git diff --name-only HEAD^ HEAD || true)
+          echo "Changed files:"
+          printf '%s\n' "$changed"
+          if printf '%s\n' "$changed" \
+            | grep -qE '^(backend/|pnpm-lock\.yaml$|\.github/workflows/deploy-backend(\-manual)?\.yml$|\.github/workflows/ci\.yml$)'; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No backend CD changes — Pi deploy not scheduled."
+          fi
+
+  # ============================================
   # Backend Job
   # ============================================
   backend:
@@ -299,3 +334,16 @@ jobs:
             fi
           done
           echo "All CI checks passed"
+
+  # ============================================
+  # Production deploy (Pi) — only on main push when backend CD gate is true
+  # ============================================
+  production-deploy:
+    name: Deploy backend (Pi)
+    needs: [ci-success, detect-backend-deploy]
+    if: |
+      needs.ci-success.result == 'success' &&
+      needs.detect-backend-deploy.result == 'success' &&
+      needs.detect-backend-deploy.outputs.deploy == 'true'
+    uses: ./.github/workflows/deploy-backend.yml
+    secrets: inherit

--- a/.github/workflows/deploy-backend-manual.yml
+++ b/.github/workflows/deploy-backend-manual.yml
@@ -1,0 +1,21 @@
+# Manual production deploy — separate workflow (does not attach to commit checks).
+# For automatic deploy on merge, use CI on main (job Deploy backend (Pi)).
+
+name: Deploy backend (Pi) — manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      skip_migrate:
+        description: "Skip prisma migrate (use if Neon/GitHub already migrated)"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  deploy:
+    name: Deploy backend (Pi)
+    uses: ./.github/workflows/deploy-backend.yml
+    secrets: inherit
+    with:
+      skip_migrate: ${{ inputs.skip_migrate }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,40 +1,22 @@
-# CD: (1) Apply Prisma migrations on GitHub-hosted runner (reaches Neon reliably).
-# (2) Build on self-hosted Pi, deploy via `pnpm deploy` (production bundle), prisma generate, restart.
+# Reusable CD — only invoked from CI (push main) or deploy-backend-manual.yml.
+# Do not add workflow_dispatch here (manual runs stay off commit checks).
 #
-# Trigger: CI workflow completed successfully after a push to `main`, or manual workflow_dispatch.
+# (1) Prisma migrate on GitHub-hosted (Neon). (2) Build bundle on Pi, rsync, restart.
 #
-# Path filter: `workflow_run` does not natively support `paths:` filters, so the
-# `check-changes` job inspects the head commit (vs its first parent) and only lets
-# `migrate`/`deploy` run when at least one of `backend/**`, `pnpm-lock.yaml`, or
-# `.github/workflows/deploy-backend.yml` changed. `workflow_dispatch` always
-# deploys regardless of paths. Rebase-merge with multiple commits in one push
-# only inspects the last commit — use `workflow_dispatch` for those rare cases.
-#
-# Requires: GitHub-hosted runner secrets for migrate; Pi runner with labels: self-hosted, diecast360-pi
-#
-# Requires on Pi once: corepack enable && corepack prepare pnpm@10.33.4 --activate
-# (matches root package.json "packageManager").
-#
-# GitHub Environment "production" secrets (for migrate job):
-#   PRODUCTION_DATABASE_URL — Neon pooled URL (same meaning as backend DATABASE_URL)
-#   PRODUCTION_DIRECT_URL   — Neon direct URL (for prisma migrate)
-#
-# Optional secret: DEPLOY_REMOTE_PATH (default /opt/diecast360-backend)
+# Requires: Pi runner labels self-hosted, diecast360-pi; corepack pnpm@10.33.4 on Pi.
+# Secrets (environment production): PRODUCTION_DATABASE_URL, PRODUCTION_DIRECT_URL;
+# optional DEPLOY_REMOTE_PATH.
 
 name: Deploy backend (Pi)
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
-  workflow_dispatch:
+  workflow_call:
     inputs:
       skip_migrate:
-        description: "Skip prisma migrate (use if Neon/GitHub already migrated)"
+        description: Skip prisma migrate deploy
         required: false
-        default: false
         type: boolean
+        default: false
 
 concurrency:
   group: deploy-backend-${{ github.ref }}
@@ -47,53 +29,8 @@ env:
   NODE_VERSION: "20"
 
 jobs:
-  check-changes:
-    name: Check if backend changed
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'main')
-    outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
-          fetch-depth: 2
-
-      - name: Detect backend-relevant changes
-        id: filter
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "::notice::Manual dispatch — skipping path filter, deploying."
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if ! git rev-parse HEAD^ >/dev/null 2>&1; then
-            echo "::notice::No parent commit available; defaulting to deploy."
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          changed=$(git diff --name-only HEAD^ HEAD || true)
-          echo "Changed files in head commit:"
-          printf '%s\n' "$changed"
-          if printf '%s\n' "$changed" \
-            | grep -qE '^(backend/|pnpm-lock\.yaml$|\.github/workflows/deploy-backend\.yml$)'; then
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "backend=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No backend-relevant changes — skipping migrate & deploy."
-          fi
-
   migrate:
     name: Prisma migrate (production)
-    needs: check-changes
-    if: needs.check-changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     environment: production
     defaults:
@@ -103,8 +40,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -122,7 +57,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Prisma generate & migrate deploy
-        if: ${{ github.event_name != 'workflow_dispatch' || !fromJSON(github.event.inputs.skip_migrate || 'false') }}
+        if: ${{ !inputs.skip_migrate }}
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
           DIRECT_URL: ${{ secrets.PRODUCTION_DIRECT_URL }}
@@ -130,14 +65,13 @@ jobs:
           pnpm --filter ./backend exec prisma generate
           pnpm --filter ./backend exec prisma migrate deploy
 
-      - name: Skip migrate (manual dispatch)
-        if: ${{ github.event_name == 'workflow_dispatch' && fromJSON(github.event.inputs.skip_migrate || 'false') }}
-        run: echo "::notice::Skipped prisma migrate deploy — manual skip."
+      - name: Skip migrate
+        if: ${{ inputs.skip_migrate }}
+        run: echo "::notice::Skipped prisma migrate deploy."
 
   deploy:
     name: Build & deploy on Pi
-    needs: [check-changes, migrate]
-    if: needs.check-changes.outputs.backend == 'true'
+    needs: migrate
     runs-on: [self-hosted, diecast360-pi]
     environment: production
     env:
@@ -149,8 +83,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Enable corepack / pnpm
         run: |
@@ -194,11 +126,9 @@ jobs:
           set -euo pipefail
           REDIR="${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
           mkdir -p "$REDIR"
-          # Excludes protect operator state that lives in REDIR but is NOT part of
-          # the deploy bundle. Without these, `--delete` wipes user data each deploy.
-          # - .env: secrets configured per-host
-          # - /uploads: legacy default UPLOAD_DIR (./uploads -> $REDIR/uploads). New
-          #   installs should set UPLOAD_DIR outside REDIR (see backend/.env.production.example).
+          # Excludes protect operator state in REDIR (not part of the bundle).
+          # - .env: per-host secrets
+          # - /uploads: legacy UPLOAD_DIR; prefer UPLOAD_DIR outside REDIR (see backend/.env.production.example).
           rsync -a --delete \
             --exclude='/.env' \
             --exclude='/uploads' \
@@ -221,6 +151,7 @@ jobs:
           HEALTH_INTERVAL_SEC="${HEALTH_INTERVAL_SEC:-2}"
           for i in $(seq 1 "$HEALTH_RETRIES"); do
             if curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null; then
+              echo "::notice::API healthy on port ${PORT}"
               break
             fi
             if [ "$i" -eq "$HEALTH_RETRIES" ]; then

--- a/docs/BACKEND_SELF_HOSTED_RUNNER.md
+++ b/docs/BACKEND_SELF_HOSTED_RUNNER.md
@@ -111,8 +111,8 @@ Environment **production** (nếu workflow gắn `environment: production`): có
 
 ## Bước 5 — Kích hoạt deploy
 
-- **Push `main`** có thay đổi `backend/**` hoặc `.github/workflows/deploy-backend.yml`.
-- Hoặc **Actions** → **Deploy backend (Pi)** → **Run workflow**.
+- **Push `main` (CD)**: sau **CI Success**, job **Deploy backend (Pi)** chỉ chạy nếu **Backend deploy gate** = true (`backend/**`, `pnpm-lock.yaml`, hoặc workflow `ci.yml` / `deploy-backend*.yml`).
+- **Thủ công**: Actions → **Deploy backend (Pi) — manual** (workflow riêng, không hiện trên popup check của commit).
 
 Job chỉ chạy khi có runner **online** với label **`diecast360-pi`**. Nếu không có runner, job sẽ **treo chờ** — cần bật Pi + `sudo ./svc.sh start`.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -178,13 +178,13 @@ Chi tiết Facebook, OpenAI, Pinecone: tùy tính năng bật — vẫn trong [`
 5. Cập nhật `VITE_API_BASE_URL` trên host frontend, deploy lại frontend.
 6. Kiểm tra đăng nhập, upload nhỏ, catalog; đọc [`COOKIE_AUTH.md`](COOKIE_AUTH.md) nếu cookie cross-site lỗi.
 
-Tự động deploy backend khi **`CI` workflow** trên `main` hoàn thành (sự kiện **push**) với conclusion **success** (đã thay trigger `paths:` bằng `workflow_run` — không deploy nếu CI đỏ). Runner Pi: checkout + **`pnpm install` / `pnpm --filter ./backend run build`** + **`pnpm --filter ./backend deploy --prod --legacy`** (bundle production), **`rsync --exclude .env`** vào `DEPLOY_REMOTE_PATH` (thường `/opt/diecast360-backend`), **`npx prisma generate`**, restart `diecast360-api`, probe `GET /api/v1/health`. Vẫn có **`workflow_dispatch`** (tùy chọn skip migrate).
+Tự động deploy backend khi merge `main`: cài [GitHub self-hosted runner trên Pi](BACKEND_SELF_HOSTED_RUNNER.md). Sau **CI Success**, workflow **CI** gọi reusable [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml) — job **Prisma migrate (production)** và **Build & deploy on Pi** nằm **cùng một run CI** trên commit (không deploy nếu CI đỏ). **Backend deploy gate** chỉ bật CD khi commit đổi `backend/**`, `pnpm-lock.yaml`, hoặc workflow CD liên quan. Migrate Neon trên GitHub-hosted; Pi: `pnpm deploy` bundle, `rsync` (exclude `.env`, `uploads/`), `prisma generate`, restart `diecast360-api`, probe health. Deploy thủ công: Actions → **Deploy backend (Pi) — manual** (workflow riêng, không gắn commit check; có thể skip migrate).
 
 ---
 
 ## 6. CI và migration
 
-Workflow CI mặc định: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). Deploy backend: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml) và [`BACKEND_SELF_HOSTED_RUNNER.md`](BACKEND_SELF_HOSTED_RUNNER.md).
+Workflow CI: [`.github/workflows/ci.yml`](../.github/workflows/ci.yml). Deploy reusable: [`.github/workflows/deploy-backend.yml`](../.github/workflows/deploy-backend.yml). Deploy thủ công: [`.github/workflows/deploy-backend-manual.yml`](../.github/workflows/deploy-backend-manual.yml). Hướng dẫn Pi: [`BACKEND_SELF_HOSTED_RUNNER.md`](BACKEND_SELF_HOSTED_RUNNER.md).
 
 **Migration production** chạy **trước** bước Pi, trên runner `ubuntu-latest`, biến lấy từ GitHub Environment **production**:
 


### PR DESCRIPTION
## Summary

- Call \deploy-backend.yml\ as a reusable workflow from **CI** after **CI Success** on \main\ push, so **Prisma migrate (production)** and **Build & deploy on Pi** appear on the same commit check run.
- Add **Backend deploy gate** so Pi CD only runs when the commit changes \ackend/**\, \pnpm-lock.yaml\, or CD workflow files.
- Replace \workflow_run\ trigger with \workflow_call\; add **Deploy backend (Pi) — manual** for off-commit deploys (optional skip migrate).
- Update \docs/DEPLOYMENT.md\ and \docs/BACKEND_SELF_HOSTED_RUNNER.md\.

## Test plan

- [ ] Merge PR and push a **frontend-only** commit to \main\ → CI passes; **Deploy backend (Pi)** job skipped (gate false).
- [ ] Push a **backend** change to \main\ → CI run shows migrate + Pi deploy jobs; production health OK.
- [ ] Run **Deploy backend (Pi) — manual** from Actions → completes without attaching to a commit popup.
