### PR TITLE
docs: bổ sung UC-16–20, đồng bộ UC hiện có với codebase, sửa divergences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ For multi-step tasks, state a brief plan:
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
 **Diecast360 examples:**
-- "Add member tier upgrade" → "Points crossing a tier threshold auto-upgrade the member. Downgrade does not happen automatically. Ledger records the event with `reference_type/reference_id`."
+- "Add member tier upgrade" → "Points crossing a tier threshold auto-upgrades the member. **Downgrade also happens automatically** when points_balance drops below current tier threshold (e.g., after redeem or refund). Ledger records the event with `reference_type/reference_id`."
 - "Fix spinner upload" → "24-frame upload succeeds. Frame order preserved after reorder. `(spin_set_id, frame_index)` unique constraint not violated. Exceeding `VITE_MAX_SPINNER_FRAMES` shows an error."
 - "Fix public catalog tenant isolation" → "Requests with `shop_id` query param never bleed into another shop. Inactive shop returns 404. Anonymous requests in production return `PUBLIC_SHOP_REQUIRED (422)`."
 
@@ -131,7 +131,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 **Member FK RESTRICT:** cannot delete a member who has active (non-terminal) pre-orders. Service must check before calling DELETE; the DB will reject otherwise.
 
-**Member points:** every points change must go through the ledger (`MemberPointsLedger`) — never mutate `points_balance` directly.
+**Member points:** every points change must go through the ledger (`MemberPointsLedger`) — never mutate `points_balance` directly. Tier auto-evaluates on every ledger entry: both upgrade and downgrade happen automatically when `points_balance` crosses tier thresholds.
 
 **Item `da_ban` invariant:** `quantity` is always `0` when `status = da_ban`. Service enforces this on both create and update; don't bypass.
 

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -29,13 +29,16 @@
 
 ### Shop / User / RBAC
 - `Shop` là tenant dữ liệu, có `name`, `slug`, `is_active`, `contact_json`, `appearance_json`, `loyalty_json`.
+  - `loyalty_json` structure: `{ vnd_per_point: number, preorder_points_basis: 'paid_amount' | 'total_amount' }`. `vnd_per_point` là số VND cần chi để được 1 điểm (integer ≥1, default 1000 — tức 1 điểm / 1.000 VND). `preorder_points_basis` xác định cơ sở tính điểm khi PAID: `paid_amount` (mặc định) hoặc `total_amount`.
 - `User` có `email`, `password_hash`, `full_name`, `role` legacy, `platform_role`, `is_active`.
 - `UserShopRole` gán user vào shop với vai trò `shop_admin` hoặc `shop_staff`; `shop_staff` là read-only cho mutating API theo guard chung; `platform_super` thao tác quản trị nền tảng không cần active tenant.
 - `ShopAuditLog` ghi thay đổi nhạy cảm: thêm admin/staff, reset password, active/inactive user, update/deactivate/activate shop, đổi role.
+- **Switch active shop:** Khi user gọi `POST /api/v1/auth/switch-shop`, server xác minh user có `UserShopRole` tại shop yêu cầu và shop đang active, sau đó phát JWT mới với claim `active_shop_id` cập nhật và set lại HttpOnly cookie. `TenantGuard` đọc `active_shop_id` từ JWT để scope mọi query — không có session state phía server.
 
 ### RefreshToken
 - Lưu refresh token đã phát hành để hỗ trợ revoke.
 - Thuộc tính: `id`, `user_id`, `token_hash`, `expires_at`, `revoked_at` (nullable), `created_at`.
+- TTL mặc định: access token **15 phút**, refresh token **7 ngày** (lưu trong `expires_at`). Bị revoke sau `POST /auth/logout` hoặc password reset (tất cả refresh token của user bị revoke).
 
 ### AiItemDraft
 - Bản nháp item do AI phân tích từ ảnh chụp sản phẩm.
@@ -88,7 +91,9 @@
   - `PENDING_CONFIRMATION` khi `preorder → con_hang`: **không** tự động advance. Lý do: đơn chưa được shop xác nhận nên admin phải xem xét thủ công. Response trả `preorders_pending_count` để UI cảnh báo.
   - Đơn đã cọc (`paid_amount > 0`) khi `preorder → da_ban`: **không** tự động hủy. Lý do: đã thu tiền khách, phải liên hệ hoàn tiền thủ công. Nếu sau đó admin làm `da_ban → con_hang`, các đơn này giữ nguyên trạng thái.
   - `giu_cho → preorder`: được phép. Admin có thể mở campaign cho item đang reserved. Không có guard tự động — admin tự kiểm tra holds trước khi chuyển.
-- Member points: mọi thay đổi điểm phải đi qua ledger để có audit trail.
+- Member points: mọi thay đổi điểm phải đi qua ledger để có audit trail. Ledger type: `earn` (auto khi PAID), `redeem` (admin áp dụng điểm vào đơn), `adjust` (manual cộng/trừ).
+- Tier auto-evaluate: sau **mỗi** thay đổi ledger, hệ thống so sánh `points_balance` với `min_points` của tất cả tier trong shop. **Upgrade và downgrade đều xảy ra tự động** khi số dư vượt/dưới threshold. Trade-off: tier phản ánh số dư thực tế, không phải điểm tích lũy lifetime — shop cần thông báo rõ chính sách này cho khách hàng.
+- Rate limiting: `POST /auth/forgot-password` tối đa 10 request/IP/giờ (429 Too Many Requests) và 3 request/email/giờ (silent reject — vẫn trả 200 để tránh enumeration). Window là sliding 1 giờ.
 - QR code:
   - Token chỉ được tạo nếu item thuộc về tenant đang request (TenantGuard enforcement).
   - Nếu hai request đồng thời cùng tạo token, race condition được xử lý bằng `updateMany WHERE qr_token IS NULL`; người thua đọc lại token của người thắng từ DB.

--- a/docs/project-docs/group2-product/11_user_story_map.md
+++ b/docs/project-docs/group2-product/11_user_story_map.md
@@ -19,6 +19,31 @@ Epic (Backbone)
 
 ---
 
+## Epic 0: Authentication & Session
+
+**Mục tiêu:** Đảm bảo user truy cập đúng quyền, quản lý phiên đăng nhập an toàn
+
+### Activity 0.1 — Đăng nhập / Đăng xuất
+
+| Story | Task |
+|-------|------|
+| US-008: Là user, tôi muốn đăng xuất để kết thúc phiên làm việc an toàn | T1: Nút "Đăng xuất" trong menu header |
+| | T2: API `POST /api/v1/auth/logout` — revoke refresh token |
+| | T3: Xóa HttpOnly cookies (access_token, refresh_token, csrf_token) |
+| | T4: Redirect về trang login sau khi logout |
+
+### Activity 0.2 — Quản lý Mật khẩu
+
+| Story | Task |
+|-------|------|
+| US-009: Là user, tôi muốn đặt lại mật khẩu khi quên để lấy lại quyền truy cập | T1: Link "Quên mật khẩu?" trên trang login |
+| | T2: API `POST /auth/forgot-password` (always 200, no enumeration) |
+| | T3: Email với reset link (Resend provider, SHA-256 token, 1h TTL) |
+| | T4: API `POST /auth/reset-password` — one-time use, revoke all refresh tokens |
+| | T5: Rate limiting: 10/IP/h, 3/email/h (silent reject) |
+
+---
+
 ## Epic 1: Catalog Management
 
 **Mục tiêu:** Shop admin quản lý toàn bộ vòng đời của item diecast
