### PR TITLE
ci: document cicd flow and add fail-fast production deploy gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           for i in $(seq 1 30); do
             if curl -sf http://127.0.0.1:3000/api/v1/health > /tmp/health.json; then
               echo "Health OK after ${i} attempts"
-              jq -e '.ok == true and (.data.ok == true or .data.status == "healthy")' /tmp/health.json
+              bash scripts/ci/assert-health-json.sh /tmp/health.json
               exit 0
             fi
             if [ "$i" -eq 30 ]; then
@@ -275,24 +275,62 @@ jobs:
         run: pnpm audit --audit-level=high
 
   # ============================================
+  # Push file list for CD path filter (multi-commit push)
+  # ============================================
+  record-push-changes:
+    name: Record push changed files
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Write changed-files list
+        run: |
+          set -euo pipefail
+          before="${{ github.event.before }}"
+          after="${{ github.sha }}"
+          if [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            git diff --name-only HEAD^ HEAD > changed-files.txt
+          else
+            git diff --name-only "$before" "$after" > changed-files.txt
+          fi
+          echo "Files in push (${before:0:7}..${after:0:7}):"
+          cat changed-files.txt
+
+      - name: Upload artifact for Deploy backend (Pi)
+        uses: actions/upload-artifact@v6
+        with:
+          name: push-changed-files-${{ github.sha }}
+          path: changed-files.txt
+          retention-days: 7
+          if-no-files-found: error
+
+  # ============================================
   # Final Status Check (for branch protection)
   # ============================================
   ci-success:
     name: CI Success
-    needs: [backend, frontend, security, health-check]
+    needs: [backend, frontend, security, health-check, record-push-changes]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          for job in backend frontend security health-check; do
+          for job in backend frontend security health-check record-push-changes; do
             r=""
             case "$job" in
               backend) r="${{ needs.backend.result }}" ;;
               frontend) r="${{ needs.frontend.result }}" ;;
               security) r="${{ needs.security.result }}" ;;
               health-check) r="${{ needs.health-check.result }}" ;;
+              record-push-changes) r="${{ needs.record-push-changes.result }}" ;;
             esac
+            if [ "$r" = "skipped" ]; then
+              continue
+            fi
             if [ "$r" != "success" ]; then
               echo "Job ${job} result: ${r}"
               exit 1

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,14 +1,12 @@
-# CD: (1) Apply Prisma migrations on GitHub-hosted runner (reaches Neon reliably).
-# (2) Build on self-hosted Pi, deploy via `pnpm deploy` (production bundle), prisma generate, restart.
+# CD (fail-fast): check-changes → build gate (GitHub) → migrate (Neon) → deploy (Pi) → CD Success.
+# Build runs before migrate so a broken compile does not touch production schema.
 #
 # Trigger: CI workflow completed successfully after a push to `main`, or manual workflow_dispatch.
 #
-# Path filter: `workflow_run` does not natively support `paths:` filters, so the
-# `check-changes` job inspects the head commit (vs its first parent) and only lets
-# `migrate`/`deploy` run when at least one of `backend/**`, `pnpm-lock.yaml`, or
-# `.github/workflows/deploy-backend.yml` changed. `workflow_dispatch` always
-# deploys regardless of paths. Rebase-merge with multiple commits in one push
-# only inspects the last commit — use `workflow_dispatch` for those rare cases.
+# Path filter: `check-changes` uses artifact `push-changed-files-<sha>` from CI
+# (full push before..after diff on main). Fallback: HEAD^..HEAD. Only runs
+# migrate/deploy when `backend/**`, `pnpm-lock.yaml`, or this workflow changed.
+# `workflow_dispatch` always deploys. See docs/CICD.md.
 #
 # Requires: GitHub-hosted runner secrets for migrate; Pi runner with labels: self-hosted, diecast360-pi
 #
@@ -42,6 +40,7 @@ concurrency:
 
 permissions:
   contents: read
+  actions: read
 
 env:
   NODE_VERSION: "20"
@@ -65,6 +64,16 @@ jobs:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 2
 
+      - name: Download push changed-files from CI
+        if: github.event_name == 'workflow_run'
+        id: push_artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: push-changed-files-${{ github.event.workflow_run.head_sha }}
+          path: /tmp/push-changed-files
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
       - name: Detect backend-relevant changes
         id: filter
         run: |
@@ -74,25 +83,71 @@ jobs:
             echo "backend=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if ! git rev-parse HEAD^ >/dev/null 2>&1; then
