### PR TITLE
fix(print): print receipt via popup onload instead of parent print()

### DIFF
--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -2,6 +2,10 @@ import { useEffect, useRef, useState } from 'react';
 import type { PreorderReceiptPayload } from '../../types/preorderReceipt';
 import { buildPreorderReceiptHtml } from '../../utils/preorderReceiptHtml';
 import type { PaperWidth } from '../../utils/preorderReceiptHtml';
+import {
+  openReceiptPrintPopup,
+  RECEIPT_AFTER_PRINT_MSG,
+} from '../../utils/printPreorderReceipt';
 import styles from './PrintReceiptModal.module.css';
 
 const PAPER_WIDTH_KEY = 'receipt_paper_width';
@@ -34,8 +38,8 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
   const [paperWidth, setPaperWidth] = useState<PaperWidth>(readPaperWidth);
   const [printing, setPrinting] = useState(false);
   const [iframeReady, setIframeReady] = useState(false);
+  const [printBlocked, setPrintBlocked] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
-  const previewRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -45,37 +49,38 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
     return () => document.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
-  useEffect(() => {
-    if (!open) return;
-    const onMsg = (e: MessageEvent) => {
-      if (e.source === previewRef.current?.contentWindow && e.data === 'dc360:afterprint') {
-        setPrinting(false);
-        onClose();
-      }
-    };
-    window.addEventListener('message', onMsg);
-    return () => window.removeEventListener('message', onMsg);
-  }, [open, onClose]);
-
   if (!open) return null;
 
   const selectPaper = (pw: PaperWidth) => {
     setPaperWidth(pw);
-    // key={paperWidth} remounts iframe — reset readiness để tránh postMessage bị drop
-    // trước khi message listener trong srcdoc được đăng ký.
     setIframeReady(false);
     try { localStorage.setItem(PAPER_WIDTH_KEY, pw); } catch { /* ignore */ }
   };
 
   const handlePrint = () => {
     if (printing || !iframeReady) return;
-    const win = previewRef.current?.contentWindow;
-    if (!win) return;
+    setPrintBlocked(false);
+    const result = openReceiptPrintPopup(previewHtml);
+    if (!result.ok) {
+      setPrintBlocked(true);
+      return;
+    }
+    const { popup } = result;
     setPrinting(true);
-    // postMessage để iframe tự gọi window.print() từ bên trong —
-    // Chrome không cho phép parent gọi iframe.contentWindow.print() để in iframe content.
-    win.postMessage('dc360:print', '*');
-    setTimeout(() => setPrinting(false), 2000);
+    const onMsg = (e: MessageEvent) => {
+      if (e.source === popup && e.data === RECEIPT_AFTER_PRINT_MSG) {
+        window.removeEventListener('message', onMsg);
+        setPrinting(false);
+        onClose();
+      }
+    };
+    window.addEventListener('message', onMsg);
+    // Fallback nếu afterprint/postMessage không fire (một số mobile browser)
+    setTimeout(() => {
+      window.removeEventListener('message', onMsg);
+      if (!popup.closed) popup.close();
+      setPrinting(false);
+    }, 60_000);
   };
 
   const previewHtml = buildPreorderReceiptHtml(data, 'thermal', { paperWidth });
@@ -129,7 +134,6 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
           {/* key={paperWidth} buộc iframe remount khi đổi khổ giấy */}
           <iframe
             key={paperWidth}
-            ref={previewRef}
             srcDoc={previewHtml}
             onLoad={() => setIframeReady(true)}
             className={styles.previewFrame}
@@ -138,6 +142,11 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
           />
         </div>
 
+        {printBlocked && (
+          <p style={{ color: '#b91c1c', fontSize: '0.875rem', margin: '0 0 8px', textAlign: 'center' }} role="alert">
+            Trình duyệt đã chặn cửa sổ in. Vui lòng cho phép popup và thử lại.
+          </p>
+        )}
         <div className={styles.actions}>
           <button type="button" className={styles.btnClose} onClick={onClose}>
             Đóng