@@ -171,6 +196,28 @@ Epic (Backbone)
 | | T2: Tạo MemberPointsLedger entry |
 | | T3: Update member tier nếu cần |
 
+### Activity 4.4 — Quản lý Pre-order Campaign
+
+| Story | Task |
+|-------|------|
+| US-038: Là shop admin, tôi muốn mở campaign pre-order với cửa sổ thời gian để bán trước khi hàng về | T1: Chuyển item sang status `preorder` với preorder_price, expected_arrival_at |
+| | T2: preorder_opens_at gán tự động = NOW() |
+| | T3: API `PATCH /items/:id/close-preorder` (đóng sớm) |
+| | T4: API `PATCH /items/:id/reopen-preorder` (mở lại) |
+| | T5: Trang công khai `/preorders` hiển thị campaign với countdown timer |
+| | T6: Transition preorder → con_hang: auto-advance WAITING_FOR_GOODS → ARRIVED |
+| | T7: Cảnh báo preorders_pending_count (PENDING_CONFIRMATION không auto-advance) |
+| | T8: Transition preorder → da_ban: không tự hủy đơn đã cọc |
+
+### Activity 4.5 — Theo dõi Tài chính Pre-order
+
+| Story | Task |
+|-------|------|
+| US-039: Là shop admin, tôi muốn ghi nhận đặt cọc và thanh toán để theo dõi tài chính từng đơn | T1: Fields deposit_amount, paid_amount trên pre-order |
+| | T2: Computed remaining = max(0, total_amount - paid_amount) |
+| | T3: Receipt view với đầy đủ thông tin tài chính |
+| | T4: Admin chia sẻ link biên lai cho khách |
+
 ---
 
 ## Epic 5: Inventory Management
@@ -230,6 +277,15 @@ Epic (Backbone)
 | US-054: Là shop admin, tôi muốn cấu hình chương trình điểm để phù hợp chiến lược kinh doanh | T1: UI cấu hình: earn rate (X điểm / Y nghìn VND) |
 | | T2: UI cấu hình tier: tên + threshold + mô tả |
 | | T3: Lưu vào `shop.loyalty_json` |
+
+### Activity 6.4 — Đổi điểm (Redeem)
+
+| Story | Task |
+|-------|------|
+| US-057: Là shop admin, tôi muốn áp dụng điểm thành tiền giảm giá khi khách thanh toán để giữ chân khách | T1: Form redeem: nhập số điểm muốn dùng (validate <= points_balance) |
+| | T2: Tính giá trị discount theo loyalty_json.redeem_rate |
+| | T3: Tạo MemberPointsLedger (type: redeem, reference: pre_order_id) |
+| | T4: Tier auto-evaluate sau redeem (downgrade nếu < threshold) |
 
 ---
 
@@ -313,6 +369,15 @@ Epic (Backbone)
 | | T2: Form gán role vào shop |
 | | T3: 1 user có thể có nhiều role ở nhiều shop |
 
+### Activity 9.3 — Multi-shop Navigation
+
+| Story | Task |
+|-------|------|
+| US-085: Là user có nhiều shop role, tôi muốn chuyển qua lại giữa các shop mà không cần đăng xuất | T1: Menu dropdown "Chọn shop" ở header (hiển thị shop đang active) |
+| | T2: API switch-shop: validate shop active + user có UserShopRole |
+| | T3: Phát JWT mới với active_shop_id mới, set lại HttpOnly cookie |
+| | T4: Reload dashboard, tất cả data filter theo shop mới |
+
 ---
 
 ## Epic 10: Reports & Analytics
@@ -338,3 +403,27 @@ Epic (Backbone)
 | | T2: Giá trị tồn kho ước tính |
 | US-093: Là shop admin, tôi muốn xem báo cáo member để biết ai là khách VIP | T1: Bảng top member theo điểm |
 | | T2: Member sinh nhật tháng này |
+
+---
+
+## Epic 11: QR Code
+
+**Mục tiêu:** Kết nối offline (vật lý) và online catalog qua mã QR dán lên sản phẩm
+
+### Activity 11.1 — Tạo QR Code (Admin)
+
+| Story | Task |
+|-------|------|
+| US-095: Là shop admin, tôi muốn tạo mã QR cho item để dán lên sản phẩm vật lý | T1: Tab/bước "Mã QR" trong trang chi tiết item |
+| | T2: API `GET /items/:id/qr` — lazy-create qr_token (16-hex, race-safe via `updateMany WHERE qr_token IS NULL`) |
+| | T2b: Backend generate QR PNG từ resolve URL (`qrcode` library hoặc tương đương) |
+| | T3: Hiển thị ảnh QR, link resolve, nút "Tải PNG", nút "Copy link" |
+| | T4: Banner cảnh báo nếu `is_public = false`: "Bật công khai trước khi in QR" |
+
+### Activity 11.2 — Quét QR (Customer)
+
+| Story | Task |
+|-------|------|
+| US-096: Là khách hàng, tôi muốn quét QR trên sản phẩm để xem catalog online ngay lập tức | T1: `GET /public/qr/:token` — no auth, redirect 302 đến item detail |
+| | T2: Frontend hiển thị banner "Bạn đang xem qua mã QR" khi URL có source=qr |
+| | T3: 404 friendly nếu token không tồn tại |

--- a/docs/project-docs/group2-product/12_product_backlog.md
+++ b/docs/project-docs/group2-product/12_product_backlog.md
@@ -12,8 +12,8 @@ project: Diecast360
 
 | Metric | Giá trị |
 |--------|---------|
-| Tổng số User Stories | 56 |
-| Tổng Story Points | 398 |
+| Tổng số User Stories | 64 |
+| Tổng Story Points | 431 |
 | Velocity ước tính | 40 points/sprint (2 tuần) |
 | Số sprint ước tính | ~10 sprints |
 | Thời gian hoàn thành ước tính | ~5 tháng |
@@ -23,22 +23,45 @@ project: Diecast360
 
 | Priority | Số stories | Story Points |
 |----------|-----------|--------------|
-| Critical | 14 | 124 |
-| High | 22 | 162 |
+| Critical | 16 | 131 |
+| High | 26 | 183 |
 | Medium | 14 | 84 |
-| Low | 6 | 28 |
+| Low | 8 | 33 |
 
 ### Phân bổ theo Status
 
 | Status | Số stories | Story Points |
 |--------|-----------|--------------|
-| Done | 32 | 226 |
+| Done | 40 | 259 |
 | In Progress | 8 | 62 |
 | Todo | 16 | 110 |
 
 ---
 
 ## Backlog Items