+          if [ -f /tmp/push-changed-files/changed-files.txt ]; then
+            changed=$(cat /tmp/push-changed-files/changed-files.txt)
+            echo "Changed files (CI push artifact):"
+          elif ! git rev-parse HEAD^ >/dev/null 2>&1; then
             echo "::notice::No parent commit available; defaulting to deploy."
             echo "backend=true" >> "$GITHUB_OUTPUT"
             exit 0
+          else
+            changed=$(git diff --name-only HEAD^ HEAD || true)
+            echo "::warning::CI push-changed-files artifact missing — using HEAD^..HEAD (may miss files in multi-commit push)."
+            echo "Changed files (fallback HEAD^..HEAD):"
           fi
-          changed=$(git diff --name-only HEAD^ HEAD || true)
-          echo "Changed files in head commit:"
           printf '%s\n' "$changed"
           if printf '%s\n' "$changed" \
             | grep -qE '^(backend/|pnpm-lock\.yaml$|\.github/workflows/deploy-backend\.yml$)'; then
             echo "backend=true" >> "$GITHUB_OUTPUT"
           else
             echo "backend=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No backend-relevant changes — skipping migrate & deploy."
+            echo "::notice::No backend-relevant changes — skipping build, migrate & deploy."
           fi
+
+  build:
+    name: Build backend (gate)
+    needs: check-changes
+    if: needs.check-changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install & build
+        env:
+          NPM_CONFIG_PRODUCTION: "false"
+          NODE_ENV: development
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter ./backend run build
+
+      - name: Verify build output
+        run: |
+          test -d backend/dist
+          test -n "$(find backend/dist -type f -print -quit)" \
+            || (echo "::error::backend/dist empty — aborting CD"; exit 1)
 
   migrate:
     name: Prisma migrate (production)
-    needs: check-changes
+    needs: [check-changes, build]
     if: needs.check-changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     environment: production
@@ -208,6 +263,7 @@ jobs:
       - name: Prisma generate & restart API
         run: |
           set -euo pipefail
+          HEALTH_ASSERT="${GITHUB_WORKSPACE}/scripts/ci/assert-health-json.sh"
           REDIR="${DEPLOY_REMOTE_PATH:-/opt/diecast360-backend}"
           cd "$REDIR"
           set -a
@@ -220,7 +276,9 @@ jobs:
           HEALTH_RETRIES="${HEALTH_RETRIES:-30}"
           HEALTH_INTERVAL_SEC="${HEALTH_INTERVAL_SEC:-2}"
           for i in $(seq 1 "$HEALTH_RETRIES"); do
-            if curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null; then
+            if curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" > /tmp/prod-health.json; then
+              bash "$HEALTH_ASSERT" /tmp/prod-health.json
+              echo "Production API healthy after ${i} attempt(s)"
               break
             fi
             if [ "$i" -eq "$HEALTH_RETRIES" ]; then
@@ -231,3 +289,56 @@ jobs:
             fi
             sleep "${HEALTH_INTERVAL_SEC}"
           done
