### PR TITLE
feat(admin): shop_staff read-only UI (#352)

### DIFF
--- a/frontend/src/components/AdminLayout.tsx
+++ b/frontend/src/components/AdminLayout.tsx
@@ -27,7 +27,9 @@ import { useShop } from '../hooks/useShop';
 import { useDocumentTitleAndFavicon } from '../hooks/useDocumentTitleAndFavicon';
 import { safeHttpUrlForAttribute } from '../utils/safeHttpUrl';
 import ShopSelector from './admin/ShopSelector';
+import { ShopStaffReadOnlyBanner } from './admin/ShopStaffReadOnlyBanner';
 import { BrandFallbackTile } from './BrandFallbackTile';
+import { isShopStaffReadOnly } from '../utils/shopStaffReadOnly';
 
 interface AdminLayoutProps {
   children: React.ReactNode;
@@ -47,6 +49,7 @@ export const AdminLayout = ({ children }: AdminLayoutProps) => {
   const { activeShop } = useShop();
   const adminShopBranding = useAdminShopBranding(true);
   const isSuperAdmin = useIsSuperAdmin();
+  const isStaffReadOnly = isShopStaffReadOnly(activeShop?.role);
   const [menuState, setMenuState] = useState({ open: false, pathname: location.pathname });
   const isMenuOpen = menuState.open && menuState.pathname === location.pathname;
 
@@ -208,14 +211,16 @@ export const AdminLayout = ({ children }: AdminLayoutProps) => {
             <ShoppingBag size={18} strokeWidth={2} />
             <span>Sản phẩm</span>
           </Link>
-          <Link
-            to={ROUTES.admin.itemsImport}
-            className={cn(adminSidebarNavLinkBase, isAdminItemsImportActive(pathname) && adminSidebarNavLinkActive)}
-            onClick={closeMobileMenu}
-          >
-            <Sparkles size={18} strokeWidth={2} />
-            <span>AI tool</span>
-          </Link>
+          {!isStaffReadOnly && (
+            <Link
+              to={ROUTES.admin.itemsImport}
+              className={cn(adminSidebarNavLinkBase, isAdminItemsImportActive(pathname) && adminSidebarNavLinkActive)}
+              onClick={closeMobileMenu}
+            >
+              <Sparkles size={18} strokeWidth={2} />
+              <span>AI tool</span>
+            </Link>
+          )}
           <Link
             to={ROUTES.admin.preorders}
             className={cn(adminSidebarNavLinkBase, isAdminPreordersHubActive(pathname) && adminSidebarNavLinkActive)}
@@ -326,7 +331,10 @@ export const AdminLayout = ({ children }: AdminLayoutProps) => {
           </button>
         </header>
 
-        <main className="flex-1">{children}</main>
+        <main className="flex-1">
+          {isStaffReadOnly ? <ShopStaffReadOnlyBanner /> : null}
+          {children}
+        </main>
         {sharedFooter}
       </div>
     </div>

--- a/frontend/src/components/admin/CategoryQuickManage.tsx
+++ b/frontend/src/components/admin/CategoryQuickManage.tsx
@@ -6,6 +6,8 @@ import type { CategoryItem, ApiError } from '../../types/category';
 import styles from './CategoryQuickManage.module.css';
 import { useOptionalActiveShopId } from '../../hooks/useOptionalActiveShopId';
 import { useOptionalPlatformSuper } from '../../hooks/useOptionalPlatformSuper';
+import { useShop } from '../../hooks/useShop';
+import { isShopStaffReadOnly } from '../../utils/shopStaffReadOnly';
 
 interface Props {
   type: 'car_brand' | 'model_brand';
@@ -14,8 +16,10 @@ interface Props {
 
 export const CategoryQuickManage = ({ type, categories }: Props) => {
   const queryClient = useQueryClient();
+  const { activeShop } = useShop();
   const activeShopId = useOptionalActiveShopId();
   const isPlatformSuperUser = useOptionalPlatformSuper();
+  const readOnly = isShopStaffReadOnly(activeShop?.role) && !isPlatformSuperUser;
   const [isOpen, setIsOpen] = useState(false);
   const [newName, setNewName] = useState('');
   const [error, setError] = useState('');
@@ -157,6 +161,10 @@ export const CategoryQuickManage = ({ type, categories }: Props) => {
     if (a.is_active !== b.is_active) return a.is_active ? -1 : 1;
     return a.display_order - b.display_order;
   });
+
+  if (readOnly) {
+    return null;
+  }
 
   return (
     <div className={styles.wrapper} ref={popoverRef}>

--- a/frontend/src/components/admin/ShopStaffReadOnlyBanner.tsx
+++ b/frontend/src/components/admin/ShopStaffReadOnlyBanner.tsx
@@ -1,0 +1,17 @@
+import { Eye } from 'lucide-react';
+import { SHOP_STAFF_READONLY_BANNER_TEXT } from '../../utils/shopStaffReadOnly';
+
+export function ShopStaffReadOnlyBanner() {
+  return (
+    <div
+      role="status"
+      data-testid="shop-staff-readonly-banner"
+      className="border-b border-amber-200/90 bg-amber-50 px-4 py-2.5 text-sm font-medium text-amber-950"
+    >
+      <div className="mx-auto flex max-w-7xl items-center gap-2">
+        <Eye size={16} className="shrink-0 text-amber-700" strokeWidth={2.25} aria-hidden />
+        <span>{SHOP_STAFF_READONLY_BANNER_TEXT}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/AiImportPage.tsx
+++ b/frontend/src/pages/admin/AiImportPage.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useShop } from '../../hooks/useShop';
+import { isShopStaffReadOnly } from '../../utils/shopStaffReadOnly';
 import { Upload, Loader2, Check, AlertCircle } from 'lucide-react';
 import { isAxiosError } from 'axios';
 import { apiClient, uploadFile } from '../../api/client';
@@ -40,12 +42,23 @@ interface ApiEnvelope<T> {
 
 export const AiImportPage = () => {
   const navigate = useNavigate();
+  const { activeShop } = useShop();
+  const readOnly = isShopStaffReadOnly(activeShop?.role);
   const [uploading, setUploading] = useState(false);
   const [analyzing, setAnalyzing] = useState(false);
   const [draft, setDraft] = useState<AiDraftResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
-
   const [formData, setFormData] = useState<Partial<ItemFormData>>({});
+
+  useEffect(() => {
+    if (readOnly) {
+      navigate('/admin/items', { replace: true });
+    }
+  }, [readOnly, navigate]);
+
+  if (readOnly) {
+    return null;
+  }
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {

--- a/frontend/src/pages/admin/CategoriesPage.tsx
+++ b/frontend/src/pages/admin/CategoriesPage.tsx
@@ -5,6 +5,7 @@ import { apiClient } from '../../api/client';
 import type { CategoryItem, ApiError, ApiResponse, CategoryType } from '../../types/category';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { useShop } from '../../hooks/useShop';
+import { isShopStaffReadOnly } from '../../utils/shopStaffReadOnly';
 import { useOptionalPlatformSuper } from '../../hooks/useOptionalPlatformSuper';
 import { cn } from '../../lib/utils';
 import styles from './CategoriesPage.module.css';
@@ -20,12 +21,14 @@ const TYPE_LABELS: Record<CategoryType, string> = {
 
 interface CategoryActionProps {
   category: CategoryItem;
+  readOnly?: boolean;
   onEdit: (category: CategoryItem) => void;
   onToggle: (id: string) => void;
   onDelete: (category: CategoryItem) => void;
 }
 
 interface CategoryListActionProps {
+  readOnly?: boolean;
   onEdit: (category: CategoryItem) => void;
   onToggle: (id: string) => void;
   onDelete: (category: CategoryItem) => void;
@@ -39,7 +42,12 @@ interface CategoryDesktopTableProps extends CategoryListActionProps {
   categories: CategoryItem[];
 }
 
-const CategoryActions = ({ category, onEdit, onToggle, onDelete }: CategoryActionProps) => (
+const CategoryActions = ({ category, readOnly = false, onEdit, onToggle, onDelete }: CategoryActionProps) => {
+  if (readOnly) {
+    return <span style={{ fontSize: '12px', color: '#94a3b8' }}>Chỉ xem</span>;
+  }
+
+  return (
   <>
     <button
       className={styles.iconButton}
@@ -67,10 +75,12 @@ const CategoryActions = ({ category, onEdit, onToggle, onDelete }: CategoryActio
       <Trash2 size={16} />
     </button>
   </>
-);
+  );
+};
 
 const CategoryMobileList = ({
   categories,
+  readOnly = false,
   onEdit,
   onToggle,
   onDelete,
@@ -96,6 +106,7 @@ const CategoryMobileList = ({
         <div className={styles.mobileActions}>
           <CategoryActions
             category={category}
+            readOnly={readOnly}
             onEdit={onEdit}
             onToggle={onToggle}
             onDelete={onDelete}
@@ -108,6 +119,7 @@ const CategoryMobileList = ({
 
 const CategoryDesktopTable = ({
   categories,
+  readOnly = false,
   onEdit,
   onToggle,
   onDelete,
@@ -137,6 +149,7 @@ const CategoryDesktopTable = ({
             <div style={{ display: 'flex', gap: '4px', justifyContent: 'center' }}>
               <CategoryActions
                 category={category}
+                readOnly={readOnly}
                 onEdit={onEdit}
                 onToggle={onToggle}
                 onDelete={onDelete}
@@ -154,6 +167,7 @@ export const CategoriesPage = () => {
   const isMobile = useIsMobile();
   const { activeShop } = useShop();
   const isPlatformSuper = useOptionalPlatformSuper();
+  const readOnly = isShopStaffReadOnly(activeShop?.role) && !isPlatformSuper;
   const [activeType, setActiveType] = useState<CategoryType>('car_brand');
 
   // Modal states
@@ -319,16 +333,18 @@ export const CategoriesPage = () => {
       </div>
 
       {/* Actions Bar */}
-      <div className={styles.actionsBar}>
-        <button
-          className={styles.addButton}
-          onClick={openCreateModal}
-          aria-label={`Thêm ${TYPE_LABELS[activeType].toLowerCase()}`}
-        >
-          <Plus size={18} />
-          Thêm {TYPE_LABELS[activeType].toLowerCase()}
-        </button>
-      </div>
+      {!readOnly && (
+        <div className={styles.actionsBar}>
+          <button
+            className={styles.addButton}
+            onClick={openCreateModal}
+            aria-label={`Thêm ${TYPE_LABELS[activeType].toLowerCase()}`}
+          >
+            <Plus size={18} />
+            Thêm {TYPE_LABELS[activeType].toLowerCase()}
+          </button>
+        </div>
+      )}
 
       {/* Table */}
       {categories.length === 0 ? (
@@ -338,6 +354,7 @@ export const CategoriesPage = () => {
       ) : isMobile ? (
         <CategoryMobileList
           categories={categories}
+          readOnly={readOnly}
           onEdit={openEditModal}
           onToggle={(id) => toggleMutation.mutate(id)}
           onDelete={setDeleteConfirm}
@@ -345,6 +362,7 @@ export const CategoriesPage = () => {
       ) : (
         <CategoryDesktopTable
           categories={categories}
+          readOnly={readOnly}
           onEdit={openEditModal}
           onToggle={(id) => toggleMutation.mutate(id)}
           onDelete={setDeleteConfirm}

--- a/frontend/src/pages/admin/ItemsPage.tsx
+++ b/frontend/src/pages/admin/ItemsPage.tsx
@@ -3,6 +3,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../../api/client';
 import { API_CONFIG } from '../../config/api';
 import { useDebounce } from '../../hooks/useDebounce';
+import { useShop } from '../../hooks/useShop';
+import { isShopStaffReadOnly } from '../../utils/shopStaffReadOnly';
 import type { ItemsResponse } from '../../types/item.types';
 import type { ApiResponse } from '../../types/category';
 import styles from './ItemsPage.module.css';
@@ -14,6 +16,8 @@ import { PaginationControl } from './components/PaginationControl';
 import { DeleteConfirmModal } from './components/DeleteConfirmModal';
 
 export const ItemsPage = () => {
+  const { activeShop } = useShop();
+  const readOnly = isShopStaffReadOnly(activeShop?.role);
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
   const [preorderOpenFilter, setPreorderOpenFilter] = useState(false);
@@ -162,6 +166,7 @@ export const ItemsPage = () => {
       {/* Action Bar: Search + Add */}
       <SearchHeader
         search={search}
+        readOnly={readOnly}
         onSearchChange={(value) => {
           setSearch(value);
           setPage(1);
@@ -191,6 +196,7 @@ export const ItemsPage = () => {
       {/* Table */}
       <ItemsTable
         items={data?.items || []}
+        readOnly={readOnly}
         onDelete={handleDelete}
         onTogglePublic={handleTogglePublic}
         onClosePreorder={handleClosePreorder}

--- a/frontend/src/pages/admin/MembersPage.tsx
+++ b/frontend/src/pages/admin/MembersPage.tsx
@@ -23,6 +23,8 @@ import {
   validateAdjustPointsInput,
   validateCreateMemberInput,
 } from './members/memberFormValidation';
+import { useShop } from '../../hooks/useShop';
+import { isShopStaffReadOnly } from '../../utils/shopStaffReadOnly';
 
 function getErrorMessage(error: unknown, fallback: string): string {
   return (
@@ -33,6 +35,8 @@ function getErrorMessage(error: unknown, fallback: string): string {
 }
 
 export const MembersPage = () => {
+  const { activeShop } = useShop();
+  const readOnly = isShopStaffReadOnly(activeShop?.role);
   const queryClient = useQueryClient();
   const [keywordInput, setKeywordInput] = useState('');
   const [keyword, setKeyword] = useState('');
@@ -246,6 +250,7 @@ export const MembersPage = () => {
 
       <section className="grid gap-4 lg:grid-cols-[minmax(0,5fr)_minmax(0,7fr)]">
         <MemberListPanel
+          readOnly={readOnly}
           keywordInput={keywordInput}
           summaryText={
             membersQuery.isLoading ? 'Đang tải hội viên...' : `${members.length} hội viên trong shop hiện tại`
@@ -283,6 +288,7 @@ export const MembersPage = () => {
 
         <div className="space-y-4">
           <PointsAdjustmentForm
+            readOnly={readOnly}
             selectedMember={selectedMember}
             form={adjustForm}
             isSubmitting={adjustMutation.isPending}
@@ -307,6 +313,7 @@ export const MembersPage = () => {
       </section>
 
       <TierManagementPanel
+        readOnly={readOnly}
         form={tierForm}
         tiers={tiers}
         isLoading={tiersQuery.isLoading}

--- a/frontend/src/pages/admin/PreOrdersPage.tsx
+++ b/frontend/src/pages/admin/PreOrdersPage.tsx
@@ -7,9 +7,13 @@ import { usePreorderTransition } from '../../hooks/usePreorderTransition';
 import type { PreOrderStatus } from '../../types/preorder';
 import { PREORDER_STATUS_COLORS, PREORDER_TRANSITIONS } from './preorders/status';
 import { PreorderReceiptActions } from '../../components/preorders/PreorderReceiptActions';
+import { useShop } from '../../hooks/useShop';
+import { isShopStaffReadOnly } from '../../utils/shopStaffReadOnly';
 import styles from './preorders/preordersAdmin.module.css';
 
 export const PreOrdersPage = () => {
+  const { activeShop } = useShop();
+  const readOnly = isShopStaffReadOnly(activeShop?.role);
   const [filterStatus, setFilterStatus] = useState<PreOrderStatus | 'ALL'>('ALL');
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery({
@@ -31,9 +35,11 @@ export const PreOrdersPage = () => {
       </header>
       <div className={styles.card}>
         <div className={styles.controls}>
-          <Link className={styles.buttonPrimary} to="/admin/preorders/create">
-            Tạo Pre-Order Mới
-          </Link>
+          {!readOnly && (
+            <Link className={styles.buttonPrimary} to="/admin/preorders/create">
+              Tạo Pre-Order Mới
+            </Link>
+          )}
           <Link className={styles.button} to="/admin/preorders/manage">
             Quản lý theo campaign
           </Link>
@@ -85,19 +91,21 @@ export const PreOrdersPage = () => {
               className={styles.controls}
               buttonClassName={styles.button}
             />
-            <div className={styles.controls}>
-              {(PREORDER_TRANSITIONS[preorder.status] ?? []).map((status) => (
-                <button
-                  key={status}
-                  type="button"
-                  className={styles.button}
-                  disabled={transitionMutation.isPending}
-                  onClick={() => transitionMutation.mutate({ id: preorder.id, status })}
-                >
-                  Chuyển sang: {PREORDER_STATUS_LABELS[status]}
-                </button>
-              ))}
-            </div>
+            {!readOnly && (
+              <div className={styles.controls}>
+                {(PREORDER_TRANSITIONS[preorder.status] ?? []).map((status) => (
+                  <button
+                    key={status}
+                    type="button"
+                    className={styles.button}
+                    disabled={transitionMutation.isPending}
+                    onClick={() => transitionMutation.mutate({ id: preorder.id, status })}
+                  >
+                    Chuyển sang: {PREORDER_STATUS_LABELS[status]}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       ))}

--- a/frontend/src/pages/admin/components/ItemsTable.tsx
+++ b/frontend/src/pages/admin/components/ItemsTable.tsx
@@ -25,6 +25,7 @@ import { PreorderCountdown } from '../../../components/preorder/PreorderCountdow
 
 interface ItemsTableProps {
   items: AdminItem[];
+  readOnly?: boolean;
   onDelete: (id: string, name: string) => void;
   onTogglePublic: (id: string, isPublic: boolean) => void;
   onClosePreorder: (id: string) => Promise<void>;
@@ -35,6 +36,7 @@ interface ItemsTableProps {
 
 export const ItemsTable = ({
   items,
+  readOnly = false,
   onDelete,
   onTogglePublic,
   onClosePreorder,
@@ -289,11 +291,11 @@ export const ItemsTable = ({
                 <div className={styles.rowActions}>
                   <button
                     onClick={() => navigate(`/admin/items/${item.id}`)}
-                    title="Sửa"
+                    title={readOnly ? 'Xem chi tiết' : 'Sửa'}
                     className={styles.iconButton}
-                    aria-label={`Sửa ${item.name}`}
+                    aria-label={readOnly ? `Xem ${item.name}` : `Sửa ${item.name}`}
                   >
-                    <Pencil size={18} />
+                    {readOnly ? <Eye size={18} /> : <Pencil size={18} />}
                   </button>
                   <button
                     onClick={() => handlePrintQr(item)}
@@ -305,7 +307,7 @@ export const ItemsTable = ({
                   >
                     <Printer size={18} />
                   </button>
-                  {isPreorderOpen(item) && (
+                  {!readOnly && isPreorderOpen(item) && (
                     <button
                       onClick={() => handleClosePreorder(item.id)}
                       title="Đóng preorder"
@@ -317,7 +319,7 @@ export const ItemsTable = ({
                       <X size={18} />
                     </button>
                   )}
-                  {isPreorderClosed(item) && (
+                  {!readOnly && isPreorderClosed(item) && (
                     <button
                       onClick={() => handleReopenPreorder(item.id)}
                       title="Mở lại preorder"
@@ -329,25 +331,29 @@ export const ItemsTable = ({
                       <AlarmClock size={18} />
                     </button>
                   )}
-                  <button
-                    onClick={() => onDelete(item.id, item.name)}
-                    title="Xóa"
-                    disabled={isDeletePending}
-                    className={styles.deleteButton}
-                    aria-label={`Xóa ${item.name}`}
-                  >
-                    <Trash2 size={18} />
-                  </button>
-                  <button
-                    onClick={() => onTogglePublic(item.id, item.is_public)}
-                    title={item.is_public ? 'Ẩn khỏi công khai' : 'Hiển thị công khai'}
-                    disabled={isTogglePublicPending}
-                    className={styles.iconButton}
-                    style={{ opacity: isTogglePublicPending ? 0.5 : 1 }}
-                    aria-label={item.is_public ? `Ẩn ${item.name}` : `Công khai ${item.name}`}
-                  >
-                    {item.is_public ? <Eye size={18} /> : <EyeOff size={18} />}
-                  </button>
+                  {!readOnly && (
+                    <button
+                      onClick={() => onDelete(item.id, item.name)}
+                      title="Xóa"
+                      disabled={isDeletePending}
+                      className={styles.deleteButton}
+                      aria-label={`Xóa ${item.name}`}
+                    >
+                      <Trash2 size={18} />
+                    </button>
+                  )}
+                  {!readOnly && (
+                    <button
+                      onClick={() => onTogglePublic(item.id, item.is_public)}
+                      title={item.is_public ? 'Ẩn khỏi công khai' : 'Hiển thị công khai'}
+                      disabled={isTogglePublicPending}
+                      className={styles.iconButton}
+                      style={{ opacity: isTogglePublicPending ? 0.5 : 1 }}
+                      aria-label={item.is_public ? `Ẩn ${item.name}` : `Công khai ${item.name}`}
+                    >
+                      {item.is_public ? <Eye size={18} /> : <EyeOff size={18} />}
+                    </button>
+                  )}
                 </div>
               </td>
             </tr>

--- a/frontend/src/pages/admin/components/SearchHeader.tsx
+++ b/frontend/src/pages/admin/components/SearchHeader.tsx
@@ -9,9 +9,10 @@ import { ROUTES } from '../../../config/routes';
 interface SearchHeaderProps {
   search: string;
   onSearchChange: (value: string) => void;
+  readOnly?: boolean;
 }
 
-export const SearchHeader = ({ search, onSearchChange }: SearchHeaderProps) => {
+export const SearchHeader = ({ search, onSearchChange, readOnly = false }: SearchHeaderProps) => {
   const [isExporting, setIsExporting] = useState(false);
 
   const handleExportCsv = async () => {
@@ -47,14 +48,18 @@ export const SearchHeader = ({ search, onSearchChange }: SearchHeaderProps) => {
           className={cn('input-trust py-2.5 pl-10 pr-3')}
         />
       </div>
-      <Link to={`${ROUTES.admin.items}/new`} className={styles.addButton}>
-        <Plus size={18} strokeWidth={2} />
-        <span>Thêm sản phẩm</span>
-      </Link>
-      <Link to={ROUTES.admin.itemsImport} className={styles.aiImportButton}>
-        <Sparkles size={18} strokeWidth={2} />
-        <span>Thêm sản phẩm (AI)</span>
-      </Link>
+      {!readOnly && (
+        <>
+          <Link to={`${ROUTES.admin.items}/new`} className={styles.addButton}>
+            <Plus size={18} strokeWidth={2} />
+            <span>Thêm sản phẩm</span>
+          </Link>
+          <Link to={ROUTES.admin.itemsImport} className={styles.aiImportButton}>
+            <Sparkles size={18} strokeWidth={2} />
+            <span>Thêm sản phẩm (AI)</span>
+          </Link>
+        </>
+      )}
       <button
         type="button"
         onClick={handleExportCsv}

--- a/frontend/src/pages/admin/item-detail/ItemDetailPage.tsx
+++ b/frontend/src/pages/admin/item-detail/ItemDetailPage.tsx
@@ -26,6 +26,8 @@ import {
 } from "../itemWorkflow";
 import { useIsMobile } from "../../../hooks/useIsMobile";
 import { useOptionalActiveShopId } from "../../../hooks/useOptionalActiveShopId";
+import { useShop } from "../../../hooks/useShop";
+import { isShopStaffReadOnly } from "../../../utils/shopStaffReadOnly";
 
 import type {
   AttributeRow,
@@ -73,6 +75,8 @@ export const ItemDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { activeShop } = useShop();
+  const readOnly = isShopStaffReadOnly(activeShop?.role);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [status, setStatus] = useState("con_hang");
@@ -213,6 +217,12 @@ export const ItemDetailPage = () => {
     () => (modelBrandsData?.categories || []).filter((c: CategoryItem) => c.is_active),
     [modelBrandsData],
   );
+
+  useEffect(() => {
+    if (readOnly && id === "new") {
+      navigate("/admin/items", { replace: true });
+    }
+  }, [readOnly, id, navigate]);
 
   useEffect(() => {
     imagePreviewUrlsRef.current = imagePreviewUrls;
@@ -877,6 +887,14 @@ export const ItemDetailPage = () => {
   };
 
   const goToStep = (step: ProductStep) => {
+    if (readOnly) {
+      if (isNewItem && step > 1) {
+        return;
+      }
+      setCurrentStep(step);
+      return;
+    }
+
     void (async () => {
       if (stepNavInFlightRef.current) return;
       if (isNewItem && step > 1) {
@@ -899,6 +917,13 @@ export const ItemDetailPage = () => {
   };
 
   const goToNextStep = async () => {
+    if (readOnly) {
+      if (currentStep < 5) {
+        setCurrentStep((currentStep + 1) as ProductStep);
+      }
+      return;
+    }
+
     if (isNewItem && currentStep === 1) {
       if (!name.trim()) {
         showToast("Vui lòng nhập tên sản phẩm trước khi chuyển bước.");
@@ -937,6 +962,13 @@ export const ItemDetailPage = () => {
   };
 
   const goToPrevStep = async () => {
+    if (readOnly) {
+      if (currentStep > 1) {
+        setCurrentStep((currentStep - 1) as ProductStep);
+      }
+      return;
+    }
+
     await navigateStepWithAutoSave({
       currentStep,
       direction: "prev",
@@ -1144,7 +1176,7 @@ export const ItemDetailPage = () => {
               <ArrowLeft size={18} />
               <span>Quay lại danh sách</span>
             </button>
-            {id && id !== "new" && (
+            {id && id !== "new" && !readOnly && (
               <Link
                 to={`/admin/preorders/create?item_id=${encodeURIComponent(id)}`}
                 style={{
@@ -1215,7 +1247,11 @@ export const ItemDetailPage = () => {
                   lineHeight: "1.15",
                 }}
               >
-                {id === "new" ? "Tạo sản phẩm mới" : "Chỉnh sửa sản phẩm"}
+                {id === "new"
+                  ? "Tạo sản phẩm mới"
+                  : readOnly
+                    ? "Xem sản phẩm"
+                    : "Chỉnh sửa sản phẩm"}
               </h1>
               <p
                 style={{
@@ -1227,7 +1263,9 @@ export const ItemDetailPage = () => {
               >
                 {id === "new"
                   ? "Thêm sản phẩm mới vào kho"
-                  : `Chỉnh sửa thông tin sản phẩm: ${item?.name || ""}`}
+                  : readOnly
+                    ? `Chế độ chỉ xem: ${item?.name || ""}`
+                    : `Chỉnh sửa thông tin sản phẩm: ${item?.name || ""}`}
               </p>
             </div>
           </div>
@@ -1271,6 +1309,10 @@ export const ItemDetailPage = () => {
           })}
         </div>
 
+        <fieldset
+          disabled={readOnly}
+          style={{ border: "none", margin: 0, padding: 0, minWidth: 0 }}
+        >
         <form
           onSubmit={(e) => e.preventDefault()}
           onKeyDown={preventEnterSubmit}
@@ -1403,6 +1445,7 @@ export const ItemDetailPage = () => {
             </div>
           </div>
         )}
+        </fieldset>
 
         {/* Step 5: QR Code — rendered outside the id/item guard so new items see the save-first prompt */}
         <div
@@ -1485,9 +1528,13 @@ export const ItemDetailPage = () => {
                   : "0 4px 14px 0 rgb(var(--shop-primary-rgb) / 0.28)",
             }}
           >
-            {saveMutation.isPending ? "Đang lưu..." : "Bước tiếp →"}
+            {readOnly
+              ? "Bước tiếp →"
+              : saveMutation.isPending
+                ? "Đang lưu..."
+                : "Bước tiếp →"}
           </button>
-          {currentStep === 5 && (
+          {currentStep === 5 && !readOnly && (
             <button
               type="button"
               onClick={handleSaveAndBackToList}

--- a/frontend/src/pages/admin/members/MemberListPanel.tsx
+++ b/frontend/src/pages/admin/members/MemberListPanel.tsx
@@ -2,6 +2,7 @@ import { UserPlus } from 'lucide-react';
 import type { Member, Pagination } from '../../../types/member';
 
 type MemberListPanelProps = {
+  readOnly?: boolean;
   keywordInput: string;
   summaryText: string;
   members: Member[];
@@ -24,15 +25,17 @@ export function MemberListPanel(props: MemberListPanelProps) {
     <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between gap-3">
         <h2 className="text-lg font-semibold text-slate-900">Danh sách hội viên</h2>
-        <button
-          type="button"
-          onClick={props.onOpenCreateModal}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-shop text-white shadow-sm transition hover:bg-shop/90 active:bg-shop/80"
-          aria-label="Tạo hội viên mới"
-          title="Tạo hội viên mới"
-        >
-          <UserPlus size={18} strokeWidth={2.25} />
-        </button>
+        {!props.readOnly && (
+          <button
+            type="button"
+            onClick={props.onOpenCreateModal}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-shop text-white shadow-sm transition hover:bg-shop/90 active:bg-shop/80"
+            aria-label="Tạo hội viên mới"
+            title="Tạo hội viên mới"
+          >
+            <UserPlus size={18} strokeWidth={2.25} />
+          </button>
+        )}
       </div>
       <div className="mb-3 grid gap-2">
         <input
@@ -72,23 +75,25 @@ export function MemberListPanel(props: MemberListPanelProps) {
                 {member.points_balance.toLocaleString('vi-VN')} điểm · {member.tier?.name || 'Chưa xếp hạng'}
               </div>
             </button>
-            <div className="mt-2 flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => props.onEditMember(member)}
-                className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-white"
-              >
-                Sửa
-              </button>
-              <button
-                type="button"
-                onClick={() => props.onDeleteMember(member)}
-                className="rounded-md border border-rose-200 px-2.5 py-1 text-xs font-semibold text-rose-700 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={props.isDeletingMember}
-              >
-                Xoá
-              </button>
-            </div>
+            {!props.readOnly && (
+              <div className="mt-2 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => props.onEditMember(member)}
+                  className="rounded-md border border-slate-300 px-2.5 py-1 text-xs font-medium text-slate-700 hover:bg-white"
+                >
+                  Sửa
+                </button>
+                <button
+                  type="button"
+                  onClick={() => props.onDeleteMember(member)}
+                  className="rounded-md border border-rose-200 px-2.5 py-1 text-xs font-semibold text-rose-700 hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={props.isDeletingMember}
+                >
+                  Xoá
+                </button>
+              </div>
+            )}
           </div>
         ))}
         {!props.isLoading && props.members.length === 0 && (

--- a/frontend/src/pages/admin/members/PointsAdjustmentForm.tsx
+++ b/frontend/src/pages/admin/members/PointsAdjustmentForm.tsx
@@ -10,6 +10,7 @@ type AdjustFormState = {
 };
 
 type PointsAdjustmentFormProps = {
+  readOnly?: boolean;
   selectedMember: Member | null;
   form: AdjustFormState;
   isSubmitting: boolean;
@@ -26,6 +27,15 @@ export function PointsAdjustmentForm(props: PointsAdjustmentFormProps) {
     if (!props.selectedMember) return;
     setIsConfirmOpen(true);
   };
+
+  if (props.readOnly) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">Điều chỉnh điểm</h2>
+        <p className="text-sm text-slate-500">Chế độ chỉ xem — không thể điều chỉnh điểm hội viên.</p>
+      </div>
+    );
+  }
 
   return (
     <form onSubmit={handleSubmit} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">

--- a/frontend/src/pages/admin/members/TierManagementPanel.tsx
+++ b/frontend/src/pages/admin/members/TierManagementPanel.tsx
@@ -9,6 +9,7 @@ type TierFormState = {
 };
 
 type TierManagementPanelProps = {
+  readOnly?: boolean;
   form: TierFormState;
   tiers: MemberTier[];
   isLoading: boolean;
@@ -27,6 +28,9 @@ export function TierManagementPanel(props: TierManagementPanelProps) {
   return (
     <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
       <h2 className="mb-3 text-lg font-semibold text-slate-900">Quản lý hạng hội viên</h2>
+      {props.readOnly ? (
+        <p className="mb-3 text-sm text-slate-500">Chế độ chỉ xem — không thể thêm hoặc xoá hạng hội viên.</p>
+      ) : (
       <form onSubmit={props.onSubmit} className="grid gap-3 md:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1fr)_auto]">
         <label className="grid gap-1 text-sm">
           <span className="inline-flex items-center gap-1 font-medium text-slate-700">Tên hạng</span>
@@ -74,6 +78,7 @@ export function TierManagementPanel(props: TierManagementPanelProps) {
           {props.isSubmitting ? 'Đang thêm...' : 'Thêm hạng'}
         </button>
       </form>
+      )}
       {props.isLoading && <p className="mt-3 text-sm text-slate-500">Đang tải danh sách hạng...</p>}
       {props.loadError && (
         <p className="mt-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
@@ -94,14 +99,16 @@ export function TierManagementPanel(props: TierManagementPanelProps) {
                   Bậc hạng {tier.rank} · Từ {tier.min_points.toLocaleString('vi-VN')} điểm
               </div>
             </div>
-            <button
-              type="button"
-              className="rounded-lg border border-rose-200 px-3 py-1.5 text-xs font-semibold text-rose-700"
-              onClick={() => setConfirmTier(tier)}
-              disabled={props.isDeleting}
-            >
-              Xoá
-            </button>
+            {!props.readOnly && (
+              <button
+                type="button"
+                className="rounded-lg border border-rose-200 px-3 py-1.5 text-xs font-semibold text-rose-700"
+                onClick={() => setConfirmTier(tier)}
+                disabled={props.isDeleting}
+              >
+                Xoá
+              </button>
+            )}
           </div>
         ))}
       </div>

--- a/frontend/src/pages/admin/preorders/CreatePreOrderPage.tsx
+++ b/frontend/src/pages/admin/preorders/CreatePreOrderPage.tsx
@@ -1,6 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useShop } from '../../../hooks/useShop';
+import { isShopStaffReadOnly } from '../../../utils/shopStaffReadOnly';
 import { createPreorder } from '../../../api/preorders';
 import { PreorderReceiptActions } from '../../../components/preorders/PreorderReceiptActions';
 import { fetchMembers } from '../../../api/members';
@@ -354,7 +356,20 @@ const CreatePreOrderForm = ({ initialItemId }: CreatePreOrderFormProps) => {
 
 export const CreatePreOrderPage = () => {
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { activeShop } = useShop();
+  const readOnly = isShopStaffReadOnly(activeShop?.role);
   const itemIdFromQuery = searchParams.get('item_id')?.trim() ?? '';
+
+  useEffect(() => {
+    if (readOnly) {
+      navigate('/admin/preorders', { replace: true });
+    }
+  }, [readOnly, navigate]);
+
+  if (readOnly) {
+    return null;
+  }
 
   return <CreatePreOrderForm key={itemIdFromQuery} initialItemId={itemIdFromQuery} />;
 };

--- a/frontend/src/pages/admin/preorders/PreOrderManagementPage.tsx
+++ b/frontend/src/pages/admin/preorders/PreOrderManagementPage.tsx
@@ -7,11 +7,15 @@ import { usePreorderTransition } from '../../../hooks/usePreorderTransition';
 import { PREORDER_TRANSITIONS } from './status';
 import { PreorderCountdown } from '../../../components/preorder/PreorderCountdown';
 import { PreorderReceiptActions } from '../../../components/preorders/PreorderReceiptActions';
+import { useShop } from '../../../hooks/useShop';
+import { isShopStaffReadOnly } from '../../../utils/shopStaffReadOnly';
 import styles from './preordersAdmin.module.css';
 
 const PAGE_SIZE = 50;
 
 export const PreOrderManagementPage = () => {
+  const { activeShop } = useShop();
+  const readOnly = isShopStaffReadOnly(activeShop?.role);
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
 
@@ -183,23 +187,25 @@ export const PreOrderManagementPage = () => {
             >
               Xem chi tiết campaign
             </Link>
-            <Link
-              className={styles.button}
-              to={
-                effectiveCampaignId
-                  ? `/admin/preorders/create?item_id=${encodeURIComponent(effectiveCampaignId)}`
-                  : '#'
-              }
-              aria-disabled={!effectiveCampaignId}
-              tabIndex={effectiveCampaignId ? undefined : -1}
-              onClick={(event) => {
-                if (!effectiveCampaignId) {
-                  event.preventDefault();
+            {!readOnly && (
+              <Link
+                className={styles.button}
+                to={
+                  effectiveCampaignId
+                    ? `/admin/preorders/create?item_id=${encodeURIComponent(effectiveCampaignId)}`
+                    : '#'
                 }
-              }}
-            >
-              Thêm người tham gia
-            </Link>
+                aria-disabled={!effectiveCampaignId}
+                tabIndex={effectiveCampaignId ? undefined : -1}
+                onClick={(event) => {
+                  if (!effectiveCampaignId) {
+                    event.preventDefault();
+                  }
+                }}
+              >
+                Thêm người tham gia
+              </Link>
+            )}
           </div>
         </div>
       </div>
@@ -229,22 +235,24 @@ export const PreOrderManagementPage = () => {
               className={styles.controls}
               buttonClassName={styles.button}
             />
-            <div className={styles.controls}>
-              {(PREORDER_TRANSITIONS[participant.status] ?? []).map((status) => (
-                <button
-                  key={status}
-                  type="button"
-                  className={styles.button}
-                  disabled={transitionMutation.isPending}
-                  data-testid="admin-participant-transition"
-                  onClick={() =>
-                    transitionMutation.mutate({ id: participant.preorder_id, status })
-                  }
-                >
-                  Chuyển sang: {PREORDER_STATUS_LABELS[status]}
-                </button>
-              ))}
-            </div>
+            {!readOnly && (
+              <div className={styles.controls}>
+                {(PREORDER_TRANSITIONS[participant.status] ?? []).map((status) => (
+                  <button
+                    key={status}
+                    type="button"
+                    className={styles.button}
+                    disabled={transitionMutation.isPending}
+                    data-testid="admin-participant-transition"
+                    onClick={() =>
+                      transitionMutation.mutate({ id: participant.preorder_id, status })
+                    }
+                  >
+                    Chuyển sang: {PREORDER_STATUS_LABELS[status]}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/frontend/src/utils/shopStaffReadOnly.ts
+++ b/frontend/src/utils/shopStaffReadOnly.ts
@@ -1,0 +1,9 @@
+/** True when the active shop membership is read-only (shop_staff). */
+export function isShopStaffReadOnly(role?: string | null): boolean {
+  return role === 'shop_staff';
+}
+
+export const SHOP_STAFF_READONLY_TOOLTIP = 'Chế độ chỉ xem';
+
+export const SHOP_STAFF_READONLY_BANNER_TEXT =
+  'Chế độ chỉ xem — tài khoản nhân viên không thể thay đổi dữ liệu';

--- a/frontend/tests/e2e/rbac.spec.ts
+++ b/frontend/tests/e2e/rbac.spec.ts
@@ -7,6 +7,8 @@
  * 3. AddMemberModal renders role picker with shop_admin and shop_staff options
  * 4. Role picker defaults to shop_admin
  * 5. Role picker can be changed to shop_staff
+ * 6. shop_staff sees read-only banner and mutation buttons hidden on items list
+ * 7. shop_staff is redirected from /admin/items/new and /admin/items/import
  */
 import { test, expect, apiOk, authMePayload, stubAuthCsrf, type Route } from './fixtures';
 import type { MockUser, MockShop } from './fixtures';
@@ -42,6 +44,24 @@ const SHOP_ADMIN_USER: MockUser = {
   active_shop_id: 'shop-platform',
   allowed_shop_ids: ['shop-platform'],
   allowed_shops: [PLATFORM_SHOP],
+};
+
+const SHOP_STAFF_SHOP: MockShop = {
+  id: 'shop-staff',
+  name: 'Staff Shop',
+  slug: 'staff-shop',
+  is_active: true,
+  role: 'shop_staff',
+};
+
+const SHOP_STAFF_USER: MockUser = {
+  id: 'u-shop-staff',
+  email: 'staff@example.com',
+  full_name: 'Shop Staff',
+  role: 'admin',
+  active_shop_id: 'shop-staff',
+  allowed_shop_ids: ['shop-staff'],
+  allowed_shops: [SHOP_STAFF_SHOP],
 };
 
 function mockShopsList(page: import('@playwright/test').Page) {
@@ -180,5 +200,75 @@ test.describe('RBAC — AddMemberModal role picker', () => {
     expect(capturedBody).not.toBeNull();
     expect(capturedBody?.role).toBe('shop_staff');
     expect(capturedBody?.email).toBe('staff@example.com');
+  });
+});
+
+test.describe('RBAC — shop_staff read-only UI', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubAuthCsrf(page);
+    await page.route('**/api/v1/auth/me', (route: Route) =>
+      route.fulfill({ json: authMePayload(SHOP_STAFF_USER) }),
+    );
+    await page.route('**/api/v1/items*', (route: Route) =>
+      route.fulfill({
+        json: apiOk({
+          items: [
+            {
+              id: 'item-1',
+              name: 'Test Diecast',
+              status: 'con_hang',
+              price: 500_000,
+              quantity: 3,
+              is_public: true,
+              created_at: '2026-04-01T00:00:00.000Z',
+              updated_at: '2026-04-01T00:00:00.000Z',
+            },
+          ],
+          pagination: { total: 1, page: 1, page_size: 20, total_pages: 1 },
+        }),
+      }),
+    );
+    await page.route('**/api/v1/categories*', (route: Route) =>
+      route.fulfill({ json: apiOk({ categories: [] }) }),
+    );
+  });
+
+  test('shop_staff sees read-only banner on admin pages', async ({ page }) => {
+    await page.goto('/admin/items');
+
+    await expect(page.getByTestId('shop-staff-readonly-banner')).toBeVisible();
+    await expect(page.getByTestId('shop-staff-readonly-banner')).toContainText('Chế độ chỉ xem');
+  });
+
+  test('shop_staff items list hides create/import actions but keeps search', async ({ page }) => {
+    await page.goto('/admin/items');
+
+    await expect(page.getByRole('link', { name: /Thêm sản phẩm/i })).not.toBeVisible();
+    await expect(page.getByRole('link', { name: /Thêm sản phẩm \(AI\)/i })).not.toBeVisible();
+    await expect(page.getByPlaceholder(/tìm kiếm ai/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Xuất dữ liệu/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /AI tool/i })).not.toBeVisible();
+  });
+
+  test('shop_staff items table hides delete and publish toggles', async ({ page }) => {
+    await page.goto('/admin/items');
+
+    await expect(page.getByRole('button', { name: /Xóa Test Diecast/i })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: /Ẩn Test Diecast/i })).not.toBeVisible();
+    await expect(page.getByRole('button', { name: /Xem Test Diecast/i })).toBeVisible();
+  });
+
+  test('shop_staff navigating to /admin/items/new is redirected to items list', async ({ page }) => {
+    await page.goto('/admin/items/new');
+
+    await expect(page).toHaveURL(/\/admin\/items\/?$/, { timeout: 10_000 });
+    await expect(page.getByTestId('shop-staff-readonly-banner')).toBeVisible();
+  });
+
+  test('shop_staff navigating to /admin/items/import is redirected to items list', async ({ page }) => {
+    await page.goto('/admin/items/import');
+
+    await expect(page).toHaveURL(/\/admin\/items\/?$/, { timeout: 10_000 });
+    await expect(page.getByTestId('shop-staff-readonly-banner')).toBeVisible();
   });
 });

--- a/frontend/tests/unit/ItemDetailPage.flow.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.flow.test.tsx
@@ -89,6 +89,15 @@ vi.mock('react-router-dom', () => ({
   },
 }));
 
+vi.mock('../../src/hooks/useShop', () => ({
+  useShop: () => ({
+    activeShop: { id: 'shop-1', name: 'Test Shop', slug: 'test-shop', is_active: true, role: 'shop_admin' },
+    allowedShops: [],
+    switchShop: vi.fn(),
+    loading: false,
+  }),
+}));
+
 vi.mock('../../src/api/client', () => ({
   apiClient: h.apiClient,
   uploadFile: (...args: unknown[]) => h.uploadFile(...args),

--- a/frontend/tests/unit/ItemDetailPage.integration.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.integration.test.tsx
@@ -41,6 +41,15 @@ vi.mock('react-router-dom', () => ({
   },
 }));
 
+vi.mock('../../src/hooks/useShop', () => ({
+  useShop: () => ({
+    activeShop: { id: 'shop-1', name: 'Test Shop', slug: 'test-shop', is_active: true, role: 'shop_admin' },
+    allowedShops: [],
+    switchShop: vi.fn(),
+    loading: false,
+  }),
+}));
+
 vi.mock('../../src/api/client', () => ({
   apiClient: h.apiClient,
   uploadFile: vi.fn(async () => ({})),

--- a/frontend/tests/unit/ItemDetailPage.qr.test.tsx
+++ b/frontend/tests/unit/ItemDetailPage.qr.test.tsx
@@ -85,6 +85,15 @@ vi.mock("react-router-dom", () => ({
   },
 }));
 
+vi.mock("../../src/hooks/useShop", () => ({
+  useShop: () => ({
+    activeShop: { id: "shop-1", name: "Test Shop", slug: "test-shop", is_active: true, role: "shop_admin" },
+    allowedShops: [],
+    switchShop: vi.fn(),
+    loading: false,
+  }),
+}));
+
 vi.mock("../../src/api/client", () => ({
   apiClient: h.apiClient,
   uploadFile: (...args: unknown[]) => h.uploadFile(...args),

--- a/frontend/tests/unit/ItemsPage.semantic-search-env.test.tsx
+++ b/frontend/tests/unit/ItemsPage.semantic-search-env.test.tsx
@@ -80,6 +80,15 @@ const setupAndRender = async (semanticEnabled: boolean) => {
     ),
   }));
 
+  vi.doMock('../../src/hooks/useShop', () => ({
+    useShop: () => ({
+      activeShop: { id: 'shop-1', name: 'Test Shop', slug: 'test-shop', is_active: true, role: 'shop_admin' },
+      allowedShops: [],
+      switchShop: vi.fn(),
+      loading: false,
+    }),
+  }));
+
   const module = await import('../../src/pages/admin/ItemsPage');
   render(<module.ItemsPage />);
 };


### PR DESCRIPTION
## Summary
- Add read-only admin experience for shop_staff: banner, hidden mutation buttons, disabled forms, and redirects from create/import routes.
- Reuse useShop().activeShop.role via isShopStaffReadOnly() — no new auth hook.
- Add Playwright smoke tests for banner visibility and items list action gating.

Closes #352.

## Test plan
- [x] pnpm --filter ./frontend exec tsc --noEmit
- [x] pnpm --filter ./frontend test:e2e -- rbac.spec.ts (9/9)
- [ ] Manual: login as shop_staff, verify items/members/preorders/categories are view-only