+
+### Epic 0: Authentication & Session
+
+| ID | Epic | User Story | Priority | Points | Sprint | Status |
+|----|------|-----------|----------|--------|--------|--------|
+| US-008 | Auth | Là user, tôi muốn đăng xuất để kết thúc phiên làm việc an toàn | Critical | 2 | S1 | Done |
+| US-009 | Auth | Là user, tôi muốn đặt lại mật khẩu khi quên để lấy lại quyền truy cập | Critical | 5 | S2 | Done |
+
+**Acceptance Criteria US-008:**
+1. Nút "Đăng xuất" xuất hiện trong menu header khi đã đăng nhập
+2. Click → gọi `POST /auth/logout`, revoke refresh token, xóa cookies
+3. Redirect về `/login` với message "Bạn đã đăng xuất thành công"
+4. Sau logout: truy cập URL admin → redirect về login (không cache session)
+
+**Acceptance Criteria US-009:**
+1. Link "Quên mật khẩu?" trên trang login → form nhập email
+2. Submit luôn trả 200 dù email có tồn tại hay không (chống enumeration)
+3. Email gửi reset link (1h TTL, SHA-256 hash, one-time use)
+4. Token đã dùng → "Link không hợp lệ hoặc đã hết hạn"
+5. Sau reset: tất cả refresh token cũ bị revoke
+6. Rate limit: 10/IP/h, 3/email/h (silent reject trên email)
+
+---
 
 ### Epic 1: Catalog Management
 
@@ -124,6 +147,8 @@ project: Diecast360
 | US-035 | Pre-Order | Là shop admin, tôi muốn xem lịch sử thay đổi trạng thái của đơn để audit | High | 3 | S6 | Done |
 | US-036 | Pre-Order | Là shop admin, tôi muốn thêm note nội bộ vào đơn để ghi chú xử lý | Medium | 3 | S7 | In Progress |
 | US-037 | Pre-Order | Là shop admin, tôi muốn export danh sách pre-order ra CSV để báo cáo | Medium | 5 | S8 | Todo |
+| US-038 | Pre-Order | Là shop admin, tôi muốn mở campaign pre-order với cửa sổ thời gian để bán trước khi hàng về | High | 8 | S6 | Done |
+| US-039 | Pre-Order | Là shop admin, tôi muốn theo dõi đặt cọc và thanh toán của từng đơn để quản lý tài chính | High | 5 | S5 | Done |
 
 **Acceptance Criteria US-033:**
 1. Dropdown status chỉ hiện các transition hợp lệ từ trạng thái hiện tại
@@ -131,6 +156,22 @@ project: Diecast360
 3. Transition không hợp lệ (gọi API trực tiếp) → 422 với message "Invalid status transition"
 4. Sau transition: hiển thị badge status mới, cập nhật timeline lịch sử
 5. `CANCELLED` và `REFUNDED` là terminal: dropdown không hiện bất kỳ option nào
+
+**Acceptance Criteria US-038:**
+1. Chuyển item sang status `preorder` → form hiện thêm preorder_price, expected_arrival_at, preorder_closes_at
+2. `preorder_opens_at` tự động = NOW() (không cần admin nhập)
+3. Item xuất hiện trên `/preorders` khi is_public = true, với countdown đến preorder_closes_at
+4. `PATCH /items/:id/close-preorder` → set preorder_closes_at = NOW(); nút "Đặt hàng" ẩn trên public
+5. `PATCH /items/:id/reopen-preorder` → xóa preorder_closes_at, set preorder_opens_at = NOW()
+6. `preorder → con_hang`: WAITING_FOR_GOODS auto-advance → ARRIVED; PENDING_CONFIRMATION không tự advance
+7. `preorder → da_ban`: đơn có paid_amount > 0 không tự hủy; response trả số lượng đơn cần xử lý
+
+**Acceptance Criteria US-039:**
+1. Pre-order có fields: unit_price, total_amount, deposit_amount, paid_amount
+2. remaining = max(0, total_amount - paid_amount) — computed, không lưu riêng
+3. deposit_amount và paid_amount có thể set khi tạo pre-order; cập nhật sau tạo qua PATCH endpoint (frontend hiện chưa có UI riêng để edit sau tạo — gap đã biết)
+4. paid_amount > total_amount → API từ chối 422 "paid_amount must be <= total_amount"
+5. Receipt view hiển thị đầy đủ: tên khách, item, unit_price, total, deposit, paid, remaining
 
 ---
 
@@ -165,6 +206,7 @@ project: Diecast360
 | US-054 | Loyalty | Là khách hàng, tôi muốn tra cứu điểm qua SĐT để biết quyền lợi | Medium | 5 | S7 | In Progress |
 | US-055 | Loyalty | Là shop admin, tôi muốn xem báo cáo member để biết khách VIP | Medium | 5 | S8 | Todo |
 | US-056 | Loyalty | Là shop admin, tôi muốn xóa member không còn active | Low | 3 | S9 | Todo |
+| US-057 | Loyalty | Là shop admin, tôi muốn áp dụng điểm thành tiền giảm giá khi khách thanh toán | High | 5 | S6 | Done |
 
 **Acceptance Criteria US-053:**
 1. Cấu hình earn rate: nhập "X điểm cho mỗi Y nghìn VND" (ví dụ 1 điểm / 10,000 VND)
@@ -172,6 +214,13 @@ project: Diecast360
 3. Lưu cấu hình → áp dụng ngay cho đơn hàng mới (không hồi tố)
 4. Xem preview: "Đơn 500,000 VND → X điểm"
 5. Thay đổi tier threshold → chỉ ảnh hưởng đến upgrade từ thời điểm đó, không recompute lịch sử
+
+**Acceptance Criteria US-057:**
+1. Admin mở chi tiết pre-order hoặc profile member → nút "Dùng điểm" chỉ hiển thị khi `points_balance > 0`
+2. Nhập số điểm muốn redeem → hệ thống hiển thị giá trị discount tương đương (`points × loyalty_json.vnd_per_point` VND) trước khi xác nhận
+3. Số điểm yêu cầu > `points_balance` → "Số dư không đủ (có: X, cần: Y)", không cho xác nhận
+4. Xác nhận → tạo `MemberPointsLedger` (type: `redeem`, `reference_type: pre_order`, `reference_id: pre_order_id`); `points_balance` giảm đúng số điểm
+5. Tier auto-evaluate ngay sau redeem: nếu `points_balance` mới < `min_points` tier hiện tại → tự động downgrade
 
 ---
 
@@ -220,6 +269,7 @@ project: Diecast360
 | US-082 | Platform | Là platform admin, tôi muốn tạo user và gán vào shop với đúng quyền | Critical | 8 | S1 | Done |
 | US-083 | Platform | Là platform admin, tôi muốn xem log hoạt động toàn platform để giám sát | Medium | 8 | S9 | Todo |
 | US-084 | Platform | Là shop admin, tôi muốn cấu hình thông tin shop (tên, logo, contact) | High | 5 | S2 | Done |
+| US-085 | Platform | Là user có nhiều shop role, tôi muốn chuyển qua lại giữa các shop mà không cần đăng xuất | High | 3 | S2 | Done |
 
 **Acceptance Criteria US-082:**
 1. Tạo user: email (unique toàn platform), password tạm (8+ chars, phải đổi khi login lần đầu)
