### PR TITLE
fix(print): use preview iframe print on Android Chrome

### DIFF
--- a/frontend/src/components/preorders/PrintReceiptModal.tsx
+++ b/frontend/src/components/preorders/PrintReceiptModal.tsx
@@ -5,6 +5,8 @@ import type { PaperWidth } from '../../utils/preorderReceiptHtml';
 import {
   openReceiptPrintPopup,
   RECEIPT_AFTER_PRINT_MSG,
+  RECEIPT_PRINT_MSG,
+  shouldUsePreviewIframePrint,
 } from '../../utils/printPreorderReceipt';
 import styles from './PrintReceiptModal.module.css';
 
@@ -40,6 +42,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
   const [iframeReady, setIframeReady] = useState(false);
   const [printBlocked, setPrintBlocked] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLIFrameElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -47,6 +50,18 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
     document.addEventListener('keydown', onKey);
     modalRef.current?.focus();
     return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPreviewAfterPrint = (e: MessageEvent) => {
+      if (e.source === previewRef.current?.contentWindow && e.data === RECEIPT_AFTER_PRINT_MSG) {
+        setPrinting(false);
+        onClose();
+      }
+    };
+    window.addEventListener('message', onPreviewAfterPrint);
+    return () => window.removeEventListener('message', onPreviewAfterPrint);
   }, [open, onClose]);
 
   if (!open) return null;
@@ -60,6 +75,17 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
   const handlePrint = () => {
     if (printing || !iframeReady) return;
     setPrintBlocked(false);
+
+    // Android: in từ preview iframe đã load — popup/hidden iframe hay báo lỗi in.
+    if (shouldUsePreviewIframePrint()) {
+      const win = previewRef.current?.contentWindow;
+      if (!win) return;
+      setPrinting(true);
+      win.postMessage(RECEIPT_PRINT_MSG, '*');
+      setTimeout(() => setPrinting(false), 60_000);
+      return;
+    }
+
     const result = openReceiptPrintPopup(previewHtml);
     if (!result.ok) {
       setPrintBlocked(true);
@@ -134,6 +160,7 @@ export const PrintReceiptModal = ({ data, open, onClose }: PrintReceiptModalProp
           {/* key={paperWidth} buộc iframe remount khi đổi khổ giấy */}
           <iframe
             key={paperWidth}
+            ref={previewRef}
             srcDoc={previewHtml}
             onLoad={() => setIframeReady(true)}
             className={styles.previewFrame}

--- a/frontend/src/utils/preorderReceiptHtml.ts
+++ b/frontend/src/utils/preorderReceiptHtml.ts
@@ -1,5 +1,6 @@
 import { PREORDER_STATUS_LABELS } from '../constants/preorder';
 import type { PreorderReceiptPayload } from '../types/preorderReceipt';
+import { RECEIPT_AFTER_PRINT_MSG, RECEIPT_PRINT_MSG } from './receiptPrintConstants';
 import { formatVndAmountInWords } from './numberToVietnameseWords';
 import { formatVndLine } from './formatVnd';
 
@@ -222,6 +223,7 @@ export const buildPreorderReceiptHtml = (
     ${preorder.note?.trim() ? lineItem('Ghi chú', preorder.note.trim()) : ''}
   </div>
   <div class="words">${escapeHtml(totalAmount != null ? formatVndAmountInWords(totalAmount) : '')}</div>
+  ${mode === 'thermal' ? `<script>window.addEventListener('message',function(e){if(e.data==='${RECEIPT_PRINT_MSG}'){window.addEventListener('afterprint',function(){window.parent.postMessage('${RECEIPT_AFTER_PRINT_MSG}','*');},{once:true});setTimeout(function(){window.print();},100);}});</script>` : ''}
 </body>
 </html>`;
 };

--- a/frontend/src/utils/printPreorderReceipt.ts
+++ b/frontend/src/utils/printPreorderReceipt.ts
@@ -1,11 +1,18 @@
 import type { PreorderReceiptPayload } from '../types/preorderReceipt';
+import { RECEIPT_AFTER_PRINT_MSG } from './receiptPrintConstants';
 import { buildPreorderReceiptHtml } from './preorderReceiptHtml';
 import type { PaperWidth } from './preorderReceiptHtml';
 
 export type { PaperWidth };
+export { RECEIPT_AFTER_PRINT_MSG, RECEIPT_PRINT_MSG } from './receiptPrintConstants';
 
-/** Message popup gửi opener sau khi in xong (đóng modal). */
-export const RECEIPT_AFTER_PRINT_MSG = 'dc360:afterprint';
+/** Android Chrome: in qua preview iframe (postMessage), không dùng popup/hidden iframe. */
+export const shouldUsePreviewIframePrint = (): boolean =>
+  /Android/i.test(navigator.userAgent);
+
+export type PrintPreorderReceiptOptions = {
+  onAfterPrint?: () => void;
+};
 
 /**
  * Gắn script in sau onload — popup phải tự gọi window.print() từ bên trong.
@@ -44,6 +51,7 @@ export const openReceiptPrintPopup = (html: string): OpenReceiptPrintPopupResult
 export const printPreorderReceipt = (
   data: PreorderReceiptPayload,
   paperWidth: PaperWidth = 'K57',
+  options: PrintPreorderReceiptOptions = {},
 ): void => {
   const html = buildPreorderReceiptHtml(data, 'thermal', { paperWidth });
 
@@ -59,12 +67,17 @@ export const printPreorderReceipt = (
     }
   };
 
+  const finish = () => {
+    cleanup();
+    options.onAfterPrint?.();
+  };
+
   iframe.onload = () => {
     const win = iframe.contentWindow;
-    if (!win) { cleanup(); return; }
-    win.addEventListener('afterprint', cleanup);
+    if (!win) { finish(); return; }
+    win.addEventListener('afterprint', finish);
     // Fallback: dọn iframe sau 60s nếu afterprint không fire (một số mobile browser)
-    setTimeout(cleanup, 60_000);
+    setTimeout(finish, 60_000);
     win.focus();
     win.print();
   };

--- a/frontend/src/utils/receiptPrintConstants.ts
+++ b/frontend/src/utils/receiptPrintConstants.ts
@@ -1,0 +1,2 @@
+export const RECEIPT_PRINT_MSG = 'dc360:print';
+export const RECEIPT_AFTER_PRINT_MSG = 'dc360:afterprint';

--- a/frontend/tests/unit/printPreorderReceipt.test.ts
+++ b/frontend/tests/unit/printPreorderReceipt.test.ts
@@ -5,6 +5,8 @@ import {
   openReceiptPrintPopup,
   printPreorderReceipt,
   RECEIPT_AFTER_PRINT_MSG,
+  RECEIPT_PRINT_MSG,
+  shouldUsePreviewIframePrint,
   wrapReceiptHtmlForPopupPrint,
 } from '../../src/utils/printPreorderReceipt';
 import type { PreorderReceiptPayload } from '../../src/types/preorderReceipt';
@@ -61,6 +63,18 @@ describe('buildPreorderReceiptHtml', () => {
     const html = buildPreorderReceiptHtml(mockData, 'thermal');
     expect(html).toContain('Test Shop');
     expect(html).toContain('Mini GT BMW');
+  });
+
+  it('thermal mode gắn script postMessage in cho preview iframe', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'thermal');
+    expect(html).toContain(RECEIPT_PRINT_MSG);
+    expect(html).toContain(RECEIPT_AFTER_PRINT_MSG);
+    expect(html).toContain('window.print()');
+  });
+
+  it('share mode không gắn script in', () => {
+    const html = buildPreorderReceiptHtml(mockData, 'share');
+    expect(html).not.toContain(RECEIPT_PRINT_MSG);
   });
 
   it('không hiển thị section khách hàng khi member = null', () => {
@@ -135,6 +149,24 @@ describe('openReceiptPrintPopup', () => {
     const result = openReceiptPrintPopup('<html></html>');
     expect(result).toEqual({ ok: false, reason: 'blocked' });
     expect(writeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldUsePreviewIframePrint', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('true trên Android UA', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Linux; Android 14) Chrome/120' });
+    expect(shouldUsePreviewIframePrint()).toBe(true);
+  });
+
+  it('false trên desktop UA', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 Chrome/120',
+    });
+    expect(shouldUsePreviewIframePrint()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Android Chrome fails when printing preorder receipts via popup or hidden iframe (generic print error) even though preview renders correctly.
- On Android, trigger `window.print()` inside the already-loaded preview iframe via `postMessage`; desktop keeps the popup onload print path.
- Extract receipt print message constants and add unit tests for Android detection and thermal print script.

## Test plan

- [ ] Unit: `pnpm --filter ./frontend test:unit printPreorderReceipt`
- [ ] Desktop Chrome: open preorder receipt modal, preview shows receipt, **In ngay** opens print dialog with receipt only
- [ ] Android Chrome: same flow, print dialog opens without generic error; Bluetooth thermal printer prints receipt content
- [ ] Share image flow unchanged