### PR TITLE
ci: remove jq dependency in health assert

### DIFF
--- a/scripts/ci/assert-health-json.sh
+++ b/scripts/ci/assert-health-json.sh
@@ -2,7 +2,23 @@
 # Assert GET /api/v1/health body matches API envelope + healthy payload.
 set -euo pipefail
 file="${1:?health JSON file path}"
-if ! node -e "const fs=require('fs');const p=process.argv[1];const j=JSON.parse(fs.readFileSync(p,'utf8'));if(!(j?.ok===true && (j?.data?.ok===true || j?.data?.status==='healthy'))){process.exit(1)}" "$file"; then
+# Use Node instead of jq because Node is guaranteed on CI + Pi runners.
+if ! node - "$file" <<'NODE'
+const fs = require('fs');
+const path = process.argv[2];
+
+try {
+  const raw = fs.readFileSync(path, 'utf8');
+  const json = JSON.parse(raw);
+  const healthy =
+    json?.ok === true &&
+    (json?.data?.ok === true || json?.data?.status === 'healthy');
+  if (!healthy) process.exit(1);
+} catch {
+  process.exit(1);
+}
+NODE
+then
   echo "::error::Unexpected /api/v1/health JSON (expected ok + healthy data):" >&2
   cat "$file" >&2
   exit 1

--- a/scripts/ci/assert-health-json.sh
+++ b/scripts/ci/assert-health-json.sh
@@ -2,7 +2,7 @@
 # Assert GET /api/v1/health body matches API envelope + healthy payload.
 set -euo pipefail
 file="${1:?health JSON file path}"
-if ! jq -e '.ok == true and (.data.ok == true or .data.status == "healthy")' "$file"; then
+if ! node -e "const fs=require('fs');const p=process.argv[1];const j=JSON.parse(fs.readFileSync(p,'utf8'));if(!(j?.ok===true && (j?.data?.ok===true || j?.data?.status==='healthy'))){process.exit(1)}" "$file"; then
   echo "::error::Unexpected /api/v1/health JSON (expected ok + healthy data):" >&2
   cat "$file" >&2
   exit 1


### PR DESCRIPTION
## Summary

- remove `jq` requirement from `scripts/ci/assert-health-json.sh`
- parse `/api/v1/health` JSON with Node instead (available on runner)
- fix Pi deploy false-fail when API is healthy but `jq` is missing

## Test plan

- [ ] CI passes on this PR
- [ ] Merge and verify `Deploy backend (Pi)` health step no longer fails with `jq: command not found`