@@ -227,6 +277,13 @@ project: Diecast360
 3. 1 user có thể có nhiều role tại nhiều shop
 4. Không thể xóa role shop_admin cuối cùng của shop (phải còn ít nhất 1 admin)
 5. User bị xóa role → không thể truy cập shop đó (403 ngay lập tức, không cần logout)
+
+**Acceptance Criteria US-085:**
+1. Header hiển thị tên shop đang active; dropdown "Chọn shop" liệt kê các shop mà user có `UserShopRole` (hiện tại frontend chưa lọc inactive shops ở client — shop inactive sẽ fail ở bước validate server)
+2. Chọn shop khác → hệ thống validate: shop active + user có `UserShopRole` trong shop đó
+3. Validate thành công → phát JWT mới với `active_shop_id` mới, set lại HttpOnly cookie (không logout/login lại)
+4. Dashboard reload tự động; mọi API call tiếp theo filter theo shop mới (TenantGuard đọc `active_shop_id` từ JWT)
+5. Shop bị inactive sau khi dropdown load → switch thất bại: "Shop đang tạm ngưng, không thể chuyển"
 
 ---
 
@@ -249,17 +306,38 @@ project: Diecast360
 
 ---
 
+### Epic 11: QR Code
+
+| ID | Epic | User Story | Priority | Points | Sprint | Status |
+|----|------|-----------|----------|--------|--------|--------|
+| US-095 | QR Code | Là shop admin, tôi muốn tạo mã QR cho item để dán lên sản phẩm vật lý | Low | 3 | S9 | Done |
+| US-096 | QR Code | Là khách hàng, tôi muốn quét QR trên sản phẩm để xem catalog online ngay | Low | 2 | S9 | Done |
+
+**Acceptance Criteria US-095:**
+1. Tab/bước "Mã QR" trong trang chi tiết item (admin view)
+2. Click "Tạo mã QR" → backend sinh qr_token (16-hex, race-safe via updateMany WHERE qr_token IS NULL)
+3. Hiển thị: ảnh QR, link resolve, nút "Tải PNG", nút "Copy link"
+4. Token bất biến — không thay đổi dù item update; QR in vật lý không bao giờ hỏng
+5. Banner cảnh báo nếu item chưa is_public: "Bật công khai trước khi in QR"
+
+**Acceptance Criteria US-096:**
+1. `GET /public/qr/:token` — không cần auth, redirect 302 → item detail với ?source=qr&action=view
+2. Frontend hiển thị banner "Bạn đang xem sản phẩm qua mã QR" khi URL có source=qr
+3. Token không tồn tại → 404 friendly "Mã QR không hợp lệ"
+
+---
+
 ## Sprint Assignment Summary
 
 | Sprint | Dates | Stories | Points | Theme |
 |--------|-------|---------|--------|-------|
-| S1 | Oct 2025 | US-001~004, US-080~082 | 42 | Core CRUD + Auth |
-| S2 | Nov 2025 | US-005~006, US-010~011, US-020, US-060~061, US-084 | 38 | Media + Public + Social |
+| S1 | Oct 2025 | US-001~004, US-008, US-080~082 | 44 | Core CRUD + Auth |
+| S2 | Nov 2025 | US-005~006, US-009, US-010~011, US-020, US-060~061, US-084~085 | 49 | Media + Public + Social + Auth |
 | S3 | Nov 2025 | US-007(skip), US-012~013, US-021, US-030, US-032 | 39 | SpinSet + Pre-order |
 | S4 | Dec 2025 | US-014~017, US-022~023, US-033, US-040~041 | 47 | 360° Viewer + Inventory |
-| S5 | Dec 2025 | US-031, US-034, US-042~043, US-050~051 | 33 | Points + Member |
-| S6 | Jan 2026 | US-035, US-044, US-052~053, US-062, US-070~071 | 39 | Loyalty + AI |
+| S5 | Dec 2025 | US-031, US-034, US-039, US-042~043, US-050~051 | 38 | Points + Member + Financial |
+| S6 | Jan 2026 | US-035, US-038, US-044, US-052~053, US-057, US-062, US-070~071 | 60 | Loyalty + Campaign + AI |
 | S7 | Feb 2026 | US-036, US-054, US-063, US-072, US-090 | 29 | Polish + Dashboard |
 | S8 | Mar 2026 | US-007, US-037, US-055, US-091~092 | 26 | Reports |
-| S9 | Apr 2026 | US-045, US-056, US-073, US-083, US-093 | 27 | Analytics + Cleanup |
+| S9 | Apr 2026 | US-045, US-056, US-073, US-083, US-093, US-095~096 | 32 | Analytics + QR + Cleanup |
 | S10 | May 2026 | US-094 + bug fixes + performance | 18 | Stabilization |

--- a/docs/project-docs/group2-product/13_use_case_descriptions.md
+++ b/docs/project-docs/group2-product/13_use_case_descriptions.md
@@ -85,7 +85,9 @@ project: Diecast360
 **Main Flow (Tạo Item):**
 1. Admin click "Thêm sản phẩm mới"
 2. Hệ thống hiển thị form tạo item
-3. Admin nhập: name, brand, car_brand, model_brand, scale (default 1:64), condition, price, status, quantity, fb_post_content
+3. Admin nhập: name, brand, car_brand, model_brand, scale (default 1:64), condition, original_price, price, status, quantity, fb_post_content
+   - **Status options:** `con_hang` | `giu_cho` | `da_ban` | `preorder`
+   - Chọn `preorder`: hiện thêm trường `preorder_price` (giá ưu đãi, optional) và `expected_arrival_at` (ngày về hàng dự kiến, optional)
 4. Admin click "Lưu"
 5. Hệ thống validate input
 6. Hệ thống tạo item với `shop_id` từ active tenant
@@ -108,6 +110,11 @@ project: Diecast360
 *AF-02: Publish ngay khi tạo*
 - Bước 3: Admin check "Publish ngay" → `is_public = true` ngay sau khi tạo
 
+*AF-03: Tạo item với status preorder (campaign)*
+- Bước 3: Admin chọn status = preorder → hiện thêm: `preorder_price`, `expected_arrival_at`, `preorder_closes_at` (deadline đặt hàng)
+- Bước 6: Hệ thống gán `preorder_opens_at = created_at` của item mới tạo
+- Item xuất hiện trên trang `/preorders` công khai sau khi publish (xem UC-18)
+
 **Exception Flows:**
 
 *EF-01: Vi phạm invariant da_ban*
@@ -119,9 +126,14 @@ project: Diecast360
 *EF-03: Thay đổi quantity trực tiếp*
 - Bước 5: Phát hiện request thay đổi quantity không qua inventory → 422 "Vui lòng dùng chức năng nhập/xuất kho"
 
+*EF-04: Transition không hợp lệ*
+- Cập nhật item từ `da_ban` → `preorder` hoặc `giu_cho` → bị chặn; "Transition trạng thái không hợp lệ"
+- Transition `da_ban` → `con_hang` được phép (tự động set quantity=1 nếu không gửi)
+
 **Postconditions:**
 - Item được tạo/cập nhật với đúng thông tin
 - Nếu `is_public = true`: item xuất hiện trên public catalog
+- Item status `preorder`: item xuất hiện thêm trên trang `/preorders` công khai
 - Audit log ghi nhận thao tác
 
 ---
