### PR TITLE
fix(preorder): correct OR-overwrite, closes_at clear-on-status-change, and duplicate import (review of #229)

### DIFF
--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -253,9 +253,9 @@ Condition: ${item.condition || ''}`;
 
     if (queryDto.preorder_open === true) {
       where.status = 'preorder';
-      where.OR = [
-        { preorder_closes_at: null },
-        { preorder_closes_at: { gt: new Date() } },
+      where.AND = [
+        ...(Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : []),
+        { OR: [{ preorder_closes_at: null }, { preorder_closes_at: { gt: new Date() } }] },
       ];
     }
 
@@ -617,13 +617,13 @@ Condition: ${item.condition || ''}`;
     if (updateDto.is_public !== undefined) updateData.is_public = updateDto.is_public;
     if (updateDto.fb_post_content !== undefined) updateData.fb_post_content = updateDto.fb_post_content;
 
-    // preorder_closes_at: set when explicitly provided; clear when status leaves preorder
-    if (updateDto.preorder_closes_at !== undefined) {
+    // preorder_closes_at: leaving preorder always wins (clears the window); otherwise honor payload
+    if (nextStatus !== 'preorder' && existingItem.status === 'preorder') {
+      updateData.preorder_closes_at = null;
+    } else if (updateDto.preorder_closes_at !== undefined) {
       updateData.preorder_closes_at = updateDto.preorder_closes_at
         ? new Date(updateDto.preorder_closes_at)
         : null;
-    } else if (nextStatus !== 'preorder' && existingItem.status === 'preorder') {
-      updateData.preorder_closes_at = null;
     }
 
     // preorder_opens_at lifecycle is driven solely by status transitions and must run

--- a/backend/src/items/items.service.ts
+++ b/backend/src/items/items.service.ts
@@ -641,6 +641,7 @@ Condition: ${item.condition || ''}`;
       updateData.preorder_price = updateDto.preorder_price ?? null;
     }
 
+
     if (updateDto.car_brand !== undefined || updateDto.model_brand !== undefined) {
       const nextCarBrand =
         updateDto.car_brand !== undefined

--- a/backend/src/public/dto/query-public-items.dto.ts
+++ b/backend/src/public/dto/query-public-items.dto.ts
@@ -1,6 +1,5 @@
 import { IsOptional, IsInt, Min, IsString, IsIn, Max, MaxLength, IsBoolean } from 'class-validator';
-import { Transform } from 'class-transformer';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 
 export class QueryPublicItemsDto {
   @IsOptional()

--- a/backend/src/public/public.service.ts
+++ b/backend/src/public/public.service.ts
@@ -154,9 +154,9 @@ export class PublicService {
 
     if (queryDto.preorder_open === true) {
       where.status = 'preorder';
-      where.OR = [
-        { preorder_closes_at: null },
-        { preorder_closes_at: { gt: new Date() } },
+      where.AND = [
+        ...(Array.isArray(where.AND) ? where.AND : where.AND ? [where.AND] : []),
+        { OR: [{ preorder_closes_at: null }, { preorder_closes_at: { gt: new Date() } }] },
       ];
     }
 

--- a/frontend/src/pages/admin/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/ItemDetailPage.tsx
@@ -879,6 +879,7 @@ export const ItemDetailPage = () => {
       itemData.preorder_price = null;
     }
 
+
     return itemData;
   };
 


### PR DESCRIPTION
## Summary

Fixes ba bug được phát hiện khi review PR #229 (preorder closing countdown).

PR #229 đã đóng mà chưa merge — branch `cursor/ci-autofix-automation-c786` đã được rebase lên `main` hiện tại và áp thêm các fixes này. PR này (`claude/pr-229-review-tkomb`) chứa toàn bộ feature + fixes, sẵn sàng merge.

## Bug fixes

**1. `where.OR` overwrite** (`items.service.ts`, `public.service.ts`)
- Filter `preorder_open` gán thẳng vào `where.OR`, sẽ bị ghi đè nếu filter khác cũng dùng `OR`
- Fix: dùng `where.AND` push để các điều kiện OR compose an toàn

**2. `preorder_closes_at` không bị clear khi đổi status** (`items.service.ts`)
- PATCH với `{ status: 'con_hang', preorder_closes_at: '...' }` giữ lại closes_at trong DB vì nhánh clear bị skip
- Fix: đảo thứ tự if/else — leaving preorder luôn thắng và clear field trước

**3. Duplicate import** (`query-public-items.dto.ts`)
- `Transform` và `Type` import trên hai dòng riêng từ cùng `class-transformer`
- Fix: gộp thành một import

## Notes

Hai bug khác từ review đã được fix sẵn trong `main` trước PR này:
- Timezone bug (`closesAt.slice(0,16)`) → fixed via `toLocalDatetimeInput()`
- Cache key pollution trong `PublicService` → fixed via `buildCountCacheKey()` truncate-to-minute

## Test plan

- [ ] PATCH item `preorder → con_hang` với `preorder_closes_at` trong payload → field phải là `null` trong DB
- [ ] `GET /api/v1/items?preorder_open=true` — chỉ trả preorder items có cửa sổ còn mở
- [ ] `GET /api/v1/public/items?preorder_open=true` — tương tự trên public route
- [ ] Không regression với các update flow hiện có

https://claude.ai/code/session_01WKWoHCSXK92eDGzbwDvT2Q