+
+      - name: Job summary
+        if: success()
+        run: |
+          {
+            echo "## Production backend deployed"
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Commit** | \`${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}\` |"
+            echo "| **Health** | \`GET /api/v1/health\` on Pi (DB probe) |"
+            echo "| **Frontend** | Vercel (separate check on same commit) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  cd-success:
+    name: CD Success
+    needs: [check-changes, build, migrate, deploy]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report CD outcome
+        env:
+          CHECK_CHANGES: ${{ needs.check-changes.result }}
+          BACKEND: ${{ needs.check-changes.outputs.backend }}
+          BUILD: ${{ needs.build.result }}
+          MIGRATE: ${{ needs.migrate.result }}
+          DEPLOY: ${{ needs.deploy.result }}
+        run: |
+          set -euo pipefail
+          if [ "$CHECK_CHANGES" != "success" ]; then
+            echo "::error::check-changes job result: ${CHECK_CHANGES}"
+            exit 1
+          fi
+          if [ "$BACKEND" != "true" ]; then
+            echo "::notice::CD skipped — no backend-relevant changes in this push."
+            echo "## CD skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "No \`backend/**\`, \`pnpm-lock.yaml\`, or deploy workflow changes." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          for job in build migrate deploy; do
+            r=""
+            case "$job" in
+              build) r="$BUILD" ;;
+              migrate) r="$MIGRATE" ;;
+              deploy) r="$DEPLOY" ;;
+            esac
+            if [ "$r" != "success" ]; then
+              echo "::error::CD job ${job} result: ${r}"
+              exit 1
+            fi
+          done
+          echo "Production CD completed (build gate, migrate, Pi deploy)."
+          echo "## CD Success" >> "$GITHUB_STEP_SUMMARY"
+          echo "Build gate, Neon migrate, and Pi deploy finished." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -172,6 +172,7 @@ jobs:
       - name: Prisma generate & restart staging API
         run: |
           set -euo pipefail
+          HEALTH_ASSERT="${GITHUB_WORKSPACE}/scripts/ci/assert-health-json.sh"
           REDIR="${DEPLOY_REMOTE_PATH:-/opt/diecast360-staging}"
           cd "$REDIR"
           set -a
@@ -184,8 +185,9 @@ jobs:
           HEALTH_RETRIES="${HEALTH_RETRIES:-30}"
           HEALTH_INTERVAL_SEC="${HEALTH_INTERVAL_SEC:-2}"
           for i in $(seq 1 "$HEALTH_RETRIES"); do
-            if curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" >/dev/null; then
-              echo "✅ Backend staging healthy after ${i} attempts"
+            if curl -sfS "http://127.0.0.1:${PORT}/api/v1/health" > /tmp/staging-health.json; then
+              bash "$HEALTH_ASSERT" /tmp/staging-health.json
+              echo "Backend staging healthy after ${i} attempt(s)"
               break
             fi
             if [ "$i" -eq "$HEALTH_RETRIES" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Pinned tooling: **`packageManager`** và **`engines`** trong `package.json` gố
 | **`Commitlint`** | Pull requests | Conventional commits cho từng commit trong PR (`.commitlintrc.json`). |
 | **`PR Title Lint`** | PR opened/edited/… | Title semantic (squash-merge). Types giống commitlint (`feat`, `fix`, …). |
 | **`Labeler`** (`pull_request_target`) | Pull requests → `main`, `develop` | Label theo path (`.github/labeler.yml`); cần tạo sẵn labels `area:*`, `deps` trong repo. |
-| **`Deploy backend (Pi)`** | **`workflow_run` sau khi CI trên `main` success** (push event), hoặc `workflow_dispatch` | Migrate trên GitHub-hosted, build + **`pnpm deploy --prod --legacy`** trên runner Pi → rsync vào `/opt/diecast360-backend` (preserve `.env` + exclude `/uploads`), `prisma generate`, restart service. Trước khi sửa workflow phần `rsync`/`--delete`: review kèm `--dry-run` output trong PR description; nếu có thể, thử trên staging Pi/VM trước. Health check `/api/v1/health` hiện **không** touch storage — không tự phát hiện được "file mất nhưng app sống" (xem postmortem 2026-05-26). |
+| **`Deploy backend (Pi)`** | **`workflow_run` sau khi CI trên `main` success** (push event), hoặc `workflow_dispatch` | Fail-fast: **build gate** → migrate Neon → deploy Pi → **`CD Success`**. Path filter: artifact `push-changed-files-<sha>`. **Không** hiện trên PR checks — [`docs/CICD.md`](docs/CICD.md). Health không probe storage (postmortem 2026-05-26). |
 
 **Pi (một lần):** bật pnpm khớp [`package.json`](package.json) `packageManager`, ví dụ:
 
@@ -48,7 +48,7 @@ corepack enable
 corepack prepare pnpm@10.33.4 --activate
 ```
 
-**Branch protection:** bật required checks: **`CI Success`**, **`Scan for secrets`** (Gitleaks), **`Lint commit messages`**, **`Validate PR title`**. Labeler không bắt buộc.
+**Branch protection:** bật required checks: **`CI Success`**, **`Scan for secrets`** (Gitleaks), **`Lint commit messages`**, **`Validate PR title`**. Labeler không bắt buộc. Sau merge `main`, theo dõi **`Deploy backend (Pi)`** / **`CD Success`** (không bắt buộc trên PR) — bảng đầy đủ: [`docs/CICD.md`](docs/CICD.md).
 
 **Squash-merge:** chỉnh **PR title** đúng Conventional Commit trước khi squash (ảnh hưởng message commit trên `main`).
 

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -1,0 +1,159 @@
+# CI/CD — luồng thực tế và cách đọc trạng thái
+
+Tài liệu này khớp workflow trong `.github/workflows/` (cập nhật 2026-05). Chi tiết triển khai Pi/Neon/Vercel: [`DEPLOYMENT.md`](DEPLOYMENT.md).
+
+---
+
+## Sơ đồ
+
+### PR (fail-fast trong CI)
+
+```text
+                    ┌── Backend ──────────────┐
+                    │   lint → build → jest   │
+                    │         │               │
+                    │         ▼ (needs)       │
+                    │   Health Check (smoke)  │
+                    └───┬─────────────────────┘
+                        │
+    Frontend ───────────┼── Security (audit)
+    (lint,tsc,build,    │
+     e2e)               ▼
+                  CI Success  ←── bất kỳ job fail → đỏ, không merge
+```
+
+Song song: Gitleaks, Commitlint, PR title, Neon preview (PR), Vercel preview.
+
+### Production CD sau merge `main` (fail-fast)
+
+```text
+CI Success (main push)
+        │
+        ▼
+Check backend changed?
+        │
+   No ──┴── Yes
+   │         │
+   │         ▼
+   │    Build gate (ubuntu) ──fail──► dừng (không migrate Neon)
+   │         │
+   │         ▼
+   │    Prisma migrate (Neon) ──fail──► dừng (không deploy Pi)
+   │         │
+   │         ▼
+   │    Build & deploy on Pi + health JSON ──fail──► CD Success đỏ
+   │         │
+   │         ▼
+   │    CD Success xanh
+   │
+   └──► CD Success (skipped — chỉ frontend/docs đổi)
+
+Vercel production: check riêng; nên bật “Wait for Checks” = CI Success.
+```
+
+Thứ tự job trong `deploy-backend.yml`: `check-changes` → `build` → `migrate` → `deploy` → `cd-success` (mỗi bước `needs` bước trước).
+
+---
+
+## Bảng: check trên PR/commit vs deploy thật
+
+| Thành phần | Job / check nhìn thấy trên commit | Có deploy production? | Làm sao biết xong |
+|------------|-----------------------------------|------------------------|-------------------|
+| **Chất lượng code** | `CI / CI Success` | Không | Job xanh trên PR |
+| **Backend smoke (giả lập)** | `CI / Backend Health Check` | Không — Postgres trong container CI, không phải Neon/Pi | JSON health + DB `SELECT 1` trên runner Ubuntu |
+| **Frontend** | `CI / Frontend` + **Vercel** | Vercel: có (static) khi merge/push branch được hook | Vercel check + dashboard Deployments |
+| **DB production** | *Không hiện trên PR* | Có — sau **Build gate** CD | **Prisma migrate (production)** |
+| **Backend Pi** | *Không hiện trên PR* | Có — khi backend-relevant | **Build & deploy on Pi** → **CD Success** |
+
+---
+
+## Khi nào CD production chạy / bỏ qua
+
+Workflow **`Deploy backend (Pi)`** chạy khi:
+
+1. Workflow **CI** kết thúc **success** trên **`main`**, event **push** (sau merge), **hoặc**
+2. **`workflow_dispatch`** (luôn deploy, bỏ qua path filter).
+
+Job **`Check if backend changed`** bỏ qua **build, migrate, deploy** nếu **không** có file trong:
+
+- `backend/**`
+- `pnpm-lock.yaml`
+- `.github/workflows/deploy-backend.yml`
+
+**Path filter:** với push thường, CI upload artifact `push-changed-files-<sha>` (diff `before`…`after` của push). CD đọc artifact đó — tránh miss thay đổi khi một lần `git push` gồm nhiều commit (chỉ so `HEAD^` là không đủ). Không có artifact → fallback `git diff HEAD^ HEAD`.
+
+**Squash-merge nhiều commit trên PR:** thường một commit trên `main` — OK. Edge case hiếm: dùng **workflow_dispatch**.
+
+---
+
+## Staging (`staging` branch)
+
+| Workflow | Trigger | DB | Backend |
+|----------|---------|-----|---------|
+| `deploy-staging.yml` | push `staging` + paths backend | Neon staging secrets | Pi instance `diecast360-api-staging` :3001 |
+
+Frontend staging: Vercel preview (không job trong repo).
+
+---
+
+## Neon preview (PR)
+
+`neon-preview-branches.yml`: branch Neon `preview/pr-<n>-<branch>`, `prisma migrate deploy` trên preview — **không** thay production.
+
+---
+
+## Smoke / gap đã biết (không coi là “đã deploy prod”)
+
+| Kiểm tra | Phạm vi | Gap |
+|----------|---------|-----|
+| Backend unit tests | Jest, Prisma mock | Không nối DB thật (health-check job bù phần boot+migrate) |
+| Backend Health Check (CI) | Boot `dist`, migrate, `/api/v1/health` | Không phải Pi, không Neon prod, **không** đọc `UPLOAD_DIR` / R2 |
+| Playwright E2E | `VITE_API_BASE_URL=auto`, mock API | Không test stack prod (Vercel → Tunnel → Pi → Neon) |
+| Pi health sau deploy | `curl` + assert JSON envelope | Giống CI về DB; **không** probe media/storage (postmortem 2026-05-26) |
+| Vercel | Build + deploy static | Không verify API prod; `VITE_*` phải đúng trên Vercel dashboard |
+
+**Build gate (CD):** compile trên GitHub **trước** `prisma migrate deploy` — tránh migrate Neon khi code không build được (CI trên PR đã build một lần; gate CD bắt lại đúng SHA merge).
+
+**Migrate thành công, deploy Pi fail:** schema Neon có thể đã lên trước binary trên Pi — xử lý theo [`RUNBOOKS/data-loss-incident.md`](RUNBOOKS/data-loss-incident.md) / rollback runbook, không auto-down migration.
+
+---
+
+## Branch protection (khuyến nghị)
+
+**Bắt buộc trên PR:**
+
+- `CI Success`
+- `Scan for secrets` (Gitleaks)
+- `Lint commit messages`, `Validate PR title` (nếu dùng)
+
+**Sau merge `main` (tùy chọn, không block PR):**
+
+- Theo dõi workflow **Deploy backend (Pi)** và job **CD Success**
+- Không đặt **CD Success** là required check trên PR (job CD không chạy trên PR)
+
+---
+
+## Fail dễ gặp
+
+| Triệu chứng | Nguyên nhân thường gặp |
+|-------------|-------------------------|
+| CI xanh, prod backend cũ | Chỉ đổi `frontend/**` → CD skip (đúng thiết kế) |
+| CD xanh nhưng không deploy | `backend=false` — xem log **Check if backend changed** |
+| Build gate (CD) fail | TypeScript/Nest build lỗi — migrate/deploy không chạy |
+| Migrate fail | Secret Neon / `DIRECT_URL`, migration conflict — deploy Pi không chạy |
+| Deploy fail trên Pi | Runner offline, `sudo systemctl`, thiếu `.env`, build ARM OOM |
+| Health fail Pi | Neon down, `PORT` sai, app crash — xem `journalctl -u diecast360-api` |
+| Vercel xanh, API lỗi | `VITE_API_BASE_URL` sai hoặc Pi/tunnel down (CD không chạy) |
+| `pnpm audit` fail | CVE high trong lockfile |
+
+---
+
+## Tham chiếu file
+
+| File | Vai trò |
+|------|---------|
+| `.github/workflows/ci.yml` | CI + artifact changed-files (main push) |
+| `.github/workflows/deploy-backend.yml` | Production CD |
+| `.github/workflows/deploy-staging.yml` | Staging CD |
+| `.github/workflows/neon-preview-branches.yml` | DB preview PR |
+| `scripts/ci/assert-health-json.sh` | Probe health JSON (CI + Pi) |

--- a/scripts/ci/assert-health-json.sh
+++ b/scripts/ci/assert-health-json.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Assert GET /api/v1/health body matches API envelope + healthy payload.
+set -euo pipefail
+file="${1:?health JSON file path}"
+if ! jq -e '.ok == true and (.data.ok == true or .data.status == "healthy")' "$file"; then
+  echo "::error::Unexpected /api/v1/health JSON (expected ok + healthy data):" >&2
+  cat "$file" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add [`docs/CICD.md`](docs/CICD.md) with PR vs production CD diagrams and how to read checks (CI vs Vercel vs Deploy backend Pi).
- Record `push-changed-files-<sha>` artifact on `main` push so CD path filter uses full push diff (not only `HEAD^`).
- Production CD fail-fast: **build gate (GitHub)** → **Neon migrate** → **Pi deploy** → **CD Success**; shared health JSON probe for CI and Pi.
- Align staging deploy health assert with production.

## Test plan

- [ ] Merge after **CI Success** on this PR
- [ ] On `main` with backend-only change: verify **Deploy backend (Pi)** runs `Build backend (gate)` before migrate
- [ ] On `main` with frontend-only change: verify **CD Success** reports skipped
- [ ] Optional: Vercel project → require **CI Success** before production deploy
