### PR TITLE
chore(env): sync example env vars with runtime config

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,9 +7,12 @@ DIRECT_URL="postgresql://postgres:postgres@localhost:5432/diecast360"
 # DIRECT_URL="postgresql://neondb_owner:your_password@ep-xxx.ap-southeast-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
 
 # Application Settings
+NODE_ENV=development
 PORT=3000
 # Listen address (default in app: 0.0.0.0). Use 127.0.0.1 for localhost-only.
 # HOST=0.0.0.0
+# Proxy hops before app: 1=Nginx/Cloudflare single hop, 2=CDN+LB, 0=no proxy (direct dev).
+# TRUST_PROXY=1
 FRONTEND_URL="http://localhost:5173"
 # Optional comma-separated extra origins (CORS + cookies). localhost/127.0.0.1 variants are auto-added from FRONTEND_URL.
 # FRONTEND_URLS="https://preview.example.com"
@@ -65,3 +68,9 @@ OPENAI_MODEL="gpt-5.2"
 # Rate limit defaults
 # THROTTLE_TTL=60000
 # THROTTLE_LIMIT=100
+
+# CAPTCHA (optional)
+# CAPTCHA_ENABLED=false
+# CAPTCHA_PROVIDER=cloudflare
+# CAPTCHA_SECRET_KEY=""
+# CAPTCHA_MIN_SCORE=0.5

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,13 +1,17 @@
 # Database Connection
+# Required. Local development defaults below.
 # PostgreSQL (Local - default for development)
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/diecast360"
 DIRECT_URL="postgresql://postgres:postgres@localhost:5432/diecast360"
 # PostgreSQL (Neon - production template)
+# Replace USER/PASSWORD/host with your Neon project values.
 # DATABASE_URL="postgresql://neondb_owner:your_password@ep-xxx-pooler.ap-southeast-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
 # DIRECT_URL="postgresql://neondb_owner:your_password@ep-xxx.ap-southeast-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
 
 # Application Settings
+# Runtime mode: development | production
 NODE_ENV=development
+# Backend HTTP port
 PORT=3000
 # Listen address (default in app: 0.0.0.0). Use 127.0.0.1 for localhost-only.
 # HOST=0.0.0.0
@@ -19,33 +23,41 @@ FRONTEND_URL="http://localhost:5173"
 # Vite --host (LAN): set true in dev, keep false in production unless you need it.
 # CORS_ALLOW_LAN=true
 UPLOAD_DIR="./uploads"
+# Max single file upload size in MB
 MAX_UPLOAD_MB=10
+# Max frames for 360 spinner upload
 MAX_SPINNER_FRAMES=48
+# Allowed MIME list for uploads (comma-separated)
 ALLOWED_MIME="image/jpeg,image/png,image/webp"
 # Media storage backend: local (default) or r2 (Cloudflare R2 via S3 API).
 # STORAGE_DRIVER=local
 # When STORAGE_DRIVER=r2, set all R2_* variables below (see Cloudflare dashboard).
-# R2_ACCOUNT_ID=""
-# R2_ACCESS_KEY_ID=""
-# R2_SECRET_ACCESS_KEY=""
-# R2_BUCKET=""
+# R2_ACCOUNT_ID="your_cloudflare_account_id"
+# R2_ACCESS_KEY_ID="your_r2_access_key_id"
+# R2_SECRET_ACCESS_KEY="your_r2_secret_access_key"
+# R2_BUCKET="diecast360-media"
 # Optional: public CDN base for R2 (not used when serving via presigned URLs).
-# R2_PUBLIC_BASE_URL=""
+# R2_PUBLIC_BASE_URL="https://cdn.example.com"
 
 # Public base URL of this API (no trailing slash). Used to sign GET /api/v1/media links.
 # In production set to your HTTPS API origin (e.g. https://nhtin.name.vn). If unset, defaults to http://localhost:3000 (breaks images from a public HTTPS frontend).
 # BACKEND_URL="https://nhtin.name.vn"
 
 # Auth Settings
+# Required, >= 32 chars random secret
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"
+# Access token TTL
 JWT_EXPIRES_IN="15m"
+# Refresh token TTL
 REFRESH_TOKEN_EXPIRES_IN="7d"
 # Web-only hardening: set to false to ignore Authorization: Bearer (cookie-only JWT).
 # JWT_ALLOW_AUTHORIZATION_BEARER=false
 # Emergency: disable HSTS while still in production (Helmet). Prefer fixing TLS instead.
 # SECURITY_HSTS_DISABLED=true
 COOKIE_SECRET="your-cookie-secret-change-this-32chars-min"
+# Set true when API serves over HTTPS (production)
 COOKIE_SECURE=false
+# SameSite: lax | strict | none (none requires COOKIE_SECURE=true)
 COOKIE_SAME_SITE=lax
 # Optional: HMAC cho URL media (>=32 ký tự). Nếu bỏ trống sẽ dùng JWT_SECRET — nên tách để xoay JWT không làm hỏng link ảnh cũ.
 # MEDIA_SIGNING_SECRET="your-media-signing-secret-at-least-32-chars"
@@ -53,16 +65,17 @@ COOKIE_SAME_SITE=lax
 # MEDIA_URL_TTL_MS=604800000
 
 # AI Settings (OpenAI)
+# Optional. Leave empty if AI features are not used.
 OPENAI_API_KEY="sk-..."
 OPENAI_MODEL="gpt-5.2"
 
 # Vector Database (Pinecone) - optional semantic search
-# PINECONE_API_KEY=""
+# PINECONE_API_KEY="pcsk_..."
 # PINECONE_INDEX="diecast360"
 
 # Facebook Graph API - optional automated publish
-# FACEBOOK_PAGE_ID=""
-# FACEBOOK_PAGE_ACCESS_TOKEN=""
+# FACEBOOK_PAGE_ID="123456789012345"
+# FACEBOOK_PAGE_ACCESS_TOKEN="EAAG..."
 # FACEBOOK_GRAPH_API_VERSION="v21.0"
 
 # Rate limit defaults
@@ -70,7 +83,10 @@ OPENAI_MODEL="gpt-5.2"
 # THROTTLE_LIMIT=100
 
 # CAPTCHA (optional)
+# Enable only when you already have provider secret key.
 # CAPTCHA_ENABLED=false
+# cloudflare (Turnstile) or google (reCAPTCHA v3)
 # CAPTCHA_PROVIDER=cloudflare
-# CAPTCHA_SECRET_KEY=""
+# CAPTCHA_SECRET_KEY="your_captcha_secret_key"
+# Only applies when CAPTCHA_PROVIDER=google, value between 0.0 and 1.0
 # CAPTCHA_MIN_SCORE=0.5

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,11 +1,18 @@
+# API base URL used at build time:
+# - auto/empty: same-origin /api/v1 (recommended when frontend+api same domain or reverse-proxied)
+# - absolute URL: https://api.example.com/api/v1 (for separate API domain)
 VITE_API_BASE_URL=auto
+# Toggle admin semantic search UI
 VITE_ADMIN_SEMANTIC_SEARCH_ENABLED=false
+# Frontend spinner frame limit; should be <= backend MAX_SPINNER_FRAMES
 VITE_MAX_SPINNER_FRAMES=48
 # Optional: default shop for public /preorders when visitor has no ?shop_id= and is not logged in
+# Example: 550e8400-e29b-41d4-a716-446655440000
 VITE_PUBLIC_PREORDER_SHOP_ID=
 # Optional: default shop for public catalog (/) when no ?shop_id= in URL (single-tenant deploys)
+# Example: shop UUID or slug depending on deployment setup
 VITE_PUBLIC_CATALOG_SHOP_ID=
 # CAPTCHA frontend (must match backend CAPTCHA_* settings)
 # VITE_CAPTCHA_ENABLED=false
 # VITE_CAPTCHA_PROVIDER=cloudflare
-# VITE_CAPTCHA_SITE_KEY=
+# VITE_CAPTCHA_SITE_KEY="your_site_key_from_provider_dashboard"

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,7 @@ VITE_MAX_SPINNER_FRAMES=48
 VITE_PUBLIC_PREORDER_SHOP_ID=
 # Optional: default shop for public catalog (/) when no ?shop_id= in URL (single-tenant deploys)
 VITE_PUBLIC_CATALOG_SHOP_ID=
+# CAPTCHA frontend (must match backend CAPTCHA_* settings)
+# VITE_CAPTCHA_ENABLED=false
+# VITE_CAPTCHA_PROVIDER=cloudflare
+# VITE_CAPTCHA_SITE_KEY=


### PR DESCRIPTION
## Summary
- add missing backend runtime vars to `backend/.env.example` (`NODE_ENV`, `TRUST_PROXY`)
- add backend CAPTCHA env placeholders to `backend/.env.example`
- add frontend CAPTCHA env placeholders to `frontend/.env.example`

## Test plan
- [x] Verify `backend/.env.example` includes runtime + CAPTCHA vars used by code/docs
- [x] Verify `frontend/.env.example` includes CAPTCHA VITE vars
- [ ] Optional: copy examples to local `.env` files and boot app