--- a/frontend/src/utils/preorderReceiptHtml.ts
+++ b/frontend/src/utils/preorderReceiptHtml.ts
@@ -222,7 +222,6 @@ export const buildPreorderReceiptHtml = (
     ${preorder.note?.trim() ? lineItem('Ghi chú', preorder.note.trim()) : ''}
   </div>
   <div class="words">${escapeHtml(totalAmount != null ? formatVndAmountInWords(totalAmount) : '')}</div>
-  ${mode === 'thermal' ? '<script>window.addEventListener(\'message\',function(e){if(e.data===\'dc360:print\'){window.addEventListener(\'afterprint\',function(){window.parent.postMessage(\'dc360:afterprint\',\'*\');},{once:true});window.print();}});</script>' : ''}
 </body>
 </html>`;
 };

--- a/frontend/src/utils/printPreorderReceipt.ts
+++ b/frontend/src/utils/printPreorderReceipt.ts
@@ -4,6 +4,39 @@ import type { PaperWidth } from './preorderReceiptHtml';
 
 export type { PaperWidth };
 
+/** Message popup gửi opener sau khi in xong (đóng modal). */
+export const RECEIPT_AFTER_PRINT_MSG = 'dc360:afterprint';
+
+/**
+ * Gắn script in sau onload — popup phải tự gọi window.print() từ bên trong.
+ * Gọi popup.print() từ parent ngay sau document.write khiến Chrome in trang opener.
+ */
+export const wrapReceiptHtmlForPopupPrint = (html: string): string => {
+  const script = `<script>
+window.onload = function () {
+  window.onafterprint = function () {
+    if (window.opener) window.opener.postMessage('${RECEIPT_AFTER_PRINT_MSG}', '*');
+    window.close();
+  };
+  window.print();
+};
+</script>`;
+  return html.replace('</body>', `${script}</body>`);
+};
+
+export type OpenReceiptPrintPopupResult =
+  | { ok: true; popup: Window }
+  | { ok: false; reason: 'blocked' };
+
+/** Mở popup in phiếu — gọi đồng bộ trong click handler. */
+export const openReceiptPrintPopup = (html: string): OpenReceiptPrintPopupResult => {
+  const popup = window.open('', '_blank', 'width=400,height=640');
+  if (!popup) return { ok: false, reason: 'blocked' };
+  popup.document.write(wrapReceiptHtmlForPopupPrint(html));
+  popup.document.close();
+  return { ok: true, popup };
+};
+
 /**
  * In phiếu bằng iframe ẩn — không cần popup permission, hoạt động trên
  * cả desktop lẫn Android tablet (Chrome). iOS không hỗ trợ non-AirPrint.

--- a/frontend/tests/e2e/preorder-receipt.spec.ts
+++ b/frontend/tests/e2e/preorder-receipt.spec.ts
@@ -150,6 +150,33 @@ test.describe('Pre-order receipt — print and share', () => {
     await expect(modal).not.toBeVisible();
   });
 
+  test('print opens popup with receipt HTML, not parent page', async ({ page, context }) => {
+    await mockAdminAuth(page);
+    await page.route('**/api/v1/preorders/admin**', (route: Route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(adminListResponse),
+      }),
+    );
+    await routeReceipt(page, RECEIPT_PREORDER_ID);
+
+    await page.goto('/admin/preorders');
+    await page.getByTestId('preorder-receipt-print').click();
+    await expect(page.getByTestId('print-receipt-modal')).toBeVisible();
+
+    const popupPromise = context.waitForEvent('page');
+    await page.getByTestId('print-receipt-confirm').click();
+    const popup = await popupPromise;
+    await popup.waitForLoadState('domcontentloaded');
+
+    await expect(popup.getByText('PHIẾU ĐẶT HÀNG')).toBeVisible();
+    await expect(popup.getByText('Mini GT Porsche')).toBeVisible();
+    await expect(popup.getByText('Giao cuối tuần — E2E')).toBeVisible();
+    // Parent admin list vẫn hiển thị — không bị thay bằng nội dung in
+    await expect(page.getByRole('heading', { name: 'Quản lý Pre-order' })).toBeVisible();
+  });
+
   test('admin share image downloads PNG when Web Share is unavailable', async ({ page }) => {
     await mockAdminAuth(page);
     await page.route('**/api/v1/preorders/admin**', (route: Route) =>

--- a/frontend/tests/unit/printPreorderReceipt.test.ts
+++ b/frontend/tests/unit/printPreorderReceipt.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildPreorderReceiptHtml } from '../../src/utils/preorderReceiptHtml';
-import { printPreorderReceipt } from '../../src/utils/printPreorderReceipt';
+import {
+  openReceiptPrintPopup,
+  printPreorderReceipt,
+  RECEIPT_AFTER_PRINT_MSG,
+  wrapReceiptHtmlForPopupPrint,
+} from '../../src/utils/printPreorderReceipt';
 import type { PreorderReceiptPayload } from '../../src/types/preorderReceipt';
 
 const mockData: PreorderReceiptPayload = {
@@ -74,6 +79,62 @@ describe('buildPreorderReceiptHtml', () => {
     const html = buildPreorderReceiptHtml(dataWithMember, 'thermal');
     expect(html).toContain('Khách hàng');
     expect(html).toContain('Nguyễn Văn A');
+  });
+});
+
+describe('wrapReceiptHtmlForPopupPrint', () => {
+  it('gắn script onload + window.print() trước </body>', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal');
+    const wrapped = wrapReceiptHtmlForPopupPrint(html);
+    expect(wrapped).toContain('window.onload = function ()');
+    expect(wrapped).toContain('window.print();');
+    expect(wrapped).toContain(RECEIPT_AFTER_PRINT_MSG);
+    expect(wrapped).not.toEqual(html);
+  });
+
+  it('không làm mất nội dung phiếu', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal');
+    const wrapped = wrapReceiptHtmlForPopupPrint(html);
+    expect(wrapped).toContain('PHIẾU ĐẶT HÀNG');
+    expect(wrapped).toContain('Mini GT BMW');
+  });
+});
+
+describe('openReceiptPrintPopup', () => {
+  let openMock: ReturnType<typeof vi.fn>;
+  let writeMock: ReturnType<typeof vi.fn>;
+  let closeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeMock = vi.fn();
+    closeMock = vi.fn();
+    openMock = vi.fn(() => ({
+      document: { write: writeMock, close: closeMock },
+      closed: false,
+    }));
+    vi.stubGlobal('open', openMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('ghi HTML có script in vào popup', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal');
+    const result = openReceiptPrintPopup(html);
+    expect(result.ok).toBe(true);
+    expect(writeMock).toHaveBeenCalledOnce();
+    const written = writeMock.mock.calls[0]?.[0] as string;
+    expect(written).toContain('window.print();');
+    expect(written).toContain('PHIẾU ĐẶT HÀNG');
+    expect(closeMock).toHaveBeenCalledOnce();
+  });
+
+  it('trả blocked khi window.open null', () => {
+    openMock.mockReturnValue(null);
+    const result = openReceiptPrintPopup('<html></html>');
+    expect(result).toEqual({ ok: false, reason: 'blocked' });
+    expect(writeMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix receipt print dialog showing the entire admin preorders page instead of thermal receipt content
- Popup self-triggers `window.print()` on `onload` (same pattern as `printQr.ts`); parent no longer calls `popup.print()` after `document.write()` 
- Add unit tests for popup print helpers and E2E asserting receipt opens in a separate popup

## Test plan

- [x] Unit: `pnpm --filter ./frontend test:unit -- printPreorderReceipt` (15 passed)
- [x] E2E: `preorder-receipt.spec.ts` (CI)
- [x] Manual: In phiếu -> In ngay on Chrome — print preview shows receipt only, not admin page