@@ -373,13 +385,15 @@ project: Diecast360
 | **Priority** | Must |
 
 **Preconditions:**
-- Item `is_public=true`, status là `con_hang` hoặc `giu_cho`
+- Item `is_public=true`, status là `con_hang`, `giu_cho`, hoặc `preorder` (và cửa sổ đặt hàng còn mở)
 - Shop active
 
 **Main Flow:**
 1. Khách click "Đặt hàng trước" trên trang chi tiết item
 2. Hệ thống hiển thị form pre-order
-3. Khách nhập: họ tên, số điện thoại, ghi chú (optional)
+3. Khách nhập: họ tên, số điện thoại, số lượng (mặc định 1), ghi chú (optional)
+   - Item status `preorder` và cửa sổ còn mở: form hiển thị `preorder_price` thay vì `price`
+   - Nếu shop yêu cầu đặt cọc: hiển thị `deposit_amount` cần thanh toán trước
 4. Khách click "Xác nhận đặt hàng"
 5. Hệ thống lookup SĐT trong bảng member của shop
 6. Hệ thống tạo pre-order với status `PENDING_CONFIRMATION`
@@ -430,7 +444,7 @@ project: Diecast360
 2. Admin xem danh sách pre-order (mặc định: tất cả trạng thái, mới nhất trước)
 3. Admin filter theo trạng thái cần xử lý
 4. Admin click vào đơn cần xử lý
-5. Admin xem chi tiết: thông tin khách, item, trạng thái hiện tại, lịch sử
+5. Admin xem chi tiết: thông tin khách, item, trạng thái hiện tại, lịch sử transition; thông tin tài chính: `total_amount`, `deposit_amount`, `paid_amount`, `remaining` (= max(0, total - paid))
 6. Admin chọn trạng thái mới từ dropdown (chỉ hiện transition hợp lệ)
 7. Hệ thống hiển thị confirm dialog
 8. Admin xác nhận
@@ -446,6 +460,9 @@ project: Diecast360
 *AF-02: Refund*
 - Chỉ có thể REFUND từ PAID
 - Tự động tạo ledger entry trừ điểm
+
+*AF-03: Xuất biên lai*
+- Admin click "Xem biên lai" → hiển thị receipt với: thông tin khách, item, total_amount, deposit_amount, paid_amount, remaining (xem UC-19)
 
 **Exception Flows:**
 
@@ -493,9 +510,9 @@ project: Diecast360
 - Bước 4: quantity_out > quantity_hiện_tại → "Không đủ hàng tồn kho (có: X, cần xuất: Y)"
 
 **Postconditions:**
-- Transaction ghi bất biến vào ledger
-- `items.quantity` được cập nhật đúng
-- Không thể undo transaction (chỉ có thể tạo transaction đối ứng)
+- Transaction ghi bất biến vào ledger (`type`, `quantity`, `delta`, `resulting_quantity`, `actor_user_id`, `created_at`, `note`)
+- `items.quantity` được cập nhật đúng (atomic)
+- Reversal chính thức: admin có thể tạo reversal liên kết qua `reversal_of_id`; mỗi transaction chỉ được reverse 1 lần (double-reversal bị chặn); reversal tự tạo transaction đối ứng và cập nhật `items.quantity`
 
 ---
 
@@ -552,23 +569,34 @@ project: Diecast360
 5. Hệ thống cập nhật `members.points_balance`
 6. Hệ thống kiểm tra tier upgrade: nếu total_points >= next_tier.threshold → upgrade tier
 
+**Main Flow (Redeem — Admin áp dụng điểm vào đơn hàng):**
+1. Khách yêu cầu dùng điểm để giảm tiền khi thanh toán
+2. Admin vào chi tiết pre-order hoặc profile member → "Dùng điểm"
+3. Admin nhập số điểm muốn redeem (hệ thống kiểm tra: `points_balance >= số điểm`)
+4. Hệ thống tính giá trị tương đương: `discount = points × (loyalty_json.vnd_per_point)`
+5. Hệ thống tạo `MemberPointsLedger` (type: `redeem`, reason ghi rõ số pre-order liên quan; `reference_type/reference_id` không được set tự động qua API redeem hiện tại — audit trail phân biệt qua `type = redeem`)
+6. Cập nhật `members.points_balance` giảm đi số điểm đã redeem
+7. Admin cập nhật `paid_amount` của pre-order để phản ánh phần được giảm
+
 **Main Flow (Manual Adjust):**
 1. Admin vào profile member → "Điều chỉnh điểm"
 2. Admin chọn: cộng/trừ điểm
 3. Admin nhập số điểm và lý do (bắt buộc)
 4. Admin click "Xác nhận"
-5. Hệ thống tạo ledger entry (type: manual)
+5. Hệ thống tạo ledger entry (type: `adjust`)
 6. Cập nhật points_balance
 
 **Exception Flows:**
 
-*EF-01: Trừ điểm vượt số dư*
-- Bước 3 (Manual): điểm trừ > points_balance → "Số dư điểm không đủ (hiện có: X, yêu cầu trừ: Y)"
+*EF-01: Trừ điểm vượt số dư (Redeem hoặc Adjust)*
+- Bước 3: điểm yêu cầu > points_balance → "Số dư điểm không đủ (hiện có: X, yêu cầu: Y)"
 
 **Postconditions:**
-- `MemberPointsLedger` có bản ghi mới (immutable)
+- `MemberPointsLedger` có bản ghi mới (immutable) với type `earn` / `redeem` / `adjust`
 - `members.points_balance` cập nhật đúng
-- Tier được upgrade nếu đủ điều kiện (không bao giờ downgrade tự động)
+- Tier được auto-evaluate sau mỗi thay đổi điểm: **upgrade khi vượt threshold lên, downgrade khi điểm giảm xuống dưới threshold hiện tại** (xem ghi chú bên dưới)
+
+> **Quyết định nghiệp vụ — Tier Auto-Downgrade:** Hệ thống tự động hạ tier khi `points_balance` giảm xuống dưới `min_points` của tier hiện tại (ví dụ: sau khi redeem hoặc refund). Điều này khác với nhiều loyalty program dùng "lifetime points" không bao giờ giảm. Trade-off: đảm bảo tier phản ánh đúng số dư thực tế nhưng có thể gây bất ngờ cho khách hàng. Shop owner cần thông báo rõ cho khách chính sách này.
 
 ---
 
@@ -702,3 +730,306 @@ project: Diecast360
 - AiItemDraft tồn tại với status PENDING/CONFIRMED/REJECTED
 - Nếu CONFIRMED: Item mới được tạo với thông tin từ draft
 - Lịch sử draft có thể audit
+
+---
+
+## UC-16: Logout / Session Management
+
+| Thuộc tính | Giá trị |
+|------------|---------|
+| **ID** | UC-16 |
+| **Tên** | Đăng xuất và quản lý phiên đăng nhập |
+| **Actor chính** | Shop Admin, Shop Staff, Platform Super |
+| **Priority** | Must |
+
+**Preconditions:**
+- User đang có phiên đăng nhập hợp lệ (cookie access_token còn hiệu lực)
+
+**Main Flow (Đăng xuất chủ động):**
+1. User click "Đăng xuất" trong menu
+2. Hệ thống gọi `POST /api/v1/auth/logout`
+3. Hệ thống revoke refresh token hiện tại (set `revoked_at = NOW()`)
+4. Hệ thống xóa HttpOnly cookies: `access_token`, `refresh_token`, `csrf_token`
+5. Redirect đến trang login: "Bạn đã đăng xuất thành công"
+
+**Alternative Flows:**
+
+*AF-01: Access token hết hạn trong session (15 phút)*
+- Hệ thống tự động gọi refresh endpoint với refresh token
+- Nếu refresh thành công → phát JWT mới, session tiếp tục trong suốt
+- Nếu refresh token cũng hết hạn / bị revoke → redirect đến login (session expired)
+
+*AF-02: Đăng xuất khỏi tất cả thiết bị*
+- Xảy ra tự động sau khi reset password (UC-17): tất cả refresh token của user bị revoke
+- Thiết bị khác đang login → access token hết hạn → refresh fail → buộc login lại
+
+**Exception Flows:**
+
+*EF-01: Mạng lỗi khi gọi logout*
+- HttpOnly cookie không thể bị xóa bằng JavaScript — chỉ server mới có thể clear qua `Set-Cookie: Max-Age=0`
+- Nếu server call thất bại: client redirect về trang login; cookie vẫn tồn tại nhưng refresh token trên server sẽ expire sau 7 ngày
+- Hành vi an toàn: token hết hạn tự nhiên là fallback đủ dùng; không có action nào ở client
+
+**Postconditions:**
+- Refresh token bị revoke — không thể dùng để phát access token mới
+- Cookies bị xóa — browser không còn gửi credentials
+- Audit log ghi nhận thời điểm logout
+
+---
+
+## UC-17: Forgot Password / Password Reset
+
+| Thuộc tính | Giá trị |
+|------------|---------|
+| **ID** | UC-17 |
+| **Tên** | Quên mật khẩu và đặt lại mật khẩu |
+| **Actor chính** | Shop Admin, Shop Staff, Platform Super |
+| **Actor phụ** | MailService (Resend / mock) |
+| **Priority** | Must |
+
+**Preconditions:**
+- User có tài khoản hợp lệ trong hệ thống
+- User chưa đăng nhập
+
+**Main Flow (Yêu cầu reset):**
+1. User click "Quên mật khẩu?" trên trang login
+2. User nhập địa chỉ email
+3. User click "Gửi link đặt lại"
+4. Hệ thống luôn trả về thông báo trung lập: "Nếu email tồn tại, bạn sẽ nhận được hướng dẫn trong vài phút" (không tiết lộ email có tồn tại hay không)
+5. Nếu email hợp lệ và active: hệ thống tạo reset token (SHA-256 hash, one-time use, TTL 1 giờ)
+6. Hệ thống gửi email chứa link đặt lại mật khẩu
+
+**Main Flow (Đặt lại mật khẩu):**
+1. User click link trong email
+2. Hệ thống kiểm tra token: hợp lệ + chưa dùng (`used_at IS NULL`) + chưa hết hạn
+3. Hệ thống hiển thị form đặt mật khẩu mới
+4. User nhập mật khẩu mới (≥ 8 ký tự) và xác nhận lại
+5. Hệ thống lưu mật khẩu mới (bcrypt, cost 12), đánh dấu token `used_at = NOW()`
+6. Hệ thống revoke tất cả refresh token hiện tại của user
+7. Redirect đến trang login: "Đặt lại mật khẩu thành công, vui lòng đăng nhập lại"
+
+**Exception Flows:**
+
+*EF-01: Rate limit*
+- Bước 3 (Reset): Cùng IP > 10 request/giờ → 429 Too Many Requests
+- Cùng email > 3 request/giờ → silent reject (vẫn trả 200 để tránh enumeration)
+
+*EF-02: Token hết hạn hoặc đã dùng*
+- Bước 2 (Đặt lại): Token không hợp lệ → "Link đặt lại không hợp lệ hoặc đã hết hạn"
+- Hiển thị nút "Yêu cầu link mới"
+
+*EF-03: Mật khẩu mới quá yếu*
+- Bước 4: < 8 ký tự → "Mật khẩu phải có ít nhất 8 ký tự"
+
+*EF-04: Gửi email thất bại*
+- Bước 6: Email provider lỗi → hệ thống log lỗi nhưng vẫn trả 200 (không tiết lộ gửi thất bại)
+
+**Postconditions:**
+- Mật khẩu mới được lưu (bcrypt hash)
+- Reset token bị đánh dấu `used_at = NOW()` — không thể dùng lại
+- Tất cả refresh token cũ bị revoke → buộc đăng nhập lại trên thiết bị khác
+
+---
+
+## UC-18: Pre-order Campaign (Item status `preorder`)
+
+| Thuộc tính | Giá trị |
+|------------|---------|
+| **ID** | UC-18 |
+| **Tên** | Tạo và quản lý campaign đặt hàng trước theo thời gian |
+| **Actor chính** | Shop Admin |
+| **Actor phụ** | End Customer (xem campaign công khai) |
+| **Priority** | Must |
+
+**Preconditions:**
+- Admin đã đăng nhập
+- Item tồn tại với status bất kỳ, trừ `da_ban`
+
+**Main Flow (Mở campaign preorder):**
+1. Admin chọn item → "Mở Pre-order Campaign"
+2. Admin nhập (tất cả optional): `preorder_price` (giá ưu đãi), `preorder_closes_at` (deadline đặt hàng)
+3. Admin đổi status item → `preorder`
+4. Hệ thống gán `preorder_opens_at = item.created_at` — tính từ lúc sản phẩm được tạo, không phải lúc mở campaign (cả tạo mới lẫn update path đều dùng `created_at`)
+5. Pre-order đầu tiên của item xuất hiện trên trang công khai `/preorders`; trang này hiển thị các `PreOrder` row đang active (PENDING_CONFIRMATION / WAITING_FOR_GOODS) của item is_public — không phải item-based listing
+6. Catalog hiển thị `preorder_price` (nếu có) trong khi cửa sổ mở
+
+**Main Flow (Đóng campaign sớm):**
+1. Admin vào item đang ở status `preorder`
+2. Admin click "Đóng Campaign Sớm"
+3. Hệ thống `PATCH /items/:id/close-preorder`: set `preorder_closes_at = NOW()`
+4. Countdown về 0; trang public ẩn nút "Đặt hàng trước"
+5. Status item vẫn là `preorder` (không tự động đổi)
+
+**Main Flow (Mở lại campaign):**
+1. Admin click "Mở lại Campaign"
+2. Hệ thống `PATCH /items/:id/reopen-preorder`: xóa `preorder_closes_at`, set `preorder_opens_at = NOW()`
+3. Đợt mới tính từ thời điểm bấm mở lại (không dùng `created_at` gốc)
+4. Admin set deadline mới qua PATCH thông thường nếu cần
+
+**Main Flow (Kết thúc campaign — hàng về):**
+1. Admin chuyển item `preorder → con_hang`
+2. Hệ thống tự động advance tất cả đơn `WAITING_FOR_GOODS → ARRIVED`
+3. Đơn `PENDING_CONFIRMATION` **không** tự động advance; response trả `preorders_pending_count` → UI cảnh báo admin xem xét thủ công
+
+**Main Flow (Hủy campaign — nhà cung cấp hủy):**
+1. Admin chuyển item `preorder → da_ban`
+2. Hệ thống set `quantity = 0`
+3. Đơn đã có `paid_amount > 0` **không** tự động hủy; admin phải xử lý hoàn tiền thủ công
+
+**Alternative Flows:**
+
+*AF-01: Item giu_cho → preorder*
+- Được phép; admin tự kiểm tra các hold trước khi chuyển — không có guard tự động
+
+*AF-02: Khách xem trang campaign công khai (`/preorders`)*
+- Không cần đăng nhập
+- Thấy danh sách campaign đang mở: ảnh cover, tên item, countdown, preorder_price, nút "Đặt hàng trước"
+
+**Exception Flows:**
+
+*EF-01: Chuyển da_ban → preorder*
+- Bị chặn: "Không thể mở pre-order cho item đã bán hết"
+
+*EF-02: Cửa sổ đã đóng nhưng khách vẫn cố submit*
+- Chỉ trigger khi `preorder_closes_at IS NOT NULL AND preorder_closes_at < NOW()`
+- Nếu `preorder_closes_at IS NULL` (cửa sổ vô hạn), EF-02 không bao giờ kích hoạt — cửa sổ luôn mở
+- Hệ thống trả 422 "Cửa sổ đặt hàng đã đóng"
+
+**Postconditions:**
+- Item ở status `preorder`, hiển thị trang `/preorders` khi `is_public = true`
+- Countdown UI tính từ `preorder_opens_at` đến `preorder_closes_at`; nếu `preorder_closes_at IS NULL` → hiển thị "Không giới hạn thời gian" (không có countdown)
+- Sau khi reopen (`PATCH /reopen-preorder`): `preorder_closes_at` về NULL — cửa sổ mặc định là vô hạn cho đến khi admin tự set deadline mới
+- Sau khi cửa sổ đóng: catalog hiển thị `price` thông thường thay vì `preorder_price`
+
+---
+
+## UC-19: Pre-order Financial Tracking & Receipt
+
+| Thuộc tính | Giá trị |
+|------------|---------|
+| **ID** | UC-19 |
+| **Tên** | Theo dõi tài chính pre-order và xuất biên lai |
+| **Actor chính** | Shop Admin |
+| **Actor phụ** | End Customer (xem biên lai) |
+| **Priority** | Must |
+
+**Preconditions:**
+- Pre-order đã tồn tại (status bất kỳ non-terminal)
+- Admin đã đăng nhập với quyền trong shop
+
+**Main Flow (Ghi nhận đặt cọc):**
+1. Khách liên hệ / đến shop và đặt cọc
+2. Admin mở chi tiết pre-order
+3. Admin nhập `deposit_amount` (tổng tiền cọc thực nhận — **ghi đè**, không cộng dồn; ví dụ: cọc đợt 1: 200k → nhập 200k; cọc thêm đợt 2: 100k → nhập 300k)
+4. Hệ thống cập nhật; `remaining` = `max(0, total_amount - paid_amount)`
+5. UI hiển thị tóm tắt: Tổng đơn / Đã cọc / Đã thu / Còn lại
+
+**Main Flow (Ghi nhận thanh toán cuối):**
+1. Khách đến lấy hàng và thanh toán phần còn lại
+2. Admin nhập `paid_amount` (tổng đã thu, bao gồm tiền cọc trước đó)
+3. Hệ thống tính `remaining = max(0, total_amount - paid_amount)`
+4. Admin chuyển pre-order → PAID (xem UC-09)
+5. Nếu member: điểm tự động cộng dựa trên `total_amount` (xem UC-12)
+
+**Main Flow (Xuất biên lai):**
+1. Admin click "Xem biên lai" trên pre-order
+2. Hệ thống render receipt gồm: tên khách, SĐT, tên item, `unit_price`, `quantity`, `total_amount` (= `unit_price × quantity`; nếu item đang trong cửa sổ preorder khi tạo đơn, `unit_price` = `preorder_price`), `deposit_amount`, `paid_amount`, `remaining`, timestamp
+3. Admin chia sẻ link biên lai hoặc in cho khách
+
+**Alternative Flows:**
+
+*AF-01: Admin in biên lai để trao cho khách*
+- Admin dùng print/screenshot trang receipt để chia sẻ với khách
+- Endpoint `GET /preorders/:id/receipt` yêu cầu auth (JwtAuthGuard + TenantGuard) — không có public receipt link; khách không thể tự xem online
+
+**Exception Flows:**
+
+*EF-01: paid_amount > total_amount*
+- API từ chối: 422 "paid_amount must be <= total_amount" (`validateFinancials` trong service)
+- Admin phải nhập giá trị đúng ≤ total_amount
+
+**Postconditions:**
+- `deposit_amount` và `paid_amount` được lưu trên pre-order
+- `remaining` là computed field (`max(0, total_amount - paid_amount)`) — không lưu riêng
+- Biên lai phản ánh trạng thái tài chính mới nhất
+
+---
+
+## UC-20: Chuyển Active Shop (Multi-role User)
+
+| Thuộc tính | Giá trị |
+|------------|---------|
+| **ID** | UC-20 |
+| **Tên** | User đổi shop đang làm việc |
+| **Actor chính** | Shop Admin / Shop Staff có nhiều shop role |
+| **Priority** | Must |
+
+**Preconditions:**
+- User đã đăng nhập
+- User có `UserShopRole` ở ít nhất 2 shop khác nhau
+- Shop đích đang active
+
+**Main Flow:**
+1. User click menu "Chọn shop" (hiển thị tên shop đang active ở header)
+2. Hệ thống hiển thị danh sách các shop mà user có quyền truy cập (active only)
+3. User chọn shop mới
+4. Hệ thống validate: shop active + user có `UserShopRole` trong shop đó
+5. Hệ thống phát JWT mới với `active_shop_id = shop_moi_id`, set lại HttpOnly cookie
+6. Hệ thống reload dashboard của shop mới
+7. Header cập nhật tên shop; tất cả dữ liệu hiển thị thuộc về shop mới
+
+**Exception Flows:**
+
+*EF-01: Shop bị vô hiệu hóa sau khi list được tải*
+- Bước 4: Shop inactive → "Shop đang tạm ngưng, không thể chuyển sang shop này"
+
+*EF-02: User mất quyền sau khi list được tải*
+- Bước 4: Không có `UserShopRole` → 403 "Bạn không có quyền truy cập shop này"
+
+**Postconditions:**
+- JWT mới với `active_shop_id` mới được set trong cookie
+- Tất cả API call tiếp theo filter theo shop mới (TenantGuard đọc từ JWT)
+- Không cần logout / login lại
+
+---
+
+## UC-21: QR Code Generation & Scan
+
+| Thuộc tính | Giá trị |
+|------------|---------|
+| **ID** | UC-21 |
+| **Tên** | Tạo mã QR cho item và xử lý quét QR |
+| **Actor chính** | Shop Admin (tạo) / End Customer (quét) |
+| **Priority** | Could |
+
+**Preconditions (Tạo):**
+- Item tồn tại và thuộc về shop của admin (TenantGuard)
+- Admin đã đăng nhập
+
+**Main Flow (Admin tạo QR):**
+1. Admin vào trang chi tiết item → tab/bước "Mã QR"
+2. Admin click "Tạo mã QR"
+3. Hệ thống kiểm tra `qr_token` trên item: nếu đã có → dùng lại; nếu chưa → tạo mới (16-ký tự hex, race-safe via `updateMany WHERE qr_token IS NULL`)
+4. Hệ thống hiển thị: ảnh QR, link resolve, nút "Tải PNG", nút "Copy link"
+5. Admin in QR hoặc dán vào bao bì / catalogue vật lý
+
+**Main Flow (Customer quét QR):**
+1. Khách quét QR bằng camera điện thoại
+2. Request đến `GET /api/v1/public/qr/:token` (không yêu cầu auth)
+3. Hệ thống resolve token → tìm item → redirect 302 đến `FRONTEND_URL/items/:id?shop_id=...&source=qr&action=view`
+4. Frontend hiển thị trang chi tiết item với banner "Bạn đang xem sản phẩm qua mã QR"
+
+**Alternative Flows:**
+
+*AF-01: Item chưa public, admin tạo QR*
+- Bước 4: Banner cảnh báo "Item này chưa được publish — QR sẽ không hoạt động với khách cho đến khi bật is_public"
+- Admin vẫn có thể tạo và lưu QR trước khi publish (chuẩn bị trước)
+
+**Exception Flows:**
+
+*EF-01: QR token không tồn tại*
+- Bước 3: Token không khớp bất kỳ item nào → 404 "Mã QR không hợp lệ hoặc sản phẩm không còn tồn tại"
+
+**Postconditions:**
+- `qr_token` bất biến sau khi tạo — không thay đổi dù item cập nhật
+- QR in vật lý hoạt động khi: item chưa soft-delete, `is_public = true`, và shop đang active. Unpublish item (`is_public = false`) hoặc deactivate shop sẽ khiến QR trả 404 — admin cần cân nhắc trước khi in QR vật lý

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "overrides": {
       "fast-uri": "^3.1.2",
       "shell-quote": ">=1.8.4",
-      "esbuild": ">=0.28.1",
-      "ws": ">=8.20.1",
-      "@tootallnate/once": ">=2.0.1"
+      "esbuild": ">=0.28.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,6 @@ overrides:
   fast-uri: ^3.1.2
   shell-quote: '>=1.8.4'
   esbuild: '>=0.28.1'
-  ws: '>=8.20.1'
-  '@tootallnate/once': '>=2.0.1'
 
 importers:
 
@@ -86,7 +84,7 @@ importers:
         version: 2.1.1
       openai:
         specifier: ^6.16.0
-        version: 6.34.0(ws@8.21.0)(zod@4.3.6)
+        version: 6.34.0(ws@8.20.0)(zod@4.3.6)
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -2067,8 +2065,8 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@tootallnate/once@3.0.1':
-    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
   '@tsconfig/node10@1.0.12':
@@ -4276,7 +4274,7 @@ packages:
     resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
     hasBin: true
     peerDependencies:
-      ws: '>=8.20.1'
+      ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
@@ -5319,8 +5317,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7635,7 +7633,7 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tootallnate/once@3.0.1': {}
+  '@tootallnate/once@2.0.0': {}
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -9428,7 +9426,7 @@ snapshots:
 
   http-proxy-agent@5.0.0:
     dependencies:
-      '@tootallnate/once': 3.0.1
+      '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -9956,7 +9954,7 @@ snapshots:
       whatwg-encoding: 2.0.0
       whatwg-mimetype: 3.0.0
       whatwg-url: 12.0.1
-      ws: 8.21.0
+      ws: 8.20.0
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -10227,9 +10225,9 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@6.34.0(ws@8.21.0)(zod@4.3.6):
+  openai@6.34.0(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
-      ws: 8.21.0
+      ws: 8.20.0
       zod: 4.3.6
 
   optionator@0.9.4:
@@ -11295,7 +11293,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.21.0: {}
+  ws@8.20.0: {}
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
## Summary

- **5 UC mới** (UC-16 đến UC-20) phát hiện sau khi đọc codebase — các tính năng đã được implement nhưng chưa có tài liệu
- **5 UC hiện có cập nhật** (UC-02, UC-08, UC-09, UC-10, UC-12) để phản ánh đúng implementation thực tế
- **2 file guidelines sửa divergence** (CLAUDE.md, DOMAIN.md) — sửa sai về member auto-downgrade

### Thay đổi chi tiết

**UC mới:**
- `UC-16` — Forgot password / Password reset / First-login force change (đã implement trong `auth.service.ts`, chưa có UC)
- `UC-17` — Pre-order campaign: item status `preorder`, open/close/reopen window, countdown, transition rules (đã implement trong `items-preorder.service.ts`)
- `UC-18` — Pre-order financial tracking & receipt: deposit_amount, paid_amount, remaining, biên lai (đã implement trong `preorders.service.ts`)
- `UC-19` — Switch active shop cho user có nhiều shop role (đã implement trong `auth.controller.ts`)
- `UC-20` — QR code generation & scan, lazy-create qr_token, race-safe (đã implement trong `items.service.ts`)

**UC cập nhật:**
- `UC-02` — Thêm status `preorder` (4th status), 3 giá (`original_price`/`price`/`preorder_price`), AF-03 campaign creation flow, EF-04 invalid transitions
- `UC-08` — Thêm `preorder` vào preconditions, deposit amount trong form, preorder_price display logic
- `UC-09` — Thêm financial fields trong step 5, AF-03 receipt generation
- `UC-10` — Sửa mô tả reversal: từ "tạo đối ứng thủ công" → formal `reversal_of_id` mechanism (1 reversal/transaction, double-reversal blocked)
- `UC-12` — Thêm luồng Redeem đầy đủ; document quyết định nghiệp vụ auto-downgrade

**Sửa divergence:**
- `CLAUDE.md` & `DOMAIN.md` — Sửa sai "Downgrade does not happen automatically" → **tier auto-downgrades khi points_balance giảm dưới threshold** (đúng với code `tier-rule.engine.ts`)

## Test plan

- [ ] Đọc lại UC-16 và verify với `backend/src/auth/auth.service.ts` (forgot-password, reset-password flows)
- [ ] Đọc lại UC-17 và verify với `backend/src/items/items-preorder.service.ts` (closePreorder, reopenPreorder)
- [ ] Đọc lại UC-18 và verify với `backend/src/preorders/preorders.service.ts` (deposit/paid/remaining/receipt)
- [ ] Đọc lại UC-19 và verify với `backend/src/auth/auth.controller.ts` (switch-shop endpoint)
- [ ] Đọc lại UC-20 và verify với `backend/src/items/items.service.ts` (qr_token lazy create)
- [ ] Confirm quyết định nghiệp vụ auto-downgrade với PO/stakeholder

https://claude.ai/code/session_01WQytWXigyXGAMadGh8hqUV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQytWXigyXGAMadGh8hqUV)_