### PR TITLE
fix(print): fix receipt printing entire page instead of receipt only

### DIFF
--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -57,14 +57,13 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
     return () => window.removeEventListener('message', onMsg);
   }, [open, onClose]);
 
-  // key={paperWidth} remounts iframe khi đổi khổ giấy — reset readiness để
-  // tránh postMessage bị drop trước khi message listener trong srcdoc được đăng ký.
-  useEffect(() => { setIframeReady(false); }, [paperWidth]);
-
   if (!open) return null;
 
   const selectPaper = (pw: PaperWidth) => {
     setPaperWidth(pw);
+    // key={paperWidth} remounts iframe — reset readiness để tránh postMessage bị drop
+    // trước khi message listener trong srcdoc được đăng ký.
+    setIframeReady(false);
     try { localStorage.setItem(PAPER_WIDTH_KEY, pw); } catch { /* ignore */ }
   };
 

--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react';
 import type { PreorderReceiptPayload } from '../../types/preorderReceipt';
 import { buildPreorderReceiptHtml } from '../../utils/preorderReceiptHtml';
 import type { PaperWidth } from '../../utils/preorderReceiptHtml';
-import { printPreorderReceipt } from '../../utils/printPreorderReceipt';
 import styles from './PrintReceiptModal.module.css';
 
 const PAPER_WIDTH_KEY = 'receipt_paper_width';
@@ -35,6 +34,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
   const [paperWidth, setPaperWidth] = useState<PaperWidth>(readPaperWidth);
   const [printing, setPrinting] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -42,6 +42,15 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
     document.addEventListener('keydown', onKey);
     modalRef.current?.focus();
     return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMsg = (e: MessageEvent) => {
+      if (e.data === 'dc360:afterprint') onClose();
+    };
+    window.addEventListener('message', onMsg);
+    return () => window.removeEventListener('message', onMsg);
   }, [open, onClose]);
 
   if (!open) return null;
@@ -53,8 +62,12 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
 
   const handlePrint = () => {
     if (printing) return;
+    const win = previewRef.current?.contentWindow;
+    if (!win) return;
     setPrinting(true);
-    printPreorderReceipt(data, paperWidth);
+    // postMessage để iframe tự gọi window.print() từ bên trong —
+    // Chrome không cho phép parent gọi iframe.contentWindow.print() để in iframe content.
+    win.postMessage('dc360:print', '*');
     setTimeout(() => setPrinting(false), 2000);
   };
 
@@ -109,6 +122,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
           {/* key={paperWidth} buộc iframe remount khi đổi khổ giấy */}
           <iframe
             key={paperWidth}
+            ref={previewRef}
             srcDoc={previewHtml}
             className={styles.previewFrame}
             title="Xem trước phiếu"

--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -33,6 +33,7 @@ interface PrintReceiptModalProps {
 export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProps) => {
   const [paperWidth, setPaperWidth] = useState<PaperWidth>(readPaperWidth);
   const [printing, setPrinting] = useState(false);
+  const [iframeReady, setIframeReady] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLIFrameElement>(null);
 
@@ -47,11 +48,18 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
   useEffect(() => {
     if (!open) return;
     const onMsg = (e: MessageEvent) => {
-      if (e.data === 'dc360:afterprint') onClose();
+      if (e.source === previewRef.current?.contentWindow && e.data === 'dc360:afterprint') {
+        setPrinting(false);
+        onClose();
+      }
     };
     window.addEventListener('message', onMsg);
     return () => window.removeEventListener('message', onMsg);
   }, [open, onClose]);
+
+  // key={paperWidth} remounts iframe khi đổi khổ giấy — reset readiness để
+  // tránh postMessage bị drop trước khi message listener trong srcdoc được đăng ký.
+  useEffect(() => { setIframeReady(false); }, [paperWidth]);
 
   if (!open) return null;
 
@@ -61,7 +69,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
   };
 
   const handlePrint = () => {
-    if (printing) return;
+    if (printing || !iframeReady) return;
     const win = previewRef.current?.contentWindow;
     if (!win) return;
     setPrinting(true);
@@ -124,6 +132,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
             key={paperWidth}
             ref={previewRef}
             srcDoc={previewHtml}
+            onLoad={() => setIframeReady(true)}
             className={styles.previewFrame}
             title="Xem trước phiếu"
             data-testid="print-receipt-preview"
@@ -138,7 +147,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
             type="button"
             className={styles.btnPrint}
             onClick={handlePrint}
-            disabled={IS_IOS || printing}
+            disabled={IS_IOS || printing || !iframeReady}
             title={IS_IOS ? 'iOS không hỗ trợ in Bluetooth non-AirPrint' : undefined}
             data-testid="print-receipt-confirm"
           >

--- a/frontend/src/utils/preorderReceiptHtml.ts
+++ b/frontend/src/utils/preorderReceiptHtml.ts
@@ -222,7 +222,7 @@ export const buildPreorderReceiptHtml = (
     ${preorder.note?.trim() ? lineItem('Ghi chú', preorder.note.trim()) : ''}
   </div>
   <div class="words">${escapeHtml(totalAmount != null ? formatVndAmountInWords(totalAmount) : '')}</div>
-  <script>window.addEventListener('message',function(e){if(e.data==='dc360:print'){window.addEventListener('afterprint',function(){window.parent.postMessage('dc360:afterprint','*');},{once:true});window.print();}});</script>
+  ${mode === 'thermal' ? '<script>window.addEventListener(\'message\',function(e){if(e.data===\'dc360:print\'){window.addEventListener(\'afterprint\',function(){window.parent.postMessage(\'dc360:afterprint\',\'*\');},{once:true});window.print();}});</script>' : ''}
 </body>
 </html>`;
 };

--- a/frontend/src/utils/preorderReceiptHtml.ts
+++ b/frontend/src/utils/preorderReceiptHtml.ts
@@ -222,6 +222,7 @@ export const buildPreorderReceiptHtml = (
     ${preorder.note?.trim() ? lineItem('Ghi chú', preorder.note.trim()) : ''}
   </div>
   <div class="words">${escapeHtml(totalAmount != null ? formatVndAmountInWords(totalAmount) : '')}</div>
+  <script>window.addEventListener('message',function(e){if(e.data==='dc360:print'){window.addEventListener('afterprint',function(){window.parent.postMessage('dc360:afterprint','*');},{once:true});window.print();}});</script>
 </body>
 </html>`;
 };


### PR DESCRIPTION
## Summary

- **Root cause:** Chrome ignores `iframe.contentWindow.print()` khi được gọi từ parent JS — nó in parent document (toàn bộ trang kể cả modal overlay và preview frame) thay vì chỉ in iframe content.
- **Fix:** Dùng `postMessage` để preview iframe tự gọi `window.print()` từ bên trong context của nó. Chrome chỉ in content của iframe khi chính iframe gọi `print()`.
- **UX improvement:** Sau khi print dialog đóng (`afterprint`), iframe gửi `postMessage` ngược lên parent → modal tự đóng, không cần user click "Đóng" thủ công.

## Changes

- [`PrintReceiptModal.tsx`](frontend/src/components/preorders/PrintReceiptModal.tsx): thay `printPreorderReceipt()` bằng `previewRef.contentWindow.postMessage('dc360:print')` + thêm `useEffect` lắng nghe `dc360:afterprint` để auto-close modal
- [`preorderReceiptHtml.ts`](frontend/src/utils/preorderReceiptHtml.ts): thêm inline script vào receipt HTML — lắng nghe `dc360:print` → gọi `window.print()` → sau `afterprint` gửi `dc360:afterprint` lên parent

## Test plan

- [ ] Mở modal in phiếu → click "In ngay" → chỉ hóa đơn xuất hiện trong print dialog (không có modal chrome, overlay, hay page content)
- [ ] Sau khi dismiss print dialog → modal tự đóng
- [ ] Đổi khổ giấy K57 ↔ K80 rồi in → đúng kích thước
- [ ] Chạy E2E: `pnpm --filter frontend test:e2e -- --grep "receipt"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)