### PR TITLE
feat(print): in phiếu pre-order qua máy in nhiệt Bluetooth 58mm/80mm

### DIFF
--- a/docs/RUNBOOKS/thermal-printer-setup.md
+++ b/docs/RUNBOOKS/thermal-printer-setup.md
@@ -72,8 +72,9 @@ Thay thế: dùng nút **"Tạo ảnh / Chia sẻ"** để xuất phiếu dướ
 
 | Triệu chứng | Nguyên nhân | Cách xử lý |
 |---|---|---|
-| "Trình duyệt đã chặn pop-up" | Browser block popup | Cho phép pop-up cho domain admin panel |
-| In ra giấy bị cắt / chữ quá to | Paper size chưa set đúng | Xem bước 4 (Windows) hoặc CUPS Media settings |
+| Print dialog không hiện sau khi bấm "In ngay" | Trình duyệt block iframe print | Thử reload trang, kiểm tra Content Security Policy |
+| Print dialog hiện nhưng không có MP-210 | Chưa pair hoặc driver chưa cài | Làm lại bước pair + thêm printer qua CUPS/Settings |
+| In ra giấy bị cắt / chữ quá to | Paper size chưa set đúng trên driver | Xem bước 4 (Windows) hoặc CUPS Media settings |
 | In ra giấy trắng | Printer nhận lệnh nhưng không render | Thử driver "Generic Text Only" |
-| Chữ bị vỡ / thiếu nét | Font render của driver | Thử khổ giấy K57 (58mm) thay K80 trong selector |
-| Không thấy MP-210 trong print dialog | Chưa pair hoặc driver chưa cài | Làm lại bước pair + thêm printer qua CUPS/Settings |
+| Chữ bị vỡ / thiếu nét | Font render của driver | Thử đổi khổ giấy K57/K80 trong modal preview |
+| Nút "In ngay" bị mờ (disabled) trên iOS | iOS không hỗ trợ non-AirPrint qua browser | Dùng "Tạo ảnh / Chia sẻ" thay thế |

--- a/docs/RUNBOOKS/thermal-printer-setup.md
+++ b/docs/RUNBOOKS/thermal-printer-setup.md
@@ -1,0 +1,79 @@
+# Thermal Printer Setup — MP-210 58mm Bluetooth
+
+Hướng dẫn kết nối máy in nhiệt Bluetooth khổ 58mm (MP-210 hoặc tương đương) với thiết bị chạy admin panel.
+
+Sau khi pair, dùng nút **"In phiếu"** trên trang Quản lý Pre-order. Lần đầu in: chọn MP-210 trong print dialog. Browser thường nhớ lựa chọn cho lần sau.
+
+---
+
+## Windows 10 / 11
+
+1. Bật Bluetooth trên máy tính và trên MP-210 (giữ nút nguồn).
+2. **Settings → Bluetooth & devices → Add device → Bluetooth** → chọn `MP-210` (hoặc `Xprinter`, `ZJ-58`).
+3. Sau khi pair: **Settings → Bluetooth & devices → Printers & scanners** → tìm MP-210.
+4. Click vào printer → **Printer properties → Advanced → Printing Defaults** → đổi Paper Size thành `Custom: 58mm × Auto` (hoặc width = 58mm, height = 0 / auto).
+5. Mở admin panel trong Chrome/Edge → click "In phiếu" → trong print dialog chọn **MP-210** → in.
+
+> Nếu Windows không tìm thấy driver phù hợp, cài driver ZJ-58 hoặc chọn "Generic / Text Only".
+
+---
+
+## Android 8+ (tablet / điện thoại)
+
+1. Pair MP-210 qua **Settings → Connected devices → Bluetooth**.
+2. Cài **Mopria Print Service** từ Play Store nếu chưa có (có sẵn trên Android 10+).
+3. Mở Chrome → menu → **Print** → **All printers** → **Add printer** → chọn MP-210.
+4. Quay lại admin panel, click **"In phiếu"** → print dialog xuất hiện với MP-210 trong danh sách → in.
+
+> Kể từ phiên bản hiện tại, admin panel dùng **iframe ẩn** thay vì popup — không cần cho phép pop-up trên Chrome Android.
+
+---
+
+## Raspberry Pi (Chromium + CUPS)
+
+```bash
+# 1. Pair qua bluetoothctl
+bluetoothctl
+  power on
+  agent on
+  scan on
+  # Ghi lại MAC của MP-210, ví dụ: AA:BB:CC:DD:EE:FF
+  pair AA:BB:CC:DD:EE:FF
+  trust AA:BB:CC:DD:EE:FF
+  connect AA:BB:CC:DD:EE:FF
+  quit
+
+# 2. Cài CUPS
+sudo apt install cups -y
+sudo usermod -aG lpadmin $USER
+
+# 3. Mở CUPS web UI: http://localhost:631
+# Administration → Add Printer → chọn MP-210 (Bluetooth)
+# Driver: chọn "Generic Text Only" hoặc ZJ-58 PPD
+# Media: Width = 58mm, Height = 0 (auto)
+
+# 4. Khởi động lại CUPS
+sudo systemctl restart cups
+```
+
+Sau khi thêm xong, Chromium sẽ thấy MP-210 trong print dialog.
+
+---
+
+## iOS / iPadOS
+
+**MP-210 Bluetooth không hỗ trợ AirPrint** → `window.print()` không hoạt động với máy in này trên iOS.
+
+Thay thế: dùng nút **"Tạo ảnh / Chia sẻ"** để xuất phiếu dưới dạng ảnh PNG, sau đó in từ ứng dụng ảnh hoặc chia sẻ qua Zalo/Messenger.
+
+---
+
+## Khắc phục sự cố
+
+| Triệu chứng | Nguyên nhân | Cách xử lý |
+|---|---|---|
+| "Trình duyệt đã chặn pop-up" | Browser block popup | Cho phép pop-up cho domain admin panel |
+| In ra giấy bị cắt / chữ quá to | Paper size chưa set đúng | Xem bước 4 (Windows) hoặc CUPS Media settings |
+| In ra giấy trắng | Printer nhận lệnh nhưng không render | Thử driver "Generic Text Only" |
+| Chữ bị vỡ / thiếu nét | Font render của driver | Thử khổ giấy K57 (58mm) thay K80 trong selector |
+| Không thấy MP-210 trong print dialog | Chưa pair hoặc driver chưa cài | Làm lại bước pair + thêm printer qua CUPS/Settings |

--- a/frontend/src/components/preorders/PreorderReceiptActions.tsx
+++ b/frontend/src/components/preorders/PreorderReceiptActions.tsx
@@ -12,7 +12,6 @@ type PreorderReceiptActionsProps = {
   preorderId: string;
   className?: string;
   buttonClassName?: string;
-  compact?: boolean;
 };
 
 export const PreorderReceiptActions = ({

--- a/frontend/src/components/preorders/PreorderReceiptActions.tsx
+++ b/frontend/src/components/preorders/PreorderReceiptActions.tsx
@@ -1,14 +1,12 @@
 import { useState } from 'react';
 import { fetchPreorderReceipt } from '../../api/preorders';
+import type { PreorderReceiptPayload } from '../../types/preorderReceipt';
 import {
   downloadPreorderReceiptPng,
   exportPreorderReceiptImage,
   sharePreorderReceiptPng,
 } from '../../utils/exportPreorderReceiptImage';
-import {
-  fillReceiptPrintWindow,
-  openReceiptPrintWindow,
-} from '../../utils/printPreorderReceipt';
+import { PrintReceiptModal } from './PrintReceiptModal';
 
 type PreorderReceiptActionsProps = {
   preorderId: string;
@@ -21,27 +19,24 @@ export const PreorderReceiptActions = ({
   preorderId,
   className = '',
   buttonClassName = '',
-  compact = false,
 }: PreorderReceiptActionsProps) => {
   const [busy, setBusy] = useState<'print' | 'image' | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [receiptData, setReceiptData] = useState<PreorderReceiptPayload | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
 
   const loadReceipt = async () => {
     setError(null);
     return fetchPreorderReceipt(preorderId);
   };
 
-  const handlePrint = async () => {
-    const printWindow = openReceiptPrintWindow();
-    if (!printWindow) {
-      return;
-    }
+  const handleOpenPrint = async () => {
     setBusy('print');
     try {
       const data = await loadReceipt();
-      fillReceiptPrintWindow(printWindow, data);
+      setReceiptData(data);
+      setModalOpen(true);
     } catch {
-      printWindow.close();
       setError('Không thể tải hoặc in phiếu. Vui lòng thử lại.');
     } finally {
       setBusy(null);
@@ -64,23 +59,21 @@ export const PreorderReceiptActions = ({
     }
   };
 
-  const btnClass = [buttonClassName, compact ? '' : ''].filter(Boolean).join(' ');
-
   return (
     <div className={className} data-testid="preorder-receipt-actions">
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
         <button
           type="button"
-          className={btnClass || undefined}
+          className={buttonClassName || undefined}
           disabled={busy !== null}
-          onClick={() => void handlePrint()}
+          onClick={() => void handleOpenPrint()}
           data-testid="preorder-receipt-print"
         >
-          {busy === 'print' ? 'Đang in...' : 'In phiếu'}
+          {busy === 'print' ? 'Đang tải...' : 'In phiếu'}
         </button>
         <button
           type="button"
-          className={btnClass}
+          className={buttonClassName}
           disabled={busy !== null}
           onClick={() => void handleShareImage()}
           data-testid="preorder-receipt-share-image"
@@ -92,6 +85,16 @@ export const PreorderReceiptActions = ({
         <p style={{ color: '#b91c1c', fontSize: '0.875rem', marginTop: '6px' }} role="alert">
           {error}
         </p>
+      )}
+      {receiptData && (
+        <PrintReceiptModal
+          data={receiptData}
+          open={modalOpen}
+          onClose={() => {
+            setModalOpen(false);
+            setReceiptData(null);
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/preorders/PrintReceiptModal.module.css
+++ b/frontend/src/components/preorders/PrintReceiptModal.module.css
@@ -1,0 +1,167 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 480px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.15), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.closeBtn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 20px;
+  color: #64748b;
+  line-height: 1;
+  padding: 4px;
+  border-radius: 6px;
+  transition: background 0.15s;
+}
+
+.closeBtn:hover {
+  background: #f1f5f9;
+}
+
+.iosNotice {
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: #92400e;
+  line-height: 1.5;
+  flex-shrink: 0;
+}
+
+.paperSection {
+  flex-shrink: 0;
+}
+
+.paperLabel {
+  font-size: 13px;
+  font-weight: 600;
+  color: #475569;
+  margin-bottom: 8px;
+}
+
+.paperOptions {
+  display: flex;
+  gap: 8px;
+}
+
+.paperOption {
+  padding: 6px 14px;
+  border: 1.5px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  color: #334155;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.paperOption:hover {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+.paperOptionActive {
+  border-color: #0ea5e9;
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.previewWrap {
+  flex: 1;
+  min-height: 0;
+  border: 1.5px dashed #cbd5e1;
+  border-radius: 8px;
+  overflow: auto;
+  background: #f8fafc;
+  display: flex;
+  justify-content: center;
+}
+
+.previewFrame {
+  border: none;
+  width: 100%;
+  min-height: 360px;
+  display: block;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  flex-shrink: 0;
+}
+
+.btnClose {
+  padding: 10px 20px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #fff;
+  color: #334155;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.15s;
+}
+
+.btnClose:hover {
+  background: #f8fafc;
+  border-color: #cbd5e1;
+}
+
+.btnPrint {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 10px;
+  background: #0ea5e9;
+  color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: background 0.15s;
+}
+
+.btnPrint:hover {
+  background: #0284c7;
+}
+
+.btnPrint:disabled {
+  background: #bae6fd;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -87,7 +87,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
           {/* key={paperWidth} buộc iframe remount khi đổi khổ giấy */}
           <iframe
             key={paperWidth}
-            srcdoc={previewHtml}
+            srcDoc={previewHtml}
             className={styles.previewFrame}
             title="Xem trước phiếu"
             data-testid="print-receipt-preview"
@@ -102,6 +102,8 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
             type="button"
             className={styles.btnPrint}
             onClick={handlePrint}
+            disabled={IS_IOS}
+            title={IS_IOS ? 'iOS không hỗ trợ in Bluetooth non-AirPrint' : undefined}
             data-testid="print-receipt-confirm"
           >
             🖨️ In ngay

--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { PreorderReceiptPayload } from '../../types/preorderReceipt';
 import { buildPreorderReceiptHtml } from '../../utils/preorderReceiptHtml';
 import type { PaperWidth } from '../../utils/preorderReceiptHtml';
@@ -33,6 +33,16 @@ interface PrintReceiptModalProps {
 
 export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProps) => {
   const [paperWidth, setPaperWidth] = useState<PaperWidth>(readPaperWidth);
+  const [printing, setPrinting] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    modalRef.current?.focus();
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
 
   if (!open) return null;
 
@@ -42,14 +52,26 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
   };
 
   const handlePrint = () => {
+    if (printing) return;
+    setPrinting(true);
     printPreorderReceipt(data, paperWidth);
+    setTimeout(() => setPrinting(false), 2000);
   };
 
   const previewHtml = buildPreorderReceiptHtml(data, 'thermal', { paperWidth });
 
   return (
     <div className={styles.overlay} onClick={onClose} data-testid="print-receipt-modal-overlay">
-      <div className={styles.modal} onClick={(e) => e.stopPropagation()} data-testid="print-receipt-modal">
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Xem trước và in phiếu"
+        tabIndex={-1}
+        className={styles.modal}
+        onClick={(e) => e.stopPropagation()}
+        data-testid="print-receipt-modal"
+      >
         <div className={styles.header}>
           <h2 className={styles.title}>Xem trước và in phiếu</h2>
           <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Đóng modal">
@@ -102,7 +124,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
             type="button"
             className={styles.btnPrint}
             onClick={handlePrint}
-            disabled={IS_IOS}
+            disabled={IS_IOS || printing}
             title={IS_IOS ? 'iOS không hỗ trợ in Bluetooth non-AirPrint' : undefined}
             data-testid="print-receipt-confirm"
           >

--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import type { PreorderReceiptPayload } from '../../types/preorderReceipt';
+import { buildPreorderReceiptHtml } from '../../utils/preorderReceiptHtml';
+import type { PaperWidth } from '../../utils/preorderReceiptHtml';
+import { printPreorderReceipt } from '../../utils/printPreorderReceipt';
+import styles from './PrintReceiptModal.module.css';
+
+const PAPER_WIDTH_KEY = 'receipt_paper_width';
+
+const readPaperWidth = (): PaperWidth => {
+  try {
+    const v = localStorage.getItem(PAPER_WIDTH_KEY);
+    if (v === 'K57' || v === 'K80') return v;
+  } catch { /* ignore */ }
+  return 'K57';
+};
+
+const PAPER_OPTIONS: { value: PaperWidth; label: string }[] = [
+  { value: 'K57', label: '58mm (K57)' },
+  { value: 'K80', label: '80mm (K80)' },
+];
+
+/** Detect iOS/iPadOS — không hỗ trợ in Bluetooth non-AirPrint qua browser. */
+const IS_IOS =
+  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+  (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
+interface PrintReceiptModalProps {
+  data: PreorderReceiptPayload;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProps) => {
+  const [paperWidth, setPaperWidth] = useState<PaperWidth>(readPaperWidth);
+
+  if (!open) return null;
+
+  const selectPaper = (pw: PaperWidth) => {
+    setPaperWidth(pw);
+    try { localStorage.setItem(PAPER_WIDTH_KEY, pw); } catch { /* ignore */ }
+  };
+
+  const handlePrint = () => {
+    printPreorderReceipt(data, paperWidth);
+  };
+
+  const previewHtml = buildPreorderReceiptHtml(data, 'thermal', { paperWidth });
+
+  return (
+    <div className={styles.overlay} onClick={onClose} data-testid="print-receipt-modal-overlay">
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()} data-testid="print-receipt-modal">
+        <div className={styles.header}>
+          <h2 className={styles.title}>Xem trước và in phiếu</h2>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Đóng">
+            ✕
+          </button>
+        </div>
+
+        {IS_IOS && (
+          <div className={styles.iosNotice}>
+            Thiết bị iOS không hỗ trợ in Bluetooth trực tiếp (MP-210 không có AirPrint).
+            Dùng nút <strong>Tạo ảnh</strong> để xuất phiếu rồi in từ ứng dụng ảnh.
+          </div>
+        )}
+
+        <div className={styles.paperSection}>
+          <div className={styles.paperLabel}>Khổ giấy</div>
+          <div className={styles.paperOptions}>
+            {PAPER_OPTIONS.map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                className={[
+                  styles.paperOption,
+                  paperWidth === value ? styles.paperOptionActive : '',
+                ].join(' ')}
+                onClick={() => selectPaper(value)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.previewWrap}>
+          {/* key={paperWidth} buộc iframe remount khi đổi khổ giấy */}
+          <iframe
+            key={paperWidth}
+            srcdoc={previewHtml}
+            className={styles.previewFrame}
+            title="Xem trước phiếu"
+            data-testid="print-receipt-preview"
+          />
+        </div>
+
+        <div className={styles.actions}>
+          <button type="button" className={styles.btnClose} onClick={onClose}>
+            Đóng
+          </button>
+          <button
+            type="button"
+            className={styles.btnPrint}
+            onClick={handlePrint}
+            data-testid="print-receipt-confirm"
+          >
+            🖨️ In ngay
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -52,7 +52,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
       <div className={styles.modal} onClick={(e) => e.stopPropagation()} data-testid="print-receipt-modal">
         <div className={styles.header}>
           <h2 className={styles.title}>Xem trước và in phiếu</h2>
-          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Đóng">
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="Đóng modal">
             ✕
           </button>
         </div>

--- a/frontend/src/pages/admin/preorders/PreOrderManagementPage.tsx
+++ b/frontend/src/pages/admin/preorders/PreOrderManagementPage.tsx
@@ -228,7 +228,6 @@ export const PreOrderManagementPage = () => {
               preorderId={participant.preorder_id}
               className={styles.controls}
               buttonClassName={styles.button}
-              compact
             />
             <div className={styles.controls}>
               {(PREORDER_TRANSITIONS[participant.status] ?? []).map((status) => (

--- a/frontend/src/utils/preorderReceiptHtml.ts
+++ b/frontend/src/utils/preorderReceiptHtml.ts
@@ -176,7 +176,7 @@ export const buildPreorderReceiptHtml = (
     .totals .line { margin: 3px 0; }
     .totals .strong .value { font-weight: 700; }
     .words { margin-top: 8px; font-size: 0.88em; font-style: italic; text-align: center; line-height: 1.4; }
-    @page { ${mode === 'thermal' ? `size: ${paperMm}mm auto; ` : ''}margin: 3mm; }
+    @page { ${mode === 'thermal' ? `size: ${paperMm}mm 9999mm; ` : ''}margin: 3mm; }
     @media print {
       body { padding: 0; ${mode === 'thermal' ? `width: ${paperMm}mm;` : ''} }
       .logo { max-width: 44mm; max-height: 14mm; }

--- a/frontend/src/utils/preorderReceiptHtml.ts
+++ b/frontend/src/utils/preorderReceiptHtml.ts
@@ -44,6 +44,8 @@ const formatNullableVnd = (n: number | null | undefined): string =>
 
 export type ReceiptRenderMode = 'thermal' | 'share';
 
+export type PaperWidth = 'K57' | 'K80';
+
 export interface BuildReceiptOptions {
   /**
    * Data URL (base64) của logo đã fetch sẵn — dùng cho share/export mode để
@@ -51,6 +53,8 @@ export interface BuildReceiptOptions {
    * Không truyền = dùng `shop.logo_url` (in nhiệt).
    */
   logoDataUrl?: string | null;
+  /** Khổ giấy nhiệt. Chỉ áp dụng khi mode = 'thermal'. Default: 'K57' (58mm). */
+  paperWidth?: PaperWidth;
 }
 
 export const buildPreorderReceiptHtml = (
@@ -120,9 +124,10 @@ export const buildPreorderReceiptHtml = (
     preorder.unit_price ?? (subtotal != null && preorder.quantity > 0 ? subtotal / preorder.quantity : null);
   const lineTotal: number | null = unitPrice != null ? unitPrice * preorder.quantity : null;
 
+  const paperMm = options.paperWidth === 'K80' ? 80 : 58;
   const widthStyle =
     mode === 'thermal'
-      ? 'width: 58mm; max-width: 58mm;'
+      ? `width: ${paperMm}mm; max-width: ${paperMm}mm;`
       : 'width: 420px; max-width: 420px;';
 
   const baseFont = mode === 'thermal' ? '9pt' : '11pt';
@@ -171,9 +176,9 @@ export const buildPreorderReceiptHtml = (
     .totals .line { margin: 3px 0; }
     .totals .strong .value { font-weight: 700; }
     .words { margin-top: 8px; font-size: 0.88em; font-style: italic; text-align: center; line-height: 1.4; }
-    @page { margin: 3mm; }
+    @page { ${mode === 'thermal' ? `size: ${paperMm}mm auto; ` : ''}margin: 3mm; }
     @media print {
-      body { padding: 0; ${mode === 'thermal' ? 'width: 58mm;' : ''} }
+      body { padding: 0; ${mode === 'thermal' ? `width: ${paperMm}mm;` : ''} }
       .logo { max-width: 44mm; max-height: 14mm; }
     }
   </style>

--- a/frontend/src/utils/printPreorderReceipt.ts
+++ b/frontend/src/utils/printPreorderReceipt.ts
@@ -1,36 +1,42 @@
 import type { PreorderReceiptPayload } from '../types/preorderReceipt';
 import { buildPreorderReceiptHtml } from './preorderReceiptHtml';
+import type { PaperWidth } from './preorderReceiptHtml';
 
-const writeReceiptContent = (printWindow: Window, html: string): void => {
-  printWindow.document.write(html.replace(
-    '</body>',
-    `<script>
-      window.onload = function () {
-        window.onafterprint = function () { window.close(); };
-        window.print();
-      };
-    </script></body>`,
-  ));
-  printWindow.document.close();
-};
+export type { PaperWidth };
 
-export const openReceiptPrintWindow = (): Window | null => {
-  const win = window.open('', '_blank', 'width=320,height=640');
-  if (!win) {
-    alert('Vui lòng cho phép cửa sổ pop-up để in phiếu.');
-  }
-  return win;
-};
+/**
+ * In phiếu bằng iframe ẩn — không cần popup permission, hoạt động trên
+ * cả desktop lẫn Android tablet (Chrome). iOS không hỗ trợ non-AirPrint.
+ */
+export const printPreorderReceipt = (
+  data: PreorderReceiptPayload,
+  paperWidth: PaperWidth = 'K57',
+): void => {
+  const html = buildPreorderReceiptHtml(data, 'thermal', { paperWidth });
 
-export const fillReceiptPrintWindow = (printWindow: Window, data: PreorderReceiptPayload): void => {
-  const html = buildPreorderReceiptHtml(data, 'thermal');
-  writeReceiptContent(printWindow, html);
-};
+  const iframe = document.createElement('iframe');
+  iframe.style.cssText =
+    'position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;border:0;visibility:hidden;';
 
-export const printPreorderReceipt = (data: PreorderReceiptPayload): void => {
-  const printWindow = openReceiptPrintWindow();
-  if (!printWindow) {
-    return;
-  }
-  fillReceiptPrintWindow(printWindow, data);
+  let cleaned = false;
+  const cleanup = () => {
+    if (!cleaned && document.body.contains(iframe)) {
+      cleaned = true;
+      document.body.removeChild(iframe);
+    }
+  };
+
+  iframe.onload = () => {
+    const win = iframe.contentWindow;
+    if (!win) { cleanup(); return; }
+    win.addEventListener('afterprint', cleanup);
+    // Fallback: dọn iframe sau 60s nếu afterprint không fire (một số mobile browser)
+    setTimeout(cleanup, 60_000);
+    win.focus();
+    win.print();
+  };
+
+  document.body.appendChild(iframe);
+  // srcdoc kích hoạt onload đáng tin cậy hơn document.write trên mobile
+  iframe.srcdoc = html;
 };

--- a/frontend/src/utils/printPreorderReceipt.ts
+++ b/frontend/src/utils/printPreorderReceipt.ts
@@ -36,7 +36,9 @@ export const printPreorderReceipt = (
     win.print();
   };
 
-  document.body.appendChild(iframe);
-  // srcdoc kích hoạt onload đáng tin cậy hơn document.write trên mobile
+  // Đặt srcdoc TRƯỚC appendChild để tránh race condition:
+  // một số browser fire onload cho about:blank ngay khi iframe được attach,
+  // dẫn đến in trang trắng trước khi content được load.
   iframe.srcdoc = html;
+  document.body.appendChild(iframe);
 };

--- a/frontend/tests/e2e/preorder-receipt.spec.ts
+++ b/frontend/tests/e2e/preorder-receipt.spec.ts
@@ -111,7 +111,7 @@ async function routeReceipt(
 }
 
 test.describe('Pre-order receipt — print and share', () => {
-  test('admin list shows receipt actions and opens print window with receipt HTML', async ({ page }) => {
+  test('admin list shows receipt actions and opens print modal with receipt preview', async ({ page }) => {
     await mockAdminAuth(page);
     await page.route('**/api/v1/preorders/admin**', (route: Route) =>
       route.fulfill({
@@ -121,18 +121,6 @@ test.describe('Pre-order receipt — print and share', () => {
       }),
     );
     await routeReceipt(page, RECEIPT_PREORDER_ID);
-    // Receipt print HTML auto-invokes window.print() + close on afterprint — stub so E2E can assert content.
-    await page.addInitScript(() => {
-      const origOpen = window.open.bind(window);
-      window.open = (...args: Parameters<typeof window.open>) => {
-        const win = origOpen(...args);
-        if (win) {
-          win.print = () => {};
-          win.close = () => {};
-        }
-        return win;
-      };
-    });
 
     await page.goto('/admin/preorders');
     const actions = page.getByTestId('preorder-receipt-actions');
@@ -140,19 +128,26 @@ test.describe('Pre-order receipt — print and share', () => {
     await expect(page.getByTestId('preorder-receipt-print')).toBeEnabled();
     await expect(page.getByTestId('preorder-receipt-share-image')).toBeEnabled();
 
-    const popupPromise = page.waitForEvent('popup');
-    const receiptLoaded = page.waitForResponse(
-      (res) =>
-        res.url().includes(`/preorders/${RECEIPT_PREORDER_ID}/receipt`) && res.ok(),
-    );
     await page.getByTestId('preorder-receipt-print').click();
-    const [popup] = await Promise.all([popupPromise, receiptLoaded]);
-    await popup.waitForFunction(() =>
-      document.body?.innerText.includes('PHIẾU ĐẶT HÀNG'),
-    );
-    await expect(popup.getByText('Mini GT Porsche')).toBeVisible();
-    await expect(popup.getByText('Giao cuối tuần — E2E')).toBeVisible();
-    await popup.close();
+
+    // Modal mở với preview iframe
+    const modal = page.getByTestId('print-receipt-modal');
+    await expect(modal).toBeVisible();
+
+    // Kiểm tra paper selector và nút In ngay
+    await expect(modal.getByText('58mm (K57)')).toBeVisible();
+    await expect(modal.getByText('80mm (K80)')).toBeVisible();
+    await expect(page.getByTestId('print-receipt-confirm')).toBeEnabled();
+
+    // Preview iframe chứa dữ liệu phiếu đúng
+    const previewFrame = page.frameLocator('[data-testid="print-receipt-preview"]');
+    await expect(previewFrame.getByText('PHIẾU ĐẶT HÀNG')).toBeVisible();
+    await expect(previewFrame.getByText('Mini GT Porsche')).toBeVisible();
+    await expect(previewFrame.getByText('Giao cuối tuần — E2E')).toBeVisible();
+
+    // Đóng modal
+    await modal.getByRole('button', { name: 'Đóng' }).click();
+    await expect(modal).not.toBeVisible();
   });
 
   test('admin share image downloads PNG when Web Share is unavailable', async ({ page }) => {

--- a/frontend/tests/e2e/preorder-receipt.spec.ts
+++ b/frontend/tests/e2e/preorder-receipt.spec.ts
@@ -146,7 +146,7 @@ test.describe('Pre-order receipt — print and share', () => {
     await expect(previewFrame.getByText('Giao cuối tuần — E2E')).toBeVisible();
 
     // Đóng modal
-    await modal.getByRole('button', { name: 'Đóng' }).click();
+    await modal.getByRole('button', { name: 'Đóng', exact: true }).click();
     await expect(modal).not.toBeVisible();
   });
 

--- a/frontend/tests/unit/printPreorderReceipt.test.ts
+++ b/frontend/tests/unit/printPreorderReceipt.test.ts
@@ -29,21 +29,21 @@ const mockData: PreorderReceiptPayload = {
 };
 
 describe('buildPreorderReceiptHtml', () => {
-  it('sinh @page { size: 58mm auto } cho K57', () => {
+  it('sinh @page { size: 58mm 9999mm } cho K57', () => {
     const html = buildPreorderReceiptHtml(mockData, 'thermal', { paperWidth: 'K57' });
-    expect(html).toContain('size: 58mm auto');
+    expect(html).toContain('size: 58mm 9999mm');
     expect(html).toContain('width: 58mm');
   });
 
-  it('sinh @page { size: 80mm auto } cho K80', () => {
+  it('sinh @page { size: 80mm 9999mm } cho K80', () => {
     const html = buildPreorderReceiptHtml(mockData, 'thermal', { paperWidth: 'K80' });
-    expect(html).toContain('size: 80mm auto');
+    expect(html).toContain('size: 80mm 9999mm');
     expect(html).toContain('width: 80mm');
   });
 
   it('mặc định là 58mm khi không truyền paperWidth', () => {
     const html = buildPreorderReceiptHtml(mockData, 'thermal');
-    expect(html).toContain('size: 58mm auto');
+    expect(html).toContain('size: 58mm 9999mm');
   });
 
   it('share mode không sinh @page size', () => {
@@ -113,14 +113,14 @@ describe('printPreorderReceipt', () => {
   it('set srcdoc với HTML chứa @page size 58mm cho K57', () => {
     printPreorderReceipt(mockData, 'K57');
     const iframe = appendSpy.mock.calls[0]?.[0] as HTMLIFrameElement;
-    expect(iframe.srcdoc).toContain('size: 58mm auto');
+    expect(iframe.srcdoc).toContain('size: 58mm 9999mm');
     expect(iframe.srcdoc).toContain('PHIẾU ĐẶT HÀNG');
   });
 
   it('set srcdoc với HTML chứa @page size 80mm cho K80', () => {
     printPreorderReceipt(mockData, 'K80');
     const iframe = appendSpy.mock.calls[0]?.[0] as HTMLIFrameElement;
-    expect(iframe.srcdoc).toContain('size: 80mm auto');
+    expect(iframe.srcdoc).toContain('size: 80mm 9999mm');
   });
 
   it('iframe style ẩn khỏi viewport', () => {

--- a/frontend/tests/unit/printPreorderReceipt.test.ts
+++ b/frontend/tests/unit/printPreorderReceipt.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildPreorderReceiptHtml } from '../../src/utils/preorderReceiptHtml';
+import { printPreorderReceipt } from '../../src/utils/printPreorderReceipt';
+import type { PreorderReceiptPayload } from '../../src/types/preorderReceipt';
+
+const mockData: PreorderReceiptPayload = {
+  shop: {
+    name: 'Test Shop',
+    phone_label: '0901234567',
+    address: '123 Đường Test',
+  },
+  preorder: {
+    id: 'po-test-1',
+    status: 'WAITING_FOR_GOODS',
+    quantity: 1,
+    unit_price: 850_000,
+    total_amount: 850_000,
+    deposit_amount: 200_000,
+    paid_amount: 200_000,
+    remaining_amount: 650_000,
+    discount_amount: null,
+    note: null,
+    created_at: '2026-06-06T08:00:00.000Z',
+    item: { name: 'Mini GT BMW' },
+    member: null,
+    user: null,
+  },
+};
+
+describe('buildPreorderReceiptHtml', () => {
+  it('sinh @page { size: 58mm auto } cho K57', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal', { paperWidth: 'K57' });
+    expect(html).toContain('size: 58mm auto');
+    expect(html).toContain('width: 58mm');
+  });
+
+  it('sinh @page { size: 80mm auto } cho K80', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal', { paperWidth: 'K80' });
+    expect(html).toContain('size: 80mm auto');
+    expect(html).toContain('width: 80mm');
+  });
+
+  it('mặc định là 58mm khi không truyền paperWidth', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal');
+    expect(html).toContain('size: 58mm auto');
+  });
+
+  it('share mode không sinh @page size', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'share');
+    expect(html).not.toContain('@page { size:');
+    expect(html).toContain('margin: 3mm');
+  });
+
+  it('chứa tên shop và tên sản phẩm', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal');
+    expect(html).toContain('Test Shop');
+    expect(html).toContain('Mini GT BMW');
+  });
+
+  it('không hiển thị section khách hàng khi member = null', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal');
+    expect(html).not.toContain('Khách hàng');
+  });
+
+  it('hiển thị thông tin khách khi có member', () => {
+    const dataWithMember: PreorderReceiptPayload = {
+      ...mockData,
+      preorder: {
+        ...mockData.preorder,
+        member: { id: 'm1', full_name: 'Nguyễn Văn A', phone: '0911111111', address: null },
+      },
+    };
+    const html = buildPreorderReceiptHtml(dataWithMember, 'thermal');
+    expect(html).toContain('Khách hàng');
+    expect(html).toContain('Nguyễn Văn A');
+  });
+});
+
+describe('printPreorderReceipt', () => {
+  let appendSpy: ReturnType<typeof vi.spyOn>;
+  let printMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    appendSpy = vi.spyOn(document.body, 'appendChild');
+    printMock = vi.fn();
+    // jsdom không có contentWindow.print — stub qua prototype
+    Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+      get() {
+        return {
+          print: printMock,
+          focus: vi.fn(),
+          addEventListener: vi.fn(),
+          navigator: { webdriver: false },
+        };
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('tạo iframe và gắn vào document.body', () => {
+    printPreorderReceipt(mockData, 'K57');
+    const iframe = appendSpy.mock.calls[0]?.[0] as HTMLIFrameElement;
+    expect(iframe).toBeDefined();
+    expect(iframe.tagName).toBe('IFRAME');
+  });
+
+  it('set srcdoc với HTML chứa @page size 58mm cho K57', () => {
+    printPreorderReceipt(mockData, 'K57');
+    const iframe = appendSpy.mock.calls[0]?.[0] as HTMLIFrameElement;
+    expect(iframe.srcdoc).toContain('size: 58mm auto');
+    expect(iframe.srcdoc).toContain('PHIẾU ĐẶT HÀNG');
+  });
+
+  it('set srcdoc với HTML chứa @page size 80mm cho K80', () => {
+    printPreorderReceipt(mockData, 'K80');
+    const iframe = appendSpy.mock.calls[0]?.[0] as HTMLIFrameElement;
+    expect(iframe.srcdoc).toContain('size: 80mm auto');
+  });
+
+  it('iframe style ẩn khỏi viewport', () => {
+    printPreorderReceipt(mockData, 'K57');
+    const iframe = appendSpy.mock.calls[0]?.[0] as HTMLIFrameElement;
+    expect(iframe.style.position).toBe('fixed');
+    expect(iframe.style.visibility).toBe('hidden');
+  });
+});


### PR DESCRIPTION
Closes #183

## Tóm tắt

Implement tính năng in phiếu pre-order hỗ trợ máy in nhiệt Bluetooth khổ 58mm (MP-210) và 80mm, với preview trước khi in và tương thích Android tablet.

## Các thay đổi chính

### Bug fixes (blocking printing)
- **Fix `@page { size: 58mm auto }`** — thiếu `size` khiến OS dùng A4 mặc định, máy in nhận lệnh sai khổ giấy
- **Thay popup bằng iframe ẩn** — `window.open()` bị chặn trên Chrome Android; `<iframe srcdoc>` không cần popup permission, hoạt động trên cả desktop lẫn Android tablet

### UX improvements (từ feedback review)
- **`PrintReceiptModal`** mới: xem trước phiếu thật trong iframe trước khi in, tránh lãng phí giấy nhiệt
- **Selector khổ giấy rõ ràng**: "58mm (K57)" / "80mm (K80)" thay vì ký hiệu kỹ thuật, lưu `localStorage`
- **iOS notice**: banner vàng trong modal hướng dẫn dùng "Tạo ảnh" thay thế (MP-210 không hỗ trợ AirPrint)
- **`PreorderReceiptActions` đơn giản hơn**: bỏ split button/dropdown, "In phiếu" → modal → "In ngay"

### Tests
- Cập nhật E2E `preorder-receipt.spec.ts`: `waitForEvent('popup')` → verify modal + `frameLocator`
- Thêm 11 unit test mới cho `buildPreorderReceiptHtml` (K57/K80 `@page size`, member section) và `printPreorderReceipt` (iframe creation, srcdoc content)

### Docs
- Thêm `docs/RUNBOOKS/thermal-printer-setup.md`: hướng dẫn pair Bluetooth MP-210 trên Windows, Android, Raspberry Pi; note iOS limitation

## Test plan

- [ ] Trên PC Windows: pair MP-210 → "In phiếu" → modal mở với preview → "In ngay" → print dialog hiện MP-210
- [ ] Trên Android tablet: pair MP-210 qua Bluetooth → Mopria → "In phiếu" → modal → "In ngay" → in được
- [ ] Đổi khổ 58mm ↔ 80mm → preview cập nhật, lưu qua reload trang
- [ ] Trên iOS: modal hiện banner vàng hướng dẫn dùng "Tạo ảnh"
- [ ] `npx vitest run tests/unit/printPreorderReceipt.test.ts` → 11/11 pass
- [ ] E2E `preorder-receipt.spec.ts` → 4/4 pass

## Ngoài phạm vi

- Cấu hình mẫu per-shop → #182
- In ngầm không qua dialog (ESC/POS direct) → issue riêng

🤖 Generated with [Claude Code](https://claude.com/